### PR TITLE
[codex] fix runtime integrity false positives

### DIFF
--- a/crates/mcp-agent-mail-cli/src/lib.rs
+++ b/crates/mcp-agent-mail-cli/src/lib.rs
@@ -4867,6 +4867,52 @@ fn sqlite_conn_check_ok(
     Ok(sqlite_pragma_check_rows_ok(&rows, kind))
 }
 
+fn sqlite_conn_check_ok_with_canonical_confirmation(
+    opened_path: &str,
+    conn: &mcp_agent_mail_db::DbConn,
+    kind: mcp_agent_mail_db::CheckKind,
+) -> CliResult<bool> {
+    match sqlite_conn_check_ok(conn, kind) {
+        Ok(true) => Ok(true),
+        Ok(false) => {
+            if opened_path == ":memory:" {
+                return Ok(false);
+            }
+            let canonical =
+                mcp_agent_mail_db::CanonicalDbConn::open_file(opened_path).map_err(|e| {
+                    CliError::Other(format!(
+                        "cannot open canonical database at {opened_path}: {e}"
+                    ))
+                })?;
+            let canonical_ok = sqlite_conn_check_ok_canonical(&canonical, kind)?;
+            if canonical_ok {
+                output::info(&format!(
+                    "Startup {kind} false positive confirmed by canonical SQLite for {opened_path}; skipping automatic reconstruction"
+                ));
+            }
+            Ok(canonical_ok)
+        }
+        Err(runtime_error) => {
+            if opened_path == ":memory:" {
+                return Err(runtime_error);
+            }
+            let canonical = match mcp_agent_mail_db::CanonicalDbConn::open_file(opened_path) {
+                Ok(conn) => conn,
+                Err(_) => return Err(runtime_error),
+            };
+            match sqlite_conn_check_ok_canonical(&canonical, kind) {
+                Ok(true) => {
+                    output::info(&format!(
+                        "Startup {kind} false positive confirmed by canonical SQLite for {opened_path}; skipping automatic reconstruction"
+                    ));
+                    Ok(true)
+                }
+                Ok(false) | Err(_) => Err(runtime_error),
+            }
+        }
+    }
+}
+
 fn sqlite_conn_check_ok_canonical(
     conn: &mcp_agent_mail_db::CanonicalDbConn,
     kind: mcp_agent_mail_db::CheckKind,
@@ -15731,8 +15777,11 @@ fn doctor_database_fix_strategy(
         }
     }
 
-    let integrity_ok = match sqlite_conn_check_ok(&opened.conn, mcp_agent_mail_db::CheckKind::Full)
-    {
+    let integrity_ok = match sqlite_conn_check_ok_with_canonical_confirmation(
+        &opened.opened_path,
+        &opened.conn,
+        mcp_agent_mail_db::CheckKind::Full,
+    ) {
         Ok(ok) => ok,
         Err(error) => {
             let detail = format!(

--- a/crates/mcp-agent-mail-db/src/integrity.rs
+++ b/crates/mcp-agent-mail-db/src/integrity.rs
@@ -337,12 +337,11 @@ fn run_check(conn: &DbConn, kind: CheckKind) -> DbResult<IntegrityCheckResult> {
 /// Evaluate integrity/quick-check pragma rows and update global integrity metrics.
 ///
 /// Shared helper to keep integrity semantics consistent across all callers.
-pub fn evaluate_check_rows(
-    rows: &[Row],
+pub(crate) fn evaluate_check_details(
+    details: Vec<String>,
     kind: CheckKind,
     duration_us: u64,
 ) -> DbResult<IntegrityCheckResult> {
-    let details = extract_check_details(rows, kind);
     let ok = details_indicate_ok(&details);
 
     // Update global state.
@@ -377,6 +376,18 @@ pub fn evaluate_check_rows(
     }
 
     Ok(result)
+}
+
+/// Evaluate integrity/quick-check pragma rows and update global integrity metrics.
+///
+/// Shared helper to keep integrity semantics consistent across all callers.
+pub fn evaluate_check_rows(
+    rows: &[Row],
+    kind: CheckKind,
+    duration_us: u64,
+) -> DbResult<IntegrityCheckResult> {
+    let details = extract_check_details(rows, kind);
+    evaluate_check_details(details, kind, duration_us)
 }
 
 /// Attempt recovery by checkpointing then copying the database file.

--- a/crates/mcp-agent-mail-db/src/pool.rs
+++ b/crates/mcp-agent-mail-db/src/pool.rs
@@ -2328,7 +2328,14 @@ impl DbPool {
 
         match integrity::quick_check(&conn) {
             Ok(res) => Ok(res),
-            Err(DbError::IntegrityCorruption { .. }) => {
+            Err(DbError::IntegrityCorruption { details, .. }) => {
+                if let Some(verified_healthy) = confirm_runtime_integrity_false_positive(
+                    &self.sqlite_path,
+                    integrity::CheckKind::Quick,
+                    &details,
+                )? {
+                    return Ok(verified_healthy);
+                }
                 tracing::warn!(
                     path = %self.sqlite_path,
                     "startup integrity check failed; attempting auto-recovery from backup"
@@ -2403,7 +2410,20 @@ impl DbPool {
             "full integrity check connection",
         );
 
-        integrity::full_check(&conn)
+        match integrity::full_check(&conn) {
+            Ok(res) => Ok(res),
+            Err(DbError::IntegrityCorruption { message, details }) => {
+                if let Some(verified_healthy) = confirm_runtime_integrity_false_positive(
+                    &self.sqlite_path,
+                    integrity::CheckKind::Full,
+                    &details,
+                )? {
+                    return Ok(verified_healthy);
+                }
+                Err(DbError::IntegrityCorruption { message, details })
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Sample the N most recent messages from the DB for consistency checking.
@@ -3800,6 +3820,88 @@ fn sqlite_canonical_incremental_check_is_ok(
     conn: &crate::CanonicalDbConn,
 ) -> Result<bool, SqlError> {
     sqlite_pragma_check_is_ok_canonical(conn, integrity::CheckKind::Incremental)
+}
+
+fn confirm_runtime_integrity_false_positive(
+    sqlite_path: &str,
+    kind: integrity::CheckKind,
+    runtime_details: &[String],
+) -> DbResult<Option<integrity::IntegrityCheckResult>> {
+    let canonical = match open_sqlite_file_with_lock_retry_canonical(sqlite_path) {
+        Ok(conn) => conn,
+        Err(err) => {
+            let msg = err.to_string();
+            if is_lock_error(&msg) {
+                tracing::warn!(
+                    path = %sqlite_path,
+                    check = %kind,
+                    error = %err,
+                    "canonical sqlite integrity confirmation hit lock/busy error; preserving runtime integrity verdict"
+                );
+                return Ok(None);
+            }
+            if is_corruption_error_message(&msg) || is_sqlite_recovery_error_message(&msg) {
+                tracing::warn!(
+                    path = %sqlite_path,
+                    check = %kind,
+                    error = %err,
+                    "canonical sqlite could not confirm runtime integrity failure as a false positive"
+                );
+                return Ok(None);
+            }
+            return Err(DbError::Sqlite(format!(
+                "canonical sqlite integrity confirmation failed: {err}"
+            )));
+        }
+    };
+
+    let canonical_details = match sqlite_pragma_check_details_canonical(&canonical, kind) {
+        Ok(details) => details,
+        Err(err) => {
+            let msg = err.to_string();
+            if is_lock_error(&msg)
+                || is_corruption_error_message(&msg)
+                || is_sqlite_recovery_error_message(&msg)
+            {
+                tracing::warn!(
+                    path = %sqlite_path,
+                    check = %kind,
+                    error = %err,
+                    "canonical sqlite integrity probe could not confirm runtime integrity failure as a false positive"
+                );
+                return Ok(None);
+            }
+            return Err(DbError::Sqlite(format!(
+                "canonical sqlite integrity probe failed: {err}"
+            )));
+        }
+    };
+
+    if !integrity::details_indicate_ok(&canonical_details) {
+        tracing::warn!(
+            path = %sqlite_path,
+            check = %kind,
+            runtime_details = ?runtime_details,
+            canonical_details = ?canonical_details,
+            "runtime and canonical sqlite integrity probes both reported problems"
+        );
+        return Ok(None);
+    }
+
+    tracing::info!(
+        path = %sqlite_path,
+        check = %kind,
+        runtime_details = ?runtime_details,
+        canonical_details = ?canonical_details,
+        "runtime integrity probe reported corruption, but canonical sqlite verified the database as healthy; treating it as a compatibility false positive"
+    );
+
+    Ok(Some(integrity::IntegrityCheckResult {
+        ok: true,
+        details: canonical_details,
+        duration_us: 0,
+        kind,
+    }))
 }
 
 /// Remove corrupt or truncated WAL/SHM sidecars that cause "WAL file too
@@ -7390,6 +7492,57 @@ mod tests {
         assert!(
             result.details.contains(&"ok".to_string()),
             "details should contain 'ok'"
+        );
+    }
+
+    #[test]
+    fn canonical_confirmation_accepts_runtime_integrity_false_positive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("canonical_confirms_false_positive.db");
+        let db_path_str = db_path.to_string_lossy();
+        let conn = DbConn::open_file(db_path_str.as_ref()).expect("open healthy db");
+        conn.execute_raw(
+            "CREATE TABLE projects (id INTEGER PRIMARY KEY, slug TEXT NOT NULL UNIQUE)",
+        )
+        .expect("create projects");
+        conn.execute_raw("INSERT INTO projects(id, slug) VALUES (1, 'demo')")
+            .expect("insert project");
+        drop(conn);
+
+        let result = confirm_runtime_integrity_false_positive(
+            db_path_str.as_ref(),
+            integrity::CheckKind::Quick,
+            &[String::from(
+                "database disk image is malformed: index sqlite_autoindex_projects_1 entry for rowid 1 does not match the table row payload",
+            )],
+        )
+        .expect("confirmation should not error")
+        .expect("canonical sqlite should confirm healthy db");
+
+        assert!(
+            result.ok,
+            "canonical confirmation should treat DB as healthy"
+        );
+        assert_eq!(result.kind, integrity::CheckKind::Quick);
+        assert_eq!(result.details, vec!["ok".to_string()]);
+    }
+
+    #[test]
+    fn canonical_confirmation_preserves_runtime_verdict_for_corrupt_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("canonical_confirms_corrupt.db");
+        std::fs::write(&db_path, b"not-a-database").expect("write corrupt db");
+
+        let result = confirm_runtime_integrity_false_positive(
+            db_path.to_string_lossy().as_ref(),
+            integrity::CheckKind::Quick,
+            &[String::from("database disk image is malformed")],
+        )
+        .expect("canonical confirmation should normalize corruption to no override");
+
+        assert!(
+            result.is_none(),
+            "canonical confirmation should not override real corruption"
         );
     }
 

--- a/crates/mcp-agent-mail-db/src/pool.rs
+++ b/crates/mcp-agent-mail-db/src/pool.rs
@@ -2326,16 +2326,13 @@ impl DbPool {
             "startup integrity check connection",
         );
 
-        match integrity::quick_check(&conn) {
+        match run_runtime_integrity_check_with_confirmation(
+            &conn,
+            &self.sqlite_path,
+            integrity::CheckKind::Quick,
+        ) {
             Ok(res) => Ok(res),
-            Err(DbError::IntegrityCorruption { details, .. }) => {
-                if let Some(verified_healthy) = confirm_runtime_integrity_false_positive(
-                    &self.sqlite_path,
-                    integrity::CheckKind::Quick,
-                    &details,
-                )? {
-                    return Ok(verified_healthy);
-                }
+            Err(DbError::IntegrityCorruption { .. }) => {
                 tracing::warn!(
                     path = %self.sqlite_path,
                     "startup integrity check failed; attempting auto-recovery from backup"
@@ -2356,7 +2353,11 @@ impl DbPool {
                     })?,
                     "startup integrity check post-recovery connection",
                 );
-                integrity::quick_check(&conn)
+                run_runtime_integrity_check_with_confirmation(
+                    &conn,
+                    &self.sqlite_path,
+                    integrity::CheckKind::Quick,
+                )
             }
             Err(e) => Err(e),
         }
@@ -2410,20 +2411,11 @@ impl DbPool {
             "full integrity check connection",
         );
 
-        match integrity::full_check(&conn) {
-            Ok(res) => Ok(res),
-            Err(DbError::IntegrityCorruption { message, details }) => {
-                if let Some(verified_healthy) = confirm_runtime_integrity_false_positive(
-                    &self.sqlite_path,
-                    integrity::CheckKind::Full,
-                    &details,
-                )? {
-                    return Ok(verified_healthy);
-                }
-                Err(DbError::IntegrityCorruption { message, details })
-            }
-            Err(e) => Err(e),
-        }
+        run_runtime_integrity_check_with_confirmation(
+            &conn,
+            &self.sqlite_path,
+            integrity::CheckKind::Full,
+        )
     }
 
     /// Sample the N most recent messages from the DB for consistency checking.
@@ -3822,10 +3814,46 @@ fn sqlite_canonical_incremental_check_is_ok(
     sqlite_pragma_check_is_ok_canonical(conn, integrity::CheckKind::Incremental)
 }
 
+fn run_runtime_integrity_check_with_confirmation(
+    conn: &DbConn,
+    sqlite_path: &str,
+    kind: integrity::CheckKind,
+) -> DbResult<integrity::IntegrityCheckResult> {
+    let start = std::time::Instant::now();
+    let runtime_rows = sqlite_check_rows_with(|sql| conn.query_sync(sql, &[]), kind)
+        .map_err(|error| DbError::Sqlite(format!("{kind} failed: {error}")))?;
+    let duration_us =
+        u64::try_from(start.elapsed().as_micros().min(u128::from(u64::MAX))).unwrap_or(u64::MAX);
+
+    resolve_runtime_integrity_rows_with_confirmation(sqlite_path, kind, runtime_rows, duration_us)
+}
+
+fn resolve_runtime_integrity_rows_with_confirmation(
+    sqlite_path: &str,
+    kind: integrity::CheckKind,
+    runtime_rows: Vec<sqlmodel_core::Row>,
+    duration_us: u64,
+) -> DbResult<integrity::IntegrityCheckResult> {
+    let runtime_details = integrity::extract_check_details(&runtime_rows, kind);
+
+    if integrity::details_indicate_ok(&runtime_details) {
+        return integrity::evaluate_check_rows(&runtime_rows, kind, duration_us);
+    }
+
+    if let Some(verified_healthy) =
+        confirm_runtime_integrity_false_positive(sqlite_path, kind, &runtime_details, duration_us)?
+    {
+        return Ok(verified_healthy);
+    }
+
+    integrity::evaluate_check_rows(&runtime_rows, kind, duration_us)
+}
+
 fn confirm_runtime_integrity_false_positive(
     sqlite_path: &str,
     kind: integrity::CheckKind,
     runtime_details: &[String],
+    duration_us: u64,
 ) -> DbResult<Option<integrity::IntegrityCheckResult>> {
     let canonical = match open_sqlite_file_with_lock_retry_canonical(sqlite_path) {
         Ok(conn) => conn,
@@ -3896,12 +3924,7 @@ fn confirm_runtime_integrity_false_positive(
         "runtime integrity probe reported corruption, but canonical sqlite verified the database as healthy; treating it as a compatibility false positive"
     );
 
-    Ok(Some(integrity::IntegrityCheckResult {
-        ok: true,
-        details: canonical_details,
-        duration_us: 0,
-        kind,
-    }))
+    integrity::evaluate_check_details(canonical_details, kind, duration_us).map(Some)
 }
 
 /// Remove corrupt or truncated WAL/SHM sidecars that cause "WAL file too
@@ -6426,6 +6449,10 @@ pub fn canary_mailbox_destroyed() {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{LazyLock, Mutex};
+
+    static TEST_METRICS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
     use super::*;
     #[cfg(unix)]
     use std::ffi::OsString;
@@ -7515,6 +7542,7 @@ mod tests {
             &[String::from(
                 "database disk image is malformed: index sqlite_autoindex_projects_1 entry for rowid 1 does not match the table row payload",
             )],
+            123,
         )
         .expect("confirmation should not error")
         .expect("canonical sqlite should confirm healthy db");
@@ -7537,12 +7565,67 @@ mod tests {
             db_path.to_string_lossy().as_ref(),
             integrity::CheckKind::Quick,
             &[String::from("database disk image is malformed")],
+            123,
         )
         .expect("canonical confirmation should normalize corruption to no override");
 
         assert!(
             result.is_none(),
             "canonical confirmation should not override real corruption"
+        );
+    }
+
+    #[test]
+    fn runtime_false_positive_confirmation_preserves_success_metrics() {
+        let _guard = TEST_METRICS_LOCK.lock().expect("metrics lock");
+
+        let before = integrity::integrity_metrics();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("runtime_false_positive_metrics.db");
+        let db_path_str = db_path.to_string_lossy();
+        let healthy = DbConn::open_file(db_path_str.as_ref()).expect("open healthy db");
+        healthy
+            .execute_raw(
+                "CREATE TABLE projects (id INTEGER PRIMARY KEY, slug TEXT NOT NULL UNIQUE)",
+            )
+            .expect("create projects");
+        healthy
+            .execute_raw("INSERT INTO projects(id, slug) VALUES (1, 'demo')")
+            .expect("insert project");
+        drop(healthy);
+
+        let runtime = DbConn::open_memory().expect("open runtime probe db");
+        let runtime_rows = runtime
+            .query_sync(
+                "SELECT 'database disk image is malformed: index sqlite_autoindex_projects_1 entry for rowid 1 does not match the table row payload' AS quick_check",
+                &[],
+            )
+            .expect("build synthetic runtime corruption row");
+        drop(runtime);
+
+        let result = resolve_runtime_integrity_rows_with_confirmation(
+            db_path_str.as_ref(),
+            integrity::CheckKind::Quick,
+            runtime_rows,
+            321,
+        )
+        .expect("confirmed false positive should return success");
+
+        let after = integrity::integrity_metrics();
+        assert!(result.ok, "confirmed false positive should be healthy");
+        assert_eq!(result.duration_us, 321);
+        assert!(
+            after.checks_total >= before.checks_total.saturating_add(1),
+            "confirmed false positive should count as a completed check"
+        );
+        assert_eq!(
+            after.failures_total, before.failures_total,
+            "confirmed false positive must not increment integrity failure metrics"
+        );
+        assert!(
+            after.last_ok_ts >= after.last_check_ts,
+            "confirmed false positive should leave the latest integrity state healthy"
         );
     }
 


### PR DESCRIPTION
## What changed

This teaches the DB integrity checks to confirm FrankenSQLite corruption reports with canonical native SQLite before surfacing them as startup or integrity-guard failures.

Specifically:

- `run_startup_integrity_check()` now re-checks the same database with canonical SQLite when the runtime `quick_check` reports corruption.
- `run_full_integrity_check()` does the same for the periodic full integrity path.
- If canonical SQLite returns `ok`, the runtime result is treated as a compatibility false positive instead of a corruption event.
- Added regression tests covering:
  - runtime false positive + canonical healthy DB => override to healthy
  - canonical corruption => preserve the runtime corruption verdict

## Why

On `vps-1`, the Rust service was logging recoverable SQLite corruption on startup even though:

- native `sqlite3` returned `ok` for both `PRAGMA quick_check;` and `PRAGMA integrity_check;`
- an offline `REINDEX` did not change the warning
- a freshly rebuilt `VACUUM INTO` clone still triggered the Rust warning

That isolates the issue to the runtime integrity path rather than the mailbox file itself. The DB crate already documents canonical native SQLite as the source of truth for verification/recovery flows, so the startup and periodic integrity checks should not escalate on a FrankenSQLite-only false positive.

## Validation

- `cargo test -p mcp-agent-mail-db --lib canonical_confirmation --no-default-features`
- `cargo test -p mcp-agent-mail-db --lib startup_integrity_check_healthy_db --no-default-features`

Local note: installing `libsqlite3-dev` was required on the validation host so the canonical SQLite test binary could link.
