### PR TITLE
fix(doctor): allow read-only fixer inventory under live owner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "clap",
  "criterion",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-cli"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "asupersync",
  "beads_rust",
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-conformance"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "asupersync",
  "chrono",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-core"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "chrono",
  "criterion",
@@ -5157,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-db"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "asupersync",
  "chrono",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-guard"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "chrono",
  "git2",
@@ -5215,7 +5215,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-search-core"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "chrono",
  "criterion",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-server"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ammonia",
  "asupersync",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-share"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-storage"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "asupersync",
  "base64 0.22.1",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-test-helpers"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "git2",
  "tempfile",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-agent-mail-tools"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "arbitrary",
  "asupersync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 exclude = ["experimental/*"]
 
 [workspace.package]
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 license = "LicenseRef-MIT-Rider"
 license-file = "LICENSE"

--- a/README.md
+++ b/README.md
@@ -1246,7 +1246,46 @@ AM_INSTALLED_BINARY_PARITY_BIN=/path/to/installed/am \
 
 The gate writes `tests/artifacts/installed_binary_parity/<run>/parity_report.json` with one pass/fail row per required JSON path, redacted source/installed values, value-mismatch status, and redacted command metadata. If the candidate lacks fields that source tests rely on, or returns different required values, the report is red and the release is not closed. A local direct `am doctor check --json` or `am robot ... --format json` probe is useful for quick inspection, but it is not sufficient release evidence unless paired with this parity report and an `rch exec -- ...` cargo proof.
 
-Use `--dry-run` to inspect the lane without running it. Use `--no-block-on-conflicts` only when the slot conflict is understood and you intentionally want advisory behavior.
+For hardening uptake that must not mutate the live hub, stage the candidate and
+run the focused source/parity gates before any operator installs it:
+
+```bash
+scripts/hardening_uptake_no_live_hub.sh --profile release
+```
+
+The script installs only into `target/hardening-uptake/<run>/bin`, refuses to
+target the currently resolved live `am` directory, checks for enough local free
+space in the stage root and Cargo target directory before heavy Cargo work. The
+default minimum is 64 GiB because cold test builds can exceed smaller tmpfs
+mounts before a report can be written. The script runs the WAL hardening tests,
+then runs installed-binary parity against the staged `am`. Logs, exit codes, the
+command inventory, `version_gate`, `install_gate`, disk preflight fields, and
+`uptake_report.txt` are written under the run's `artifacts/` directory. Use the
+printed `PATH=<stage-bin>:"$PATH"` command only for explicit canary shells; it
+does not replace `~/.local/bin/am` or restart any Agent Mail process. If the
+source filesystem is under pressure, set both `CARGO_TARGET_DIR` and
+`--stage-root` to a filesystem with enough free space, for example a large
+tmpfs:
+
+```bash
+CARGO_TARGET_DIR=/dev/shm/am-hardening-cargo-target \
+  scripts/hardening_uptake_no_live_hub.sh \
+  --profile release \
+  --stage-root /dev/shm/am-hardening-uptake
+```
+
+If `install_gate=hold-until-candidate-version-is-distinguishable`, produce a
+version-distinguishable release before replacing any live binary.
+
+When canarying the staged binary with `am doctor fix --list` or
+`am doctor fix --only <fm-id> --list`, remember that list mode is detector
+inventory only. JSON fields such as `actions_planned` describe what an approved
+`--dry-run`/`--yes` repair path would plan; list mode itself must not be treated
+as a live repair or permission to run one.
+
+For `am verify` lanes, use `--dry-run` to inspect the lane without running it.
+Use `--no-block-on-conflicts` only when the slot conflict is understood and you
+intentionally want advisory behavior.
 
 ### E2E Entrypoint Policy (T9.9)
 

--- a/crates/mcp-agent-mail-cli/src/ci.rs
+++ b/crates/mcp-agent-mail-cli/src/ci.rs
@@ -2785,7 +2785,7 @@ mod tests {
     #[test]
     fn test_default_gates_count() {
         let gates = default_gates();
-        assert_eq!(gates.len(), 19, "Expected 19 default gates");
+        assert_eq!(gates.len(), 20, "Expected 20 default gates");
     }
 
     #[test]

--- a/crates/mcp-agent-mail-cli/src/lib.rs
+++ b/crates/mcp-agent-mail-cli/src/lib.rs
@@ -3319,12 +3319,17 @@ fn contacts_command_is_read_only(action: &ContactsCommand) -> bool {
 }
 
 fn doctor_command_is_read_only(action: &DoctorCommand) -> bool {
-    // `Drain` is read-only and MUST run even while a live owner holds the
-    // mailbox — reporting the supervised drain protocol is its whole purpose.
-    matches!(
-        action,
-        DoctorCommand::Locks { .. } | DoctorCommand::Drain { .. }
-    )
+    match action {
+        // `Drain` is read-only and MUST run even while a live owner holds the
+        // mailbox — reporting the supervised drain protocol is its whole purpose.
+        DoctorCommand::Locks { .. } | DoctorCommand::Drain { .. } => true,
+        // `doctor fix --list` and `doctor fix --only <fm-id> --list` are
+        // detector-only inventory surfaces. The dispatcher never calls the
+        // mutating fixer branches when `list` is set, so these must be allowed
+        // through the live-owner read-intent path.
+        DoctorCommand::Fix { list: true, .. } => true,
+        _ => false,
+    }
 }
 
 fn execute(cli: Cli) -> CliResult<()> {
@@ -43974,6 +43979,53 @@ http_headers = { Authorization = "Bearer secret" }
             },
         };
         assert!(!command_is_read_only(&fix));
+    }
+
+    #[test]
+    fn doctor_fix_list_inventory_is_read_only_but_mutating_fix_is_not() {
+        let list_all = Commands::Doctor {
+            action: DoctorCommand::Fix {
+                dry_run: false,
+                yes: false,
+                json: true,
+                only: None,
+                list: true,
+            },
+        };
+        assert!(command_is_read_only(&list_all));
+
+        let list_one = Commands::Doctor {
+            action: DoctorCommand::Fix {
+                dry_run: false,
+                yes: false,
+                json: true,
+                only: Some("fm-db-state-files-reservation-db-archive-parity".to_string()),
+                list: true,
+            },
+        };
+        assert!(command_is_read_only(&list_one));
+
+        let dry_run_chokepoint = Commands::Doctor {
+            action: DoctorCommand::Fix {
+                dry_run: true,
+                yes: false,
+                json: true,
+                only: Some("fm-db-state-files-reservation-db-archive-parity".to_string()),
+                list: false,
+            },
+        };
+        assert!(!command_is_read_only(&dry_run_chokepoint));
+
+        let apply_one = Commands::Doctor {
+            action: DoctorCommand::Fix {
+                dry_run: false,
+                yes: true,
+                json: true,
+                only: Some("fm-db-state-files-reservation-db-archive-parity".to_string()),
+                list: false,
+            },
+        };
+        assert!(!command_is_read_only(&apply_one));
     }
 
     fn doctor_locks_test_ownership(

--- a/crates/mcp-agent-mail-cli/tests/ci_integration.rs
+++ b/crates/mcp-agent-mail-cli/tests/ci_integration.rs
@@ -295,7 +295,7 @@ fn test_default_gates_count() {
     use mcp_agent_mail_cli::ci::default_gates;
 
     let gates = default_gates();
-    assert_eq!(gates.len(), 19, "should have 19 default gates");
+    assert_eq!(gates.len(), 20, "should have 20 default gates");
 }
 
 #[test]

--- a/crates/mcp-agent-mail-cli/tests/integration_runs.rs
+++ b/crates/mcp-agent-mail-cli/tests/integration_runs.rs
@@ -1184,6 +1184,22 @@ fn collect_installed_parity_outputs(binary: &Path, env: &TestEnv) -> Value {
     Value::Object(outputs)
 }
 
+fn prewarm_installed_parity_search_index(env: &TestEnv) {
+    let out = run_am_binary(
+        &am_bin(),
+        &env.base_env(),
+        Some(env.tmp.path()),
+        &["robot", "search", "parity-probe", "--format", "json"],
+        None,
+    );
+    assert!(
+        out.status.success(),
+        "failed to prewarm installed parity search index\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 fn run_startup_server_once(env: &TestEnv) -> TimedProcessOutput {
     run_startup_server_once_at(env, env.tmp.path())
 }
@@ -3384,6 +3400,11 @@ fn installed_binary_parity_probe_compares_source_and_installed_am() {
         &env.tmp.path().display().to_string(),
     );
     insert_agent(&conn, 1, 1, "Recipient", "codex-cli", "gpt-5");
+
+    // The index state transitions from delayed to fresh after the first search.
+    // Prewarm once so the source and installed binaries are compared against the
+    // same steady-state isolated mailbox instead of against run-order timing.
+    prewarm_installed_parity_search_index(&env);
 
     let source_outputs = collect_installed_parity_outputs(&am_bin(), &env);
     let installed_outputs = collect_installed_parity_outputs(&installed_binary, &env);

--- a/docs/OPERATOR_COOKBOOK.md
+++ b/docs/OPERATOR_COOKBOOK.md
@@ -368,3 +368,125 @@ saved baseline file you can compare later.
 **Troubleshooting:** If you only care about a subset, rerun with `--filter`.
 For release-signoff performance work, capture the baseline on a machine that is
 not already saturated by other agent builds.
+
+## 16. Audit canonical project-key split before swarm work [read-only]
+
+**Goal:** Confirm all agents for one Git repository are using the same project
+key before assigning or reserving work. This catches the common split where new
+sessions use a remote-derived key while older panes still read path-shaped
+projects.
+
+```bash
+cd /abs/path/project
+
+CANONICAL_PROJECT="$(agent-mail-project-key)"
+LEGACY_PROJECTS='[
+  "/abs/path/project",
+  "/older/checkout/path/project"
+]'
+
+printf 'canonical_project=%s\n' "$CANONICAL_PROJECT"
+am robot projects --format json > /tmp/am-projects.json
+
+jq --arg canonical "$CANONICAL_PROJECT" --argjson legacy "$LEGACY_PROJECTS" '
+  .projects
+  | map(select(.path == $canonical or (.path as $p | $legacy | index($p))))
+  | map({
+      slug,
+      path,
+      agents,
+      messages,
+      reservations,
+      updated_at
+    })
+' /tmp/am-projects.json
+
+for project in "$CANONICAL_PROJECT" $(jq -r '.[]' <<<"$LEGACY_PROJECTS"); do
+  printf '\n# active reservations for %s\n' "$project"
+  am robot reservations --project "$project" --all --format json \
+    | jq '{project: ._meta.project, active: (.all_active // [])}'
+done
+
+am doctor drain --json | jq '{owner_class, safe_to_mutate, detail, safe_next_command}'
+am doctor health
+
+# Candidate/new-release inventory surface for reservation parity drift.
+# This is read-only after the release that classifies `doctor fix --list` as
+# read intent; do not substitute `--dry-run` or `--yes` while a live owner holds
+# the mailbox.
+am doctor fix --only fm-db-state-files-reservation-db-archive-parity --list --json \
+  | jq '{mode, fm_id, findings_count, actions_planned}'
+```
+
+`--list` is detector inventory only: it does not create a doctor run, execute the
+chokepoint, or mutate mailbox state. Some FM outputs may still show
+`actions_planned` / `total_actions_planned` for auto-fixable findings; treat
+that as "actions that would exist under an approved `--dry-run`/`--yes` path",
+not as permission or evidence that this read-only audit changed anything.
+
+**Expected output:** The canonical project is the only project with active file
+reservations. Legacy/path-shaped projects may still contain historical messages
+or agents, but active reservations there mean some panes are operating on the
+wrong bus and must be coordinated before new edits start.
+
+**Safety:** This recipe is read-only. Do not release, force-release, archive
+normalize, reconstruct, search-index refresh, restart the server, or edit the
+database from this audit. If `am doctor drain` reports `safe_to_mutate=false`,
+that is normal for a live service owner; use it as a no-mutation guard, not as a
+reason to kill the owner. On deployed versions before the read-intent
+classification fix, `am doctor fix --only <fm-id> --list` may still be blocked
+by the live-owner guard; use a staged/candidate binary for that inventory probe
+until the live version is upgraded.
+
+**No-go criteria:**
+
+- The `agent-mail-project-key` helper is missing or returns an empty value.
+- Both the canonical project and any legacy project have active reservations.
+- `am doctor health` reports archive/DB parity drift or DB sanity failures that
+  would make project/reservation reads ambiguous. A stale search index is a
+  search-only hold; do not refresh search from this audit unless the operator
+  explicitly needs message-search evidence.
+- The installed `am` version is not distinguishable from the candidate release
+  intended to fix the coordination issue.
+
+**Next safe action:** install or update the local `agent-mail-project-key`
+helper on the affected host, point new agents at the canonical project key, and
+wait for old legacy reservations to expire or be explicitly coordinated by their
+owners. Only run stateful doctor fixes after the live service owner has been
+gracefully drained and an operator has approved the exact mutation.
+
+## 17. Stage hardening uptake without touching the live hub [local-artifact-only]
+
+**Goal:** Prove a candidate binary and runbook path before any service restart
+or live install.
+
+```bash
+cd /abs/path/mcp_agent_mail_rust
+scripts/hardening_uptake_no_live_hub.sh --profile release
+sed -n '1,120p' target/hardening-uptake/*/artifacts/uptake_report.txt
+```
+
+**Expected output:** The script writes a passed or failed `uptake_report.txt`
+containing the source commit, staged binary path, live binary path, Cargo target
+directory, disk preflight fields, WAL test results, installed-binary parity
+command, `version_gate`, and `install_gate`. It never replaces the live binary,
+never runs any stateful doctor fixer, and never starts or stops the Agent Mail
+service. The default disk preflight minimum is 64 GiB because a cold test build
+can exceed smaller tmpfs mounts before a report can be written. If it reports
+`failed_step=disk_preflight`, move the proof to a host/workspace with enough
+free space or get operator approval for cleanup; do not discover disk pressure
+by forcing the linker to continue. On a disk-full host with enough tmpfs space,
+use an off-repo stage root and Cargo target directory:
+
+```bash
+CARGO_TARGET_DIR=/dev/shm/am-hardening-cargo-target \
+  scripts/hardening_uptake_no_live_hub.sh \
+  --profile release \
+  --stage-root /dev/shm/am-hardening-uptake
+```
+
+**Rollback:** There is no live rollback for this recipe because it only writes
+under the chosen stage root and Cargo target directory. Close the canary shell
+or remove the temporary `PATH=<stage-bin>:"$PATH"` prefix. A later live install
+must have its own operator-approved rollback plan, usually reinstalling the
+previous released binary and restarting through the service supervisor.

--- a/scripts/hardening_uptake_no_live_hub.sh
+++ b/scripts/hardening_uptake_no_live_hub.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# Stage and prove an Agent Mail hardening uptake without touching the live hub.
+#
+# This script intentionally installs into target/ by default. It never replaces
+# the currently resolved `am`/`mcp-agent-mail` binaries and never starts/stops a
+# service. Use the staged bin directory only for explicit canary shells.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PROFILE="release"
+STAGE_ROOT=""
+ALLOW_SOURCE_CHANGES=0
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/hardening_uptake_no_live_hub.sh [options]
+
+Build and validate a staged Agent Mail binary without mutating the live install.
+
+Options:
+  --profile <release|debug>  Build profile to stage (default: release)
+  --stage-root <path>        Artifact/staging root (default: target/hardening-uptake/<run>)
+  --allow-source-changes     Permit a dirty tree for validating this script pre-commit
+  -h, --help                 Show help
+
+Validation:
+  - cargo test -p mcp-agent-mail-db wal_classify -- --nocapture
+  - cargo test -p mcp-agent-mail-cli wal_shm_sidecar_drift -- --nocapture
+  - install-local.sh into <stage-root>/bin, refusing the current live bin dir
+  - installed-binary parity against the staged <stage-root>/bin/am
+
+Set CARGO_TARGET_DIR to place Cargo build artifacts outside the repo target
+directory. This is useful on hosts where the source filesystem is under disk
+pressure but a tmpfs or other staging filesystem has enough space.
+
+The script writes logs, exit codes, command inventory, and uptake_report.txt
+under <stage-root>/artifacts/.
+USAGE
+}
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --profile)
+            PROFILE="${2:-}"
+            shift 2
+            ;;
+        --stage-root)
+            STAGE_ROOT="${2:-}"
+            shift 2
+            ;;
+        --allow-source-changes)
+            ALLOW_SOURCE_CHANGES=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+case "${PROFILE}" in
+    release|debug) ;;
+    *) die "--profile must be release or debug" ;;
+esac
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+canonical_dir() {
+    local path="$1"
+    if [ -d "${path}" ]; then
+        (cd "${path}" && pwd -P)
+    else
+        printf '%s\n' "${path}"
+    fi
+}
+
+command_line() {
+    printf '%q ' "$@"
+}
+
+run_step() {
+    local step_id="$1"
+    shift
+
+    local stdout_log="${ARTIFACT_DIR}/${step_id}.stdout.log"
+    local stderr_log="${ARTIFACT_DIR}/${step_id}.stderr.log"
+    local exit_code_file="${ARTIFACT_DIR}/${step_id}.exit_code"
+
+    printf '%s\t' "${step_id}" >> "${COMMANDS_TSV}"
+    command_line "$@" >> "${COMMANDS_TSV}"
+    printf '\n' >> "${COMMANDS_TSV}"
+
+    printf '\n==> %s\n' "${step_id}"
+    set +e
+    "$@" > >(tee "${stdout_log}") 2> >(tee "${stderr_log}" >&2)
+    local rc=$?
+    set -e
+    printf '%s\n' "${rc}" > "${exit_code_file}"
+
+    if [ "${rc}" -ne 0 ]; then
+        write_report "failed" "${step_id}"
+        printf 'FAILED: %s exited %s\n' "${step_id}" "${rc}" >&2
+        printf 'Logs: %s %s\n' "${stdout_log}" "${stderr_log}" >&2
+        exit "${rc}"
+    fi
+}
+
+write_report() {
+    local status="$1"
+    local failed_step="${2:-}"
+    local report="${ARTIFACT_DIR}/uptake_report.txt"
+
+    {
+        printf 'schema=agent-mail-hardening-uptake-no-live-hub-v1\n'
+        printf 'status=%s\n' "${status}"
+        if [ -n "${failed_step}" ]; then
+            printf 'failed_step=%s\n' "${failed_step}"
+        fi
+        printf 'created_at_utc=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        printf 'repo_root=%s\n' "${REPO_ROOT}"
+        printf 'git_sha=%s\n' "${GIT_SHA}"
+        printf 'profile=%s\n' "${PROFILE}"
+        printf 'stage_root=%s\n' "${STAGE_ROOT}"
+        printf 'stage_bin=%s\n' "${STAGE_BIN}"
+        printf 'build_target_dir=%s\n' "${BUILD_TARGET_DIR:-not-set}"
+        printf 'artifacts=%s\n' "${ARTIFACT_DIR}"
+        printf 'live_am_path=%s\n' "${LIVE_AM_PATH:-not-found}"
+        printf 'live_am_version=%s\n' "${LIVE_AM_VERSION:-not-found}"
+        printf 'staged_am_path=%s\n' "${STAGE_BIN}/am"
+        printf 'staged_am_version=%s\n' "${STAGED_AM_VERSION:-not-built}"
+        printf 'staged_server_path=%s\n' "${STAGE_BIN}/mcp-agent-mail"
+        printf 'version_gate=%s\n' "${VERSION_GATE:-not-evaluated}"
+        printf 'install_gate=%s\n' "${INSTALL_GATE:-not-evaluated}"
+        printf 'min_free_kib=%s\n' "${MIN_FREE_KIB:-not-checked}"
+        printf 'repo_free_kib=%s\n' "${REPO_FREE_KIB:-not-checked}"
+        printf 'stage_free_kib=%s\n' "${STAGE_FREE_KIB:-not-checked}"
+        printf 'build_free_kib=%s\n' "${BUILD_FREE_KIB:-not-checked}"
+        printf 'commands_tsv=%s\n' "${COMMANDS_TSV}"
+        if [ -s "${SOURCE_CHANGES_TXT:-}" ]; then
+            printf 'source_changes=%s\n' "${SOURCE_CHANGES_TXT}"
+        fi
+        printf 'no_live_install=true\n'
+        printf 'live_install_dir_refused=%s\n' "${LIVE_AM_DIR:-not-found}"
+        printf 'source_changes_allowed=%s\n' "${ALLOW_SOURCE_CHANGES}"
+        printf 'canary_shell=PATH=%q:"$PATH" am --version\n' "${STAGE_BIN}"
+    } > "${report}"
+
+    printf '\nReport: %s\n' "${report}"
+}
+
+require_cmd cargo
+require_cmd df
+require_cmd git
+require_cmd tee
+
+cd "${REPO_ROOT}"
+
+GIT_SHA="$(git rev-parse HEAD)"
+GIT_SHORT="${GIT_SHA:0:8}"
+RUN_ID="$(date -u '+%Y%m%dT%H%M%SZ')-${GIT_SHORT}-${PROFILE}"
+
+if [ -z "${STAGE_ROOT}" ]; then
+    STAGE_ROOT="${REPO_ROOT}/target/hardening-uptake/${RUN_ID}"
+fi
+
+STAGE_BIN="${STAGE_ROOT}/bin"
+ARTIFACT_DIR="${STAGE_ROOT}/artifacts"
+COMMANDS_TSV="${ARTIFACT_DIR}/commands.tsv"
+SOURCE_CHANGES_TXT="${ARTIFACT_DIR}/source_changes.txt"
+BUILD_TARGET_DIR="${CARGO_TARGET_DIR:-${REPO_ROOT}/target}"
+case "${BUILD_TARGET_DIR}" in
+    /*) ;;
+    *) BUILD_TARGET_DIR="${REPO_ROOT}/${BUILD_TARGET_DIR}" ;;
+esac
+export CARGO_TARGET_DIR="${BUILD_TARGET_DIR}"
+
+mkdir -p "${STAGE_BIN}" "${ARTIFACT_DIR}" "${BUILD_TARGET_DIR}"
+: > "${COMMANDS_TSV}"
+
+LIVE_AM_PATH="$(command -v am || true)"
+LIVE_AM_DIR=""
+LIVE_AM_VERSION=""
+VERSION_GATE="not-evaluated"
+INSTALL_GATE="not-evaluated"
+MIN_FREE_KIB="${AM_HARDENING_UPTAKE_MIN_FREE_KIB:-67108864}"
+REPO_FREE_KIB="not-checked"
+STAGE_FREE_KIB="not-checked"
+BUILD_FREE_KIB="not-checked"
+if [ -n "${LIVE_AM_PATH}" ]; then
+    LIVE_AM_DIR="$(dirname "${LIVE_AM_PATH}")"
+    LIVE_AM_VERSION="$("${LIVE_AM_PATH}" --version 2>/dev/null || true)"
+fi
+
+if [ -n "${LIVE_AM_DIR}" ] \
+    && [ "$(canonical_dir "${STAGE_BIN}")" = "$(canonical_dir "${LIVE_AM_DIR}")" ]; then
+    die "stage bin resolves to the live am directory: ${LIVE_AM_DIR}"
+fi
+
+case ":${PATH}:" in
+    *":${STAGE_BIN}:"*)
+        die "stage bin is already in PATH; run from a shell that resolves live am normally"
+        ;;
+esac
+
+SOURCE_CHANGES="$(git status --porcelain --untracked-files=all -- . ':!tests/artifacts' ':!target')"
+if [ -n "${SOURCE_CHANGES}" ]; then
+    printf '%s\n' "${SOURCE_CHANGES}" > "${SOURCE_CHANGES_TXT}"
+    if [ "${ALLOW_SOURCE_CHANGES}" -eq 1 ]; then
+        printf 'WARNING: source changes are present; continuing because --allow-source-changes was set.\n' >&2
+    else
+        die "worktree has source changes; commit/stash or choose a clean checkout before uptake proof"
+    fi
+fi
+
+available_kib() {
+    df -Pk "$1" | awk 'NR == 2 { print $4 }'
+}
+
+REPO_FREE_KIB="$(available_kib "${REPO_ROOT}")"
+STAGE_FREE_KIB="$(available_kib "${STAGE_ROOT}")"
+BUILD_FREE_KIB="$(available_kib "${BUILD_TARGET_DIR}")"
+
+if [ "${STAGE_FREE_KIB}" -lt "${MIN_FREE_KIB}" ] || [ "${BUILD_FREE_KIB}" -lt "${MIN_FREE_KIB}" ]; then
+    write_report "failed" "disk_preflight"
+    die "insufficient free disk for hardening uptake: require ${MIN_FREE_KIB} KiB, stage has ${STAGE_FREE_KIB} KiB, build target has ${BUILD_FREE_KIB} KiB"
+fi
+
+INSTALL_ARGS=()
+if [ "${PROFILE}" = "debug" ]; then
+    INSTALL_ARGS+=(--debug)
+fi
+
+run_step wal_classifier_tests \
+    cargo test -p mcp-agent-mail-db wal_classify -- --nocapture
+
+run_step doctor_wal_detector_tests \
+    cargo test -p mcp-agent-mail-cli wal_shm_sidecar_drift -- --nocapture
+
+run_step stage_install \
+    env DEST="${STAGE_BIN}" "${REPO_ROOT}/install-local.sh" "${INSTALL_ARGS[@]}"
+
+STAGED_AM_VERSION="$("${STAGE_BIN}/am" --version 2>/dev/null || true)"
+if [ -z "${LIVE_AM_VERSION}" ]; then
+    VERSION_GATE="no-live-binary-detected"
+    INSTALL_GATE="hold-until-operator-identifies-live-binary"
+elif [ "${STAGED_AM_VERSION}" = "${LIVE_AM_VERSION}" ]; then
+    VERSION_GATE="blocked-same-version-as-live"
+    INSTALL_GATE="hold-until-candidate-version-is-distinguishable"
+else
+    VERSION_GATE="ok-distinguishable-version"
+    INSTALL_GATE="candidate-version-distinguishable"
+fi
+
+run_step installed_binary_parity \
+    env AM_INSTALLED_BINARY_PARITY_BIN="${STAGE_BIN}/am" \
+    cargo test -p mcp-agent-mail-cli --test integration_runs \
+    installed_binary_parity_probe_compares_source_and_installed_am -- --ignored --nocapture
+
+write_report "passed"
+
+printf '\nStaged candidate is ready for explicit canary shells only:\n'
+printf '  PATH=%q:"$PATH" am --version\n' "${STAGE_BIN}"
+printf '\nInstall gate: %s (%s)\n' "${INSTALL_GATE}" "${VERSION_GATE}"
+printf '\nThis script did not replace the live am binary or touch live hub state.\n'


### PR DESCRIPTION
## Summary

This PR hardens Agent Mail coordination uptake without requiring a live hub restart or mailbox mutation.

- Classifies `am doctor fix --list` and `am doctor fix --only <fm-id> --list` as read-only inventory surfaces so agents can audit fixer inventory while the shared mailbox owner is live.
- Keeps mutating `doctor fix`, `--dry-run`, and `--yes` behind the existing live-owner guard.
- Adds a no-live staged uptake script that installs only into `target/hardening-uptake/<run>/bin`, refuses the live `am` directory, runs WAL and installed-binary parity checks, and writes an operator report.
- Documents canonical repo-derived project-key audits and no-live staged uptake in the README/operator cookbook.
- Bumps the workspace version to `0.3.14` so staged candidates are distinguishable from live `am 0.3.13`.
- Updates stale default-gate-count tests from 19 to 20 so the existing reliability coverage gate is represented in local CI expectations.

## Validation

Refreshed locally from `/data/projects/mcp_agent_mail_rust` at `df5c514778e4027f4f99d521d61bc671c5dad8c9` on 2026-06-18T20:45Z:

- `cargo fmt --check`
- `bash -n scripts/hardening_uptake_no_live_hub.sh`
- `git diff --check`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test -p mcp-agent-mail-cli doctor_fix_list_inventory_is_read_only_but_mutating_fix_is_not -- --nocapture`
- `STORAGE_ROOT=/tmp/am-test-storage-default-gates-src-refresh cargo test -p mcp-agent-mail-cli ci::tests::test_default_gates_count -- --nocapture`
- `STORAGE_ROOT=/tmp/am-test-storage-default-gates-int-refresh cargo test -p mcp-agent-mail-cli --test ci_integration test_default_gates_count -- --nocapture`

Required sibling path-dependency state for local validation:

- `/data/projects/asupersync` at `ba68ef6b4`
- `/data/projects/frankentui` at `316bd036`

## Current no-live uptake hold

The current-commit release-profile no-live uptake script is disk-held on this host, not source-failed:

```text
report=/data/projects/mcp_agent_mail_rust/target/hardening-uptake/20260618T202327Z-df5c5147-release/artifacts/uptake_report.txt
status=failed
failed_step=disk_preflight
git_sha=df5c514778e4027f4f99d521d61bc671c5dad8c9
profile=release
live_am_version=am 0.3.13
staged_am_version=not-built
min_free_kib=67108864
repo_free_kib=28209452
stage_free_kib=28209732
build_free_kib=28209732
no_live_install=true
live_install_dir_refused=/home/ubuntu/.local/bin
```

Current filesystem evidence at refresh: `/dev/sda1` has about 27 GiB free and `/dev/shm` has about 48 GiB free, both below the script's 64 GiB safety gate. Do not lower `AM_HARDENING_UPTAKE_MIN_FREE_KIB` without explicit operator approval.

## ACFS checksum discipline

Ran the checksum candidate flow in `/data/projects/agentic_coding_flywheel_setup`:

```bash
candidate="/tmp/acfs-checksums-agent-mail-1469236.candidate.yaml"
./scripts/lib/security.sh --update-checksums > "$candidate"
diff -u checksums.yaml "$candidate"
```

The diff was timestamp-header only. The `mcp_agent_mail` installer entry stayed:

```text
url: https://raw.githubusercontent.com/Dicklesworthstone/mcp_agent_mail_rust/refs/heads/main/install.sh
sha256: 69271249379f7ff4047bd736069e37e28a80f43888a71fea774a026aaca5f34d
```

Per ACFS rules, `checksums.yaml` was left unchanged. Re-run the candidate flow after this PR lands on upstream `main`; update `checksums.yaml` only if the `mcp_agent_mail` installer entry changes beyond the timestamp.

## Live hub boundary

No live hub restart, DB/archive write, Search V3 refresh, reservation mutation, live binary install, or service mutation was performed. This is source/runbook only.
