### PR TITLE
fix(db): serialize file reservation writes

### DIFF
--- a/crates/mcp-agent-mail-db/src/queries.rs
+++ b/crates/mcp-agent-mail-db/src/queries.rs
@@ -37,6 +37,23 @@ fn cache_scope_for_pool(pool: &DbPool) -> String {
 
 static MESSAGE_WRITE_SERIALIZER: LazyLock<asupersync::sync::Mutex<()>> =
     LazyLock::new(|| asupersync::sync::Mutex::new(()));
+static FILE_RESERVATION_WRITE_SERIALIZER: LazyLock<asupersync::sync::Mutex<()>> =
+    LazyLock::new(|| asupersync::sync::Mutex::new(()));
+
+async fn acquire_file_reservation_write_serializer(
+    cx: &Cx,
+    operation: &'static str,
+) -> Outcome<asupersync::sync::MutexGuard<'static, ()>, DbError> {
+    match FILE_RESERVATION_WRITE_SERIALIZER.lock(cx).await {
+        Ok(guard) => Outcome::Ok(guard),
+        Err(asupersync::sync::LockError::Cancelled) => {
+            Outcome::Cancelled(CancelReason::user("file_reservation writer lock cancelled"))
+        }
+        Err(error) => Outcome::Err(DbError::Internal(format!(
+            "{operation} file_reservation writer lock failed: {error}"
+        ))),
+    }
+}
 
 // =============================================================================
 // ATC Leader Lease types
@@ -1458,6 +1475,18 @@ async fn rebuild_indexes(cx: &Cx, tracked: &TrackedConnection<'_>) -> Outcome<()
 /// Used for write paths that are sensitive to `BEGIN CONCURRENT` backend quirks.
 async fn begin_immediate_tx(cx: &Cx, tracked: &TrackedConnection<'_>) -> Outcome<(), DbError> {
     map_sql_outcome(tracked.execute(cx, "BEGIN IMMEDIATE", &[]).await).map(|_| ())
+}
+
+/// Begin the canonical file-reservation write transaction.
+///
+/// Reservation rows are coordination substrate for every agent. Keep their
+/// INSERT/UPDATE paths on single-writer `BEGIN IMMEDIATE` semantics instead of
+/// page-level `BEGIN CONCURRENT`.
+async fn begin_file_reservation_write_tx(
+    cx: &Cx,
+    tracked: &TrackedConnection<'_>,
+) -> Outcome<(), DbError> {
+    begin_immediate_tx(cx, tracked).await
 }
 
 /// Rollback the current transaction (best-effort, errors ignored).
@@ -8706,6 +8735,13 @@ pub async fn create_file_reservations(
     exclusive: bool,
     reason: &str,
 ) -> Outcome<Vec<FileReservationRow>, DbError> {
+    let _writer_guard =
+        match acquire_file_reservation_write_serializer(cx, "create_file_reservations").await {
+            Outcome::Ok(guard) => guard,
+            Outcome::Err(e) => return Outcome::Err(e),
+            Outcome::Cancelled(r) => return Outcome::Cancelled(r),
+            Outcome::Panicked(p) => return Outcome::Panicked(p),
+        };
     let now = now_micros();
     let expires = now.saturating_add(ttl_seconds.saturating_mul(1_000_000));
 
@@ -8719,8 +8755,11 @@ pub async fn create_file_reservations(
     let tracked = tracked(&*conn);
 
     // Batch all reservation inserts in a single transaction (1 fsync instead of N).
-    // Use IMMEDIATE transaction to serialize reservation checks and prevent TOCTOU races.
-    try_in_tx!(cx, &tracked, begin_immediate_tx(cx, &tracked).await);
+    try_in_tx!(
+        cx,
+        &tracked,
+        begin_file_reservation_write_tx(cx, &tracked).await
+    );
 
     let exclusive_filter = if exclusive {
         ""
@@ -9217,6 +9256,14 @@ async fn release_reservations_by_ids_with_expiry_constraint(
         return Outcome::Ok(Vec::new());
     }
 
+    let _writer_guard =
+        match acquire_file_reservation_write_serializer(cx, "release_file_reservations").await {
+            Outcome::Ok(guard) => guard,
+            Outcome::Err(e) => return Outcome::Err(e),
+            Outcome::Cancelled(r) => return Outcome::Cancelled(r),
+            Outcome::Panicked(p) => return Outcome::Panicked(p),
+        };
+
     run_with_mvcc_retry(cx, "release_reservations_by_ids", || async {
         let conn = match acquire_conn(cx, pool).await {
             Outcome::Ok(c) => c,
@@ -9225,7 +9272,11 @@ async fn release_reservations_by_ids_with_expiry_constraint(
             Outcome::Panicked(p) => return Outcome::Panicked(p),
         };
         let tracked = tracked(&*conn);
-        try_in_tx!(cx, &tracked, begin_immediate_tx(cx, &tracked).await);
+        try_in_tx!(
+            cx,
+            &tracked,
+            begin_file_reservation_write_tx(cx, &tracked).await
+        );
         try_in_tx!(
             cx,
             &tracked,
@@ -9333,6 +9384,13 @@ pub async fn renew_reservations(
     paths: Option<&[&str]>,
     reservation_ids: Option<&[i64]>,
 ) -> Outcome<Vec<FileReservationRow>, DbError> {
+    let _writer_guard =
+        match acquire_file_reservation_write_serializer(cx, "renew_reservations").await {
+            Outcome::Ok(guard) => guard,
+            Outcome::Err(e) => return Outcome::Err(e),
+            Outcome::Cancelled(r) => return Outcome::Cancelled(r),
+            Outcome::Panicked(p) => return Outcome::Panicked(p),
+        };
     let now = now_micros();
     let extend = extend_seconds.saturating_mul(1_000_000);
 
@@ -9348,7 +9406,11 @@ pub async fn renew_reservations(
     // Wrap entire read-modify-write in a transaction so partial renewals
     // cannot occur if the process crashes or is cancelled mid-loop.
     run_with_mvcc_retry(cx, "renew_reservations", || async {
-        try_in_tx!(cx, &tracked, begin_concurrent_tx(cx, &tracked).await);
+        try_in_tx!(
+            cx,
+            &tracked,
+            begin_file_reservation_write_tx(cx, &tracked).await
+        );
 
         // Fetch candidate reservations first (so tools can report old/new expiry).
         let mut sql = format!(

--- a/crates/mcp-agent-mail-db/tests/stress.rs
+++ b/crates/mcp-agent-mail-db/tests/stress.rs
@@ -585,6 +585,204 @@ fn stress_concurrent_file_reservations() {
     );
 }
 
+#[test]
+fn stress_concurrent_http_worker_file_reservation_write_lane_preserves_integrity() {
+    let (pool, _dir) = make_pool();
+    let suffix = unique_suffix();
+    let human_key = format!("/data/stress/http_reservation_lane_{suffix}");
+
+    let (project_id, agent_ids) = {
+        let p = pool.clone();
+        block_on(|cx| async move {
+            let proj = match queries::ensure_project(&cx, &p, &human_key).await {
+                Outcome::Ok(row) => row,
+                other => panic!("ensure_project failed: {other:?}"),
+            };
+            let project_id = proj.id.unwrap();
+            let names = [
+                "BoldCastle",
+                "CalmRiver",
+                "DarkForest",
+                "AmberPeak",
+                "FrostyLake",
+                "GoldCreek",
+                "MistyCave",
+                "CopperRidge",
+            ];
+            let mut ids = Vec::with_capacity(names.len());
+            for name in names {
+                match queries::register_agent(
+                    &cx,
+                    &p,
+                    project_id,
+                    name,
+                    "serve-http-worker",
+                    "test",
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                {
+                    Outcome::Ok(row) => ids.push(row.id.unwrap()),
+                    other => panic!("register_agent {name} failed: {other:?}"),
+                }
+            }
+            (project_id, ids)
+        })
+    };
+
+    const ITERATIONS: usize = 16;
+    let worker_count = agent_ids.len();
+    let barrier = Arc::new(Barrier::new(worker_count));
+    let (result_tx, result_rx) = std::sync::mpsc::channel::<Result<(), String>>();
+
+    let handles: Vec<_> = agent_ids
+        .into_iter()
+        .enumerate()
+        .map(|(worker_idx, agent_id)| {
+            let pool = pool.clone();
+            let barrier = Arc::clone(&barrier);
+            let result_tx = result_tx.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                for iter in 0..ITERATIONS {
+                    let path = format!("src/http-worker-{worker_idx}/reservation-{iter}.rs");
+                    let created = {
+                        let pool = pool.clone();
+                        let path = path.clone();
+                        block_on(|cx| async move {
+                            let paths = [path.as_str()];
+                            queries::create_file_reservations(
+                                &cx,
+                                &pool,
+                                project_id,
+                                agent_id,
+                                &paths,
+                                3600,
+                                true,
+                                "serve-http worker regression",
+                            )
+                            .await
+                        })
+                    };
+                    let created_rows = match created {
+                        Outcome::Ok(rows) if rows.len() == 1 => rows,
+                        other => {
+                            let _ = result_tx.send(Err(format!(
+                                "worker={worker_idx} iter={iter} create failed: {other:?}"
+                            )));
+                            return;
+                        }
+                    };
+                    let reservation_id = created_rows[0]
+                        .id
+                        .expect("created reservation should carry id");
+
+                    let renewed = {
+                        let pool = pool.clone();
+                        block_on(|cx| async move {
+                            let ids = [reservation_id];
+                            queries::renew_reservations(
+                                &cx,
+                                &pool,
+                                project_id,
+                                agent_id,
+                                60,
+                                None,
+                                Some(&ids),
+                            )
+                            .await
+                        })
+                    };
+                    match renewed {
+                        Outcome::Ok(rows) if rows.len() == 1 => {}
+                        other => {
+                            let _ = result_tx.send(Err(format!(
+                                "worker={worker_idx} iter={iter} renew failed: {other:?}"
+                            )));
+                            return;
+                        }
+                    }
+
+                    if iter % 2 == 0 {
+                        let released = {
+                            let pool = pool.clone();
+                            block_on(|cx| async move {
+                                let ids = [reservation_id];
+                                queries::release_reservations(
+                                    &cx,
+                                    &pool,
+                                    project_id,
+                                    agent_id,
+                                    None,
+                                    Some(&ids),
+                                )
+                                .await
+                            })
+                        };
+                        match released {
+                            Outcome::Ok(rows) if rows.len() == 1 => {}
+                            other => {
+                                let _ = result_tx.send(Err(format!(
+                                    "worker={worker_idx} iter={iter} release failed: {other:?}"
+                                )));
+                                return;
+                            }
+                        }
+                    }
+                }
+                let _ = result_tx.send(Ok(()));
+            })
+        })
+        .collect();
+    drop(result_tx);
+
+    let mut errors = Vec::new();
+    for _ in 0..worker_count {
+        match result_rx.recv_timeout(std::time::Duration::from_secs(120)) {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => errors.push(error),
+            Err(error) => {
+                errors.push(format!(
+                    "timed out waiting for reservation worker result: {error}"
+                ));
+                break;
+            }
+        }
+    }
+    for handle in handles {
+        if let Err(payload) = handle.join() {
+            let panic_msg = payload
+                .downcast_ref::<&str>()
+                .map_or_else(
+                    || {
+                        payload
+                            .downcast_ref::<String>()
+                            .map_or("unknown panic payload", String::as_str)
+                    },
+                    |msg| *msg,
+                )
+                .to_string();
+            errors.push(format!("reservation worker panicked: {panic_msg}"));
+        }
+    }
+    assert!(
+        errors.is_empty(),
+        "reservation workers failed:\n{}",
+        errors.join("\n")
+    );
+
+    let integrity = pool
+        .run_full_integrity_check()
+        .expect("full integrity_check should run after concurrent reservation writes");
+    assert!(
+        integrity.ok,
+        "full integrity_check failed after concurrent reservation writes: {:?}",
+        integrity.details
+    );
+}
+
 // =============================================================================
 // Test: Deferred touch batching under concurrent load
 // =============================================================================


### PR DESCRIPTION
## Summary

- serialize file_reservations create/renew/release behind a process-owned writer lane
- centralize file_reservations write transactions on BEGIN IMMEDIATE instead of BEGIN CONCURRENT
- add an HTTP-worker-style concurrent create/renew/release stress regression followed by full integrity_check

## Tests

- TMPDIR=/private/tmp cargo test -p mcp-agent-mail-db stress_concurrent_http_worker_file_reservation_write_lane_preserves_integrity -- --nocapture
- TMPDIR=/private/tmp cargo test -p mcp-agent-mail-db stress_concurrent_file_reservations -- --nocapture
- cargo fmt
- git diff --check

## Notes

This keeps the fix to the stock write path. It does not include any live DB repair or schema migration.