### PR TITLE
fix(tools): cache archive read inventory by HEAD

### DIFF
--- a/crates/mcp-agent-mail-cli/src/lib.rs
+++ b/crates/mcp-agent-mail-cli/src/lib.rs
@@ -10169,24 +10169,27 @@ where
     }
 
     let path_string = path.to_string_lossy().into_owned();
-    let conn = match mcp_agent_mail_db::DbConn::open_file(&path_string) {
-        Ok(conn) => conn,
-        Err(e) => {
-            let err_text = e.to_string();
-            if mcp_agent_mail_db::is_lock_error(&err_text) {
-                return Err(sqlite_doctor_busy_error(path, &err_text));
+    let conn = mcp_agent_mail_db::guard_db_conn(
+        match mcp_agent_mail_db::DbConn::open_file(&path_string) {
+            Ok(conn) => conn,
+            Err(e) => {
+                let err_text = e.to_string();
+                if mcp_agent_mail_db::is_lock_error(&err_text) {
+                    return Err(sqlite_doctor_busy_error(path, &err_text));
+                }
+                if is_sqlite_recovery_error_message(&err_text)
+                    || mcp_agent_mail_db::is_sqlite_snapshot_conflict_error_message(&err_text)
+                {
+                    return Ok(false);
+                }
+                return Err(CliError::Other(format!(
+                    "cannot open sqlite file {} for health check: {e}",
+                    path.display()
+                )));
             }
-            if is_sqlite_recovery_error_message(&err_text)
-                || mcp_agent_mail_db::is_sqlite_snapshot_conflict_error_message(&err_text)
-            {
-                return Ok(false);
-            }
-            return Err(CliError::Other(format!(
-                "cannot open sqlite file {} for health check: {e}",
-                path.display()
-            )));
-        }
-    };
+        },
+        "cli sqlite health probe",
+    );
 
     let is_healthy = sqlite_conn_is_healthy(&conn)?;
     drop(conn);
@@ -20980,7 +20983,7 @@ fn handle_doctor_check(
 }
 
 struct DoctorOpenContext {
-    conn: mcp_agent_mail_db::DbConn,
+    conn: mcp_agent_mail_db::DbConnGuard,
     opened_path: String,
 }
 
@@ -21001,8 +21004,11 @@ fn open_db_for_doctor_check_with_context(database_url: &str) -> CliResult<Doctor
         .sqlite_path()
         .map_err(|e| CliError::Other(format!("bad database URL: {e}")))?;
     if path == ":memory:" {
-        let conn = mcp_agent_mail_db::DbConn::open_memory()
-            .map_err(|e| CliError::Other(format!("cannot open in-memory database: {e}")))?;
+        let conn = mcp_agent_mail_db::guard_db_conn(
+            mcp_agent_mail_db::DbConn::open_memory()
+                .map_err(|e| CliError::Other(format!("cannot open in-memory database: {e}")))?,
+            "doctor database probe connection",
+        );
         return Ok(DoctorOpenContext {
             conn,
             opened_path: path,
@@ -21032,50 +21038,57 @@ fn open_db_for_doctor_check_with_context(database_url: &str) -> CliResult<Doctor
     }
 
     match mcp_agent_mail_db::DbConn::open_file(&candidate_path) {
-        Ok(conn) => match conn.query_sync("SELECT 1 AS one", &[]) {
-            Ok(_) => Ok(DoctorOpenContext {
-                conn,
-                opened_path: candidate_path,
-            }),
-            Err(probe_err) => {
-                let probe_err_text = probe_err.to_string();
-                if let Some(fallback_path) =
-                    sqlite_absolute_fallback_path(&candidate_path, &probe_err_text)
-                {
-                    let fallback_conn =
+        Ok(conn) => {
+            let conn = mcp_agent_mail_db::guard_db_conn(conn, "doctor database probe connection");
+            match conn.query_sync("SELECT 1 AS one", &[]) {
+                Ok(_) => Ok(DoctorOpenContext {
+                    conn,
+                    opened_path: candidate_path,
+                }),
+                Err(probe_err) => {
+                    let probe_err_text = probe_err.to_string();
+                    if let Some(fallback_path) =
+                        sqlite_absolute_fallback_path(&candidate_path, &probe_err_text)
+                    {
+                        let fallback_conn = mcp_agent_mail_db::guard_db_conn(
                         mcp_agent_mail_db::DbConn::open_file(&fallback_path).map_err(|e| {
                             CliError::Other(format!(
                                 "database probe failed at {candidate_path}: {probe_err}; fallback {fallback_path} failed: {e}"
                             ))
-                        })?;
-                    fallback_conn
+                        })?,
+                        "doctor database fallback probe connection",
+                    );
+                        fallback_conn
                         .query_sync("SELECT 1 AS one", &[])
                         .map_err(|e| {
                             CliError::Other(format!(
                                 "database probe failed at {candidate_path}: {probe_err}; fallback {fallback_path} probe failed: {e}"
                             ))
                     })?;
-                    return Ok(DoctorOpenContext {
-                        conn: fallback_conn,
-                        opened_path: fallback_path,
-                    });
+                        return Ok(DoctorOpenContext {
+                            conn: fallback_conn,
+                            opened_path: fallback_path,
+                        });
+                    }
+                    Err(CliError::Other(format!(
+                        "database probe failed at {candidate_path}: {probe_err}"
+                    )))
                 }
-                Err(CliError::Other(format!(
-                    "database probe failed at {candidate_path}: {probe_err}"
-                )))
             }
-        },
+        }
         Err(primary_err) => {
             let primary_err_text = primary_err.to_string();
             if let Some(fallback_path) =
                 sqlite_absolute_fallback_path(&candidate_path, &primary_err_text)
             {
-                let fallback_conn =
+                let fallback_conn = mcp_agent_mail_db::guard_db_conn(
                     mcp_agent_mail_db::DbConn::open_file(&fallback_path).map_err(|e| {
                         CliError::Other(format!(
                             "cannot open database at {candidate_path}: {primary_err}; fallback {fallback_path} failed: {e}"
                         ))
-                    })?;
+                    })?,
+                    "doctor database fallback probe connection",
+                );
                 fallback_conn
                     .query_sync("SELECT 1 AS one", &[])
                     .map_err(|e| {
@@ -21096,7 +21109,7 @@ fn open_db_for_doctor_check_with_context(database_url: &str) -> CliResult<Doctor
 }
 
 fn open_db_for_doctor_check(database_url: &str) -> CliResult<mcp_agent_mail_db::DbConn> {
-    open_db_for_doctor_check_with_context(database_url).map(|opened| opened.conn)
+    open_db_for_doctor_check_with_context(database_url).map(|opened| opened.conn.into_inner())
 }
 
 fn open_db_for_doctor_check_read_only_with_context(

--- a/crates/mcp-agent-mail-core/src/backpressure.rs
+++ b/crates/mcp-agent-mail-core/src/backpressure.rs
@@ -191,17 +191,19 @@ impl HealthSignals {
             snap.storage.commit_pending_requests,
             snap.storage.commit_soft_cap,
         );
-        // Queue latency histograms are cumulative; ignore historical spikes
-        // once the queue has drained so old pressure does not pin health.
-        let wbq_queue_p95_us = if snap.storage.wbq_depth == 0 {
-            0
-        } else {
+        // Queue latency histograms are cumulative; use them only to escalate a
+        // currently material backlog. A single normal coalesced commit can be
+        // pending while it waits for its flush interval, so a historical slow
+        // sample must not pin flow-control health in yellow or red.
+        let wbq_queue_p95_us = if wbq_depth_pct >= yellow::WBQ_DEPTH_PCT {
             snap.storage.wbq_queue_latency_us.p95
-        };
-        let commit_queue_p95_us = if snap.storage.commit_pending_requests == 0 {
-            0
         } else {
+            0
+        };
+        let commit_queue_p95_us = if commit_depth_pct >= yellow::COMMIT_DEPTH_PCT {
             snap.storage.commit_queue_latency_us.p95
+        } else {
+            0
         };
         let (disk_pressure_level, disk_pressure_stale) = fresh_pressure_level(
             snap.system.disk_pressure_level,
@@ -1203,6 +1205,42 @@ mod tests {
 
         let signals = HealthSignals::from_snapshot(&snap, now_us);
 
+        assert_eq!(signals.wbq_queue_p95_us, 0);
+        assert_eq!(signals.commit_queue_p95_us, 0);
+        assert_eq!(signals.classify(), HealthLevel::Green);
+    }
+
+    #[test]
+    fn health_signals_ignore_historical_queue_latency_below_material_backlog() {
+        let mut snap = GlobalMetrics::default().snapshot();
+        let now_us = 1_000_000_000;
+        snap.storage.wbq_depth = 1;
+        snap.storage.wbq_capacity = 8192;
+        snap.storage.wbq_queue_latency_us = HistogramSnapshot {
+            count: 1,
+            sum: red::QUEUE_WAIT_P95_US,
+            min: red::QUEUE_WAIT_P95_US,
+            max: red::QUEUE_WAIT_P95_US,
+            p50: red::QUEUE_WAIT_P95_US,
+            p95: red::QUEUE_WAIT_P95_US,
+            p99: red::QUEUE_WAIT_P95_US,
+        };
+        snap.storage.commit_pending_requests = 1;
+        snap.storage.commit_soft_cap = 8192;
+        snap.storage.commit_queue_latency_us = HistogramSnapshot {
+            count: 1,
+            sum: red::QUEUE_WAIT_P95_US,
+            min: red::QUEUE_WAIT_P95_US,
+            max: red::QUEUE_WAIT_P95_US,
+            p50: red::QUEUE_WAIT_P95_US,
+            p95: red::QUEUE_WAIT_P95_US,
+            p99: red::QUEUE_WAIT_P95_US,
+        };
+
+        let signals = HealthSignals::from_snapshot(&snap, now_us);
+
+        assert_eq!(signals.wbq_depth_pct, 0);
+        assert_eq!(signals.commit_depth_pct, 0);
         assert_eq!(signals.wbq_queue_p95_us, 0);
         assert_eq!(signals.commit_queue_p95_us, 0);
         assert_eq!(signals.classify(), HealthLevel::Green);

--- a/crates/mcp-agent-mail-core/src/backpressure.rs
+++ b/crates/mcp-agent-mail-core/src/backpressure.rs
@@ -165,17 +165,25 @@ impl HealthSignals {
     /// `now_us` is the current time in microseconds (Unix epoch).
     #[must_use]
     pub const fn from_snapshot(snap: &GlobalMetricsSnapshot, now_us: u64) -> Self {
-        let pool_over_80_for_s = duration_since_s(snap.db.pool_over_80_since_us, now_us);
+        // Pool totals are lazily populated, so one active connection out of one
+        // opened connection is normal until another caller must wait. Only treat
+        // pool gauges and their cumulative latency as pressure when the pool has
+        // an actual waiter.
+        let pool_has_waiters = snap.db.pool_pending_requests > 0;
+        let pool_over_80_for_s = if pool_has_waiters {
+            duration_since_s(snap.db.pool_over_80_since_us, now_us)
+        } else {
+            0
+        };
         let wbq_over_80_for_s = duration_since_s(snap.storage.wbq_over_80_since_us, now_us);
         let commit_over_80_for_s = duration_since_s(snap.storage.commit_over_80_since_us, now_us);
-        // Pool-acquire latency is a cumulative histogram. If the pool is currently
-        // idle, historical spikes should not keep health stuck in yellow/red.
-        let pool_is_idle =
-            snap.db.pool_active_connections == 0 && snap.db.pool_pending_requests == 0;
-        let pool_acquire_p95_us = if pool_is_idle {
-            0
-        } else {
+        // Pool-acquire latency is a cumulative histogram. If the pool is not
+        // contended, historical spikes and lazy pool population should not keep
+        // health stuck in yellow/red.
+        let pool_acquire_p95_us = if pool_has_waiters {
             snap.db.pool_acquire_latency_us.p95
+        } else {
+            0
         };
 
         let wbq_depth_pct = pct(snap.storage.wbq_depth, snap.storage.wbq_capacity);
@@ -208,7 +216,11 @@ impl HealthSignals {
 
         Self {
             pool_acquire_p95_us,
-            pool_utilization_pct: snap.db.pool_utilization_pct,
+            pool_utilization_pct: if pool_has_waiters {
+                snap.db.pool_utilization_pct
+            } else {
+                0
+            },
             pool_over_80_for_s,
             wbq_depth_pct,
             wbq_queue_p95_us,
@@ -1133,6 +1145,34 @@ mod tests {
         let signals = HealthSignals::from_snapshot(&snap, now_us);
 
         assert_eq!(signals.pool_acquire_p95_us, 0);
+        assert_eq!(signals.classify(), HealthLevel::Green);
+    }
+
+    #[test]
+    fn health_signals_ignore_lazy_pool_utilization_without_waiters() {
+        let mut snap = GlobalMetrics::default().snapshot();
+        let now_us = 1_000_000_000;
+        snap.db.pool_acquire_latency_us = HistogramSnapshot {
+            count: 1,
+            sum: 500_000,
+            min: 500_000,
+            max: 500_000,
+            p50: 500_000,
+            p95: 500_000,
+            p99: 500_000,
+        };
+        snap.db.pool_total_connections = 1;
+        snap.db.pool_active_connections = 1;
+        snap.db.pool_idle_connections = 0;
+        snap.db.pool_pending_requests = 0;
+        snap.db.pool_utilization_pct = 100;
+        snap.db.pool_over_80_since_us = now_us - 600_000_000;
+
+        let signals = HealthSignals::from_snapshot(&snap, now_us);
+
+        assert_eq!(signals.pool_acquire_p95_us, 0);
+        assert_eq!(signals.pool_utilization_pct, 0);
+        assert_eq!(signals.pool_over_80_for_s, 0);
         assert_eq!(signals.classify(), HealthLevel::Green);
     }
 

--- a/crates/mcp-agent-mail-db/src/atc_queries.rs
+++ b/crates/mcp-agent-mail-db/src/atc_queries.rs
@@ -745,6 +745,12 @@ pub async fn refresh_rollups(
     lookback_micros: i64,
 ) -> Outcome<RollupSummary, DbError> {
     if pool.sqlite_path() != ":memory:" {
+        match crate::queries::ensure_file_backed_atc_pool_initialized(cx, pool).await {
+            Outcome::Ok(()) => {}
+            Outcome::Err(error) => return Outcome::Err(error),
+            Outcome::Cancelled(reason) => return Outcome::Cancelled(reason),
+            Outcome::Panicked(payload) => return Outcome::Panicked(payload),
+        }
         return match crate::queries::open_canonical_atc_conn(pool, "refresh_rollups") {
             Ok(conn) => {
                 let result = refresh_rollups_with_conn(&conn, now_micros, lookback_micros);
@@ -1772,6 +1778,42 @@ mod tests {
             .into_result()
             .expect("initialize ATC sidecar schema for test pool");
         pool
+    }
+
+    #[test]
+    fn refresh_rollups_initializes_file_backed_atc_sidecar() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("refresh_rollups_sidecar_init.db");
+        let pool = crate::create_pool(&crate::pool::DbPoolConfig {
+            database_url: format!("sqlite:///{}", db_path.display()),
+            min_connections: 1,
+            max_connections: 1,
+            run_migrations: true,
+            warmup_connections: 0,
+            ..Default::default()
+        })
+        .expect("create file-backed pool");
+        let atc_path = pool
+            .atc_sqlite_path()
+            .expect("file-backed ATC sidecar path");
+        assert!(
+            !std::path::Path::new(&atc_path).exists(),
+            "fresh pool should not need an ATC sidecar before the first ATC operation"
+        );
+
+        let runtime = RuntimeBuilder::current_thread()
+            .build()
+            .expect("build runtime");
+        let cx = Cx::for_testing();
+        let summary = runtime
+            .block_on(refresh_rollups(&cx, &pool, crate::now_micros(), 60_000_000))
+            .into_result()
+            .expect("first rollup refresh should initialize the ATC sidecar");
+        assert_eq!(summary.rows_scanned, 0);
+        assert!(
+            std::path::Path::new(&atc_path).is_file(),
+            "first rollup refresh should create the canonical ATC sidecar"
+        );
     }
 
     fn encode_outcome(spec: &TestExperienceSpec) -> Option<String> {

--- a/crates/mcp-agent-mail-db/src/integrity.rs
+++ b/crates/mcp-agent-mail-db/src/integrity.rs
@@ -190,6 +190,7 @@ pub fn inspect_mailbox_integrity(db_path: &Path, kind: CheckKind) -> MailboxInte
             };
         }
     };
+    let conn = crate::guard_db_conn(conn, "inspect_mailbox_integrity connection");
 
     match run_check(&conn, kind) {
         Ok(check) => MailboxIntegrityVerdict {

--- a/crates/mcp-agent-mail-db/src/lib.rs
+++ b/crates/mcp-agent-mail-db/src/lib.rs
@@ -344,11 +344,14 @@ pub type DbConn = sqlmodel_frankensqlite::FrankenConnection;
 pub type CanonicalDbConn = sqlmodel_sqlite::SqliteConnection;
 
 pub fn close_db_conn(conn: DbConn, context: &'static str) {
-    if let Err(error) = conn.close_sync() {
+    // Checkpoint scheduling is handled by the database maintenance path. These
+    // short-lived worker and probe connections must release their handles
+    // without contending for a final WAL checkpoint on every close.
+    if let Err(error) = conn.close_without_checkpoint_sync() {
         tracing::warn!(
             context,
             error = %error,
-            "failed to close FrankenSQLite connection explicitly"
+            "failed to close FrankenSQLite connection without final checkpoint"
         );
     }
 }

--- a/crates/mcp-agent-mail-db/src/pool.rs
+++ b/crates/mcp-agent-mail-db/src/pool.rs
@@ -6878,6 +6878,11 @@ fn quarantined_sidecar_path(
 
 const SQLITE_RECOVERY_SIDECAR_SUFFIXES: [&str; 3] = ["-journal", "-wal", "-shm"];
 
+// FrankenSQLite creates these namespace coordination files whenever it probes
+// a file-backed database. They are safe to remove only for a disposable staged
+// candidate, never for a live primary database.
+const FSQLITE_CANDIDATE_NAMESPACE_SUFFIXES: [&str; 2] = ["-fsqlite-ns-gate", "-fsqlite-ns-use"];
+
 fn sqlite_recovery_sidecar_label(suffix: &str) -> &'static str {
     match suffix {
         "-journal" => "rollback-journal",
@@ -6911,6 +6916,7 @@ fn sqlite_candidate_artifact_conflicts(candidate: &Path) -> bool {
     path_is_occupied(candidate)
         || SQLITE_RECOVERY_SIDECAR_SUFFIXES
             .iter()
+            .chain(FSQLITE_CANDIDATE_NAMESPACE_SUFFIXES.iter())
             .any(|suffix| path_is_occupied(&sqlite_sidecar_path(candidate, suffix)))
 }
 
@@ -7053,12 +7059,19 @@ fn stage_backup_restore_candidate(
     Ok(restore_candidate)
 }
 
+fn remove_sqlite_candidate_sidecars(candidate: &Path) {
+    for suffix in SQLITE_RECOVERY_SIDECAR_SUFFIXES
+        .iter()
+        .chain(FSQLITE_CANDIDATE_NAMESPACE_SUFFIXES.iter())
+    {
+        let _ = std::fs::remove_file(sqlite_sidecar_path(candidate, suffix));
+    }
+}
+
 #[allow(clippy::result_large_err)]
 fn cleanup_sqlite_candidate_artifact(candidate: &Path) {
     let _ = std::fs::remove_file(candidate);
-    for suffix in SQLITE_RECOVERY_SIDECAR_SUFFIXES {
-        let _ = std::fs::remove_file(sqlite_sidecar_path(candidate, suffix));
-    }
+    remove_sqlite_candidate_sidecars(candidate);
 }
 
 #[allow(clippy::result_large_err)]
@@ -7677,9 +7690,7 @@ fn restore_from_backup(primary_path: &Path, backup_path: &Path) -> Result<(), Sq
             backup_path.display()
         )));
     }
-    for suffix in SQLITE_RECOVERY_SIDECAR_SUFFIXES {
-        let _ = std::fs::remove_file(sqlite_sidecar_path(&restore_candidate, suffix));
-    }
+    remove_sqlite_candidate_sidecars(&restore_candidate);
 
     let quarantined_db = sqlite_path_with_file_name_suffix(
         primary_path,
@@ -10154,6 +10165,9 @@ mod tests {
         let first_wal = sqlite_sidecar_path(&first, "-wal");
         let missing_target = dir.path().join("missing-wal-target");
         symlink(&missing_target, &first_wal).expect("create broken staged wal symlink");
+        let first_namespace_use = sqlite_sidecar_path(&first, "-fsqlite-ns-use");
+        std::fs::write(&first_namespace_use, b"stale namespace marker")
+            .expect("create stale staged namespace marker");
 
         let candidate = restore_candidate_path(&primary, timestamp);
         assert_eq!(

--- a/crates/mcp-agent-mail-db/src/pool.rs
+++ b/crates/mcp-agent-mail-db/src/pool.rs
@@ -4080,7 +4080,10 @@ pub fn inspect_mailbox_db_inventory(primary_path: &Path) -> Result<MailboxDbInve
         )));
     }
 
-    let conn = open_sqlite_file_with_lock_retry(primary_path.to_string_lossy().as_ref())?;
+    let conn = crate::guard_db_conn(
+        open_sqlite_file_with_lock_retry(primary_path.to_string_lossy().as_ref())?,
+        "mailbox database inventory connection",
+    );
     let present = conn
         .query_sync(
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
@@ -5559,6 +5562,7 @@ pub fn sqlite_primary_read_path_is_healthy(path: &Path) -> Result<bool, SqlError
             }
         }
     };
+    let conn = crate::guard_db_conn(conn, "sqlite primary read health probe");
 
     match sqlite_primary_check_is_ok_with_canonical_fallback(
         path,

--- a/crates/mcp-agent-mail-db/src/queries.rs
+++ b/crates/mcp-agent-mail-db/src/queries.rs
@@ -1493,7 +1493,10 @@ async fn commit_tx(cx: &Cx, tracked: &TrackedConnection<'_>) -> Outcome<(), DbEr
                 // to the pooled connection until a later close. The checkpoint
                 // gives post-commit probes and sibling processes the same view
                 // immediately after the write path returns.
-                if let Err(error) = tracked.inner.execute_raw("PRAGMA wal_checkpoint(PASSIVE)") {
+                if let Err(error) = tracked
+                    .inner
+                    .query_sync("PRAGMA wal_checkpoint(PASSIVE)", &[])
+                {
                     tracing::warn!(
                         db_path = %tracked.inner.path(),
                         error = %error,
@@ -13684,6 +13687,20 @@ mod tests {
                 })
                 .count()
         }
+
+        fn message_count(&self, message: &str) -> usize {
+            self.events
+                .lock()
+                .expect("event capture lock poisoned")
+                .iter()
+                .filter(|event| {
+                    event
+                        .fields
+                        .iter()
+                        .any(|(name, value)| name == "message" && value.contains(message))
+                })
+                .count()
+        }
     }
 
     #[derive(Clone, Debug)]
@@ -21134,65 +21151,70 @@ mod tests {
 
         let thread_count = 8usize;
         let messages_per_thread = 8usize;
+        let capture = EventCapture::default();
+        let dispatch = tracing::Dispatch::new(capture.clone());
         let start_barrier = std::sync::Arc::new(std::sync::Barrier::new(thread_count));
         let failures = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
 
         let handles: Vec<_> = (0..thread_count)
             .map(|thread_idx| {
                 let pool = pool.clone();
+                let dispatch = dispatch.clone();
                 let start_barrier = std::sync::Arc::clone(&start_barrier);
                 let failures = std::sync::Arc::clone(&failures);
                 std::thread::spawn(move || {
-                    let rt = RuntimeBuilder::current_thread()
-                        .build()
-                        .expect("build thread runtime");
-                    start_barrier.wait();
-                    for message_idx in 0..messages_per_thread {
-                        let cx = Cx::for_testing();
-                        let subject = format!("writer-{thread_idx}-message-{message_idx}");
-                        let body = format!("body-{thread_idx}-{message_idx}");
-                        match rt.block_on(async {
-                            create_message_with_recipients(
-                                &cx,
-                                &pool,
-                                project_id,
-                                sender_id,
-                                &subject,
-                                &body,
-                                Some("THREAD-CONCURRENT-DURABILITY"),
-                                "normal",
-                                false,
-                                "[]",
-                                &[(recipient_id, "to")],
-                            )
-                            .await
-                        }) {
-                            Outcome::Ok(row) => {
-                                assert!(row.id.is_some(), "created message must include id");
-                            }
-                            Outcome::Err(error) => {
-                                failures
-                                    .lock()
-                                    .expect("failures mutex")
-                                    .push(format!(
-                                        "thread {thread_idx} message {message_idx}: {error:?}"
-                                    ));
-                                break;
-                            }
-                            Outcome::Cancelled(reason) => {
-                                failures
-                                    .lock()
-                                    .expect("failures mutex")
-                                    .push(format!(
-                                        "thread {thread_idx} message {message_idx}: cancelled {reason:?}"
-                                    ));
-                                break;
-                            }
-                            Outcome::Panicked(payload) => {
-                                panic!("thread {thread_idx} message {message_idx} panicked: {payload}");
+                    tracing::dispatcher::with_default(&dispatch, || {
+                        let rt = RuntimeBuilder::current_thread()
+                            .build()
+                            .expect("build thread runtime");
+                        start_barrier.wait();
+                        for message_idx in 0..messages_per_thread {
+                            let cx = Cx::for_testing();
+                            let subject = format!("writer-{thread_idx}-message-{message_idx}");
+                            let body = format!("body-{thread_idx}-{message_idx}");
+                            match rt.block_on(async {
+                                create_message_with_recipients(
+                                    &cx,
+                                    &pool,
+                                    project_id,
+                                    sender_id,
+                                    &subject,
+                                    &body,
+                                    Some("THREAD-CONCURRENT-DURABILITY"),
+                                    "normal",
+                                    false,
+                                    "[]",
+                                    &[(recipient_id, "to")],
+                                )
+                                .await
+                            }) {
+                                Outcome::Ok(row) => {
+                                    assert!(row.id.is_some(), "created message must include id");
+                                }
+                                Outcome::Err(error) => {
+                                    failures
+                                        .lock()
+                                        .expect("failures mutex")
+                                        .push(format!(
+                                            "thread {thread_idx} message {message_idx}: {error:?}"
+                                        ));
+                                    break;
+                                }
+                                Outcome::Cancelled(reason) => {
+                                    failures
+                                        .lock()
+                                        .expect("failures mutex")
+                                        .push(format!(
+                                            "thread {thread_idx} message {message_idx}: cancelled {reason:?}"
+                                        ));
+                                    break;
+                                }
+                                Outcome::Panicked(payload) => {
+                                    panic!("thread {thread_idx} message {message_idx} panicked: {payload}");
+                                }
                             }
                         }
-                    }
+                    });
                 })
             })
             .collect();
@@ -21208,6 +21230,12 @@ mod tests {
             failures.join("\n")
         );
         drop(failures);
+
+        assert_eq!(
+            capture.message_count("post_commit_checkpoint_failed_after_successful_commit"),
+            0,
+            "concurrent writers should not emit post-commit checkpoint warnings"
+        );
 
         rt.block_on(async {
             let rows = durability_probe_query(

--- a/crates/mcp-agent-mail-db/src/queries.rs
+++ b/crates/mcp-agent-mail-db/src/queries.rs
@@ -7073,6 +7073,49 @@ struct InboxQueryOptions {
     body_policy: InboxBodyPolicy,
 }
 
+/// Read file-backed inbox rows through canonical SQLite.
+///
+/// FrankenSQLite remains the main backend, but its file-backed read path can
+/// stall behind its own lock bookkeeping even when canonical SQLite can serve
+/// the same snapshot immediately. This connection is query-only and short-lived
+/// so it cannot alter mailbox state or inherit a stale snapshot.
+#[allow(clippy::too_many_arguments)]
+fn fetch_inbox_file_backed_canonical(
+    pool: &DbPool,
+    project_id: i64,
+    agent_id: i64,
+    since_ts: Option<i64>,
+    limit: usize,
+    options: InboxQueryOptions,
+) -> std::result::Result<Vec<InboxRow>, DbError> {
+    let conn = crate::CanonicalDbConn::open_file(pool.sqlite_path())
+        .map_err(|error| DbError::Sqlite(format!("open canonical inbox reader: {error}")))?;
+    let result = (|| {
+        conn.execute_raw("PRAGMA busy_timeout = 250")
+            .map_err(|error| {
+                DbError::Sqlite(format!("configure canonical inbox reader: {error}"))
+            })?;
+        conn.execute_raw("PRAGMA query_only = ON")
+            .map_err(|error| {
+                DbError::Sqlite(format!("configure canonical inbox reader: {error}"))
+            })?;
+        crate::sync::fetch_inbox_rows_from_canonical_conn(
+            &conn,
+            project_id,
+            agent_id,
+            since_ts,
+            limit,
+            options.urgent_only,
+            options.unread_only,
+            options.ack_required_only,
+            options.ack_overdue_before,
+            matches!(options.body_policy, InboxBodyPolicy::Full),
+        )
+    })();
+    close_canonical_db_conn(conn, "file-backed canonical inbox reader");
+    result
+}
+
 #[allow(clippy::too_many_lines)]
 async fn fetch_inbox_impl(
     cx: &Cx,
@@ -7086,6 +7129,15 @@ async fn fetch_inbox_impl(
     let Ok(_limit_i64) = i64::try_from(limit) else {
         return Outcome::Err(DbError::invalid("limit", "limit exceeds i64::MAX"));
     };
+
+    if pool.sqlite_path() != ":memory:" {
+        return match fetch_inbox_file_backed_canonical(
+            pool, project_id, agent_id, since_ts, limit, options,
+        ) {
+            Ok(rows) => Outcome::Ok(rows),
+            Err(error) => Outcome::Err(error),
+        };
+    }
 
     let conn = match acquire_conn(cx, pool).await {
         Outcome::Ok(conn) => conn,

--- a/crates/mcp-agent-mail-db/src/queries.rs
+++ b/crates/mcp-agent-mail-db/src/queries.rs
@@ -7073,49 +7073,6 @@ struct InboxQueryOptions {
     body_policy: InboxBodyPolicy,
 }
 
-/// Read file-backed inbox rows through canonical SQLite.
-///
-/// FrankenSQLite remains the main backend, but its file-backed read path can
-/// stall behind its own lock bookkeeping even when canonical SQLite can serve
-/// the same snapshot immediately. This connection is query-only and short-lived
-/// so it cannot alter mailbox state or inherit a stale snapshot.
-#[allow(clippy::too_many_arguments)]
-fn fetch_inbox_file_backed_canonical(
-    pool: &DbPool,
-    project_id: i64,
-    agent_id: i64,
-    since_ts: Option<i64>,
-    limit: usize,
-    options: InboxQueryOptions,
-) -> std::result::Result<Vec<InboxRow>, DbError> {
-    let conn = crate::CanonicalDbConn::open_file(pool.sqlite_path())
-        .map_err(|error| DbError::Sqlite(format!("open canonical inbox reader: {error}")))?;
-    let result = (|| {
-        conn.execute_raw("PRAGMA busy_timeout = 250")
-            .map_err(|error| {
-                DbError::Sqlite(format!("configure canonical inbox reader: {error}"))
-            })?;
-        conn.execute_raw("PRAGMA query_only = ON")
-            .map_err(|error| {
-                DbError::Sqlite(format!("configure canonical inbox reader: {error}"))
-            })?;
-        crate::sync::fetch_inbox_rows_from_canonical_conn(
-            &conn,
-            project_id,
-            agent_id,
-            since_ts,
-            limit,
-            options.urgent_only,
-            options.unread_only,
-            options.ack_required_only,
-            options.ack_overdue_before,
-            matches!(options.body_policy, InboxBodyPolicy::Full),
-        )
-    })();
-    close_canonical_db_conn(conn, "file-backed canonical inbox reader");
-    result
-}
-
 #[allow(clippy::too_many_lines)]
 async fn fetch_inbox_impl(
     cx: &Cx,
@@ -7129,15 +7086,6 @@ async fn fetch_inbox_impl(
     let Ok(_limit_i64) = i64::try_from(limit) else {
         return Outcome::Err(DbError::invalid("limit", "limit exceeds i64::MAX"));
     };
-
-    if pool.sqlite_path() != ":memory:" {
-        return match fetch_inbox_file_backed_canonical(
-            pool, project_id, agent_id, since_ts, limit, options,
-        ) {
-            Ok(rows) => Outcome::Ok(rows),
-            Err(error) => Outcome::Err(error),
-        };
-    }
 
     let conn = match acquire_conn(cx, pool).await {
         Outcome::Ok(conn) => conn,

--- a/crates/mcp-agent-mail-db/src/queries.rs
+++ b/crates/mcp-agent-mail-db/src/queries.rs
@@ -1484,28 +1484,14 @@ async fn begin_concurrent_tx(cx: &Cx, tracked: &TrackedConnection<'_>) -> Outcom
     }
 }
 
-/// Commit the current transaction and publish file-backed writes to fresh handles.
+/// Commit the current transaction.
 async fn commit_tx(cx: &Cx, tracked: &TrackedConnection<'_>) -> Outcome<(), DbError> {
     match map_sql_outcome(tracked.execute(cx, "COMMIT", &[]).await) {
-        Outcome::Ok(_) => {
-            if tracked.inner.path() != ":memory:" {
-                // FrankenSQLite can otherwise keep a successful COMMIT private
-                // to the pooled connection until a later close. The checkpoint
-                // gives post-commit probes and sibling processes the same view
-                // immediately after the write path returns.
-                if let Err(error) = tracked
-                    .inner
-                    .query_sync("PRAGMA wal_checkpoint(PASSIVE)", &[])
-                {
-                    tracing::warn!(
-                        db_path = %tracked.inner.path(),
-                        error = %error,
-                        "post_commit_checkpoint_failed_after_successful_commit"
-                    );
-                }
-            }
-            Outcome::Ok(())
-        }
+        // Post-commit visibility is proven by the explicit fresh-handle
+        // durability probes at the write call sites. Checkpoints belong to the
+        // periodic maintenance worker: attempting one on every successful
+        // write adds lock contention without strengthening the commit itself.
+        Outcome::Ok(_) => Outcome::Ok(()),
         Outcome::Err(error) => Outcome::Err(error),
         Outcome::Cancelled(reason) => Outcome::Cancelled(reason),
         Outcome::Panicked(payload) => Outcome::Panicked(payload),
@@ -1600,6 +1586,7 @@ async fn durability_probe_query(
             Ok(conn) => conn,
             Err(e) => return Outcome::Err(DbError::Sqlite(e.to_string())),
         };
+        let probe_conn = crate::guard_db_conn(probe_conn, "durability_probe_query connection");
         if let Err(e) = probe_conn.execute_raw(crate::schema::PRAGMA_CONN_SETTINGS_SQL) {
             return Outcome::Err(DbError::Sqlite(format!(
                 "durability probe connection init failed: {e}"
@@ -1607,7 +1594,7 @@ async fn durability_probe_query(
         }
         let probe_tracked = tracked(&probe_conn);
         let out = map_sql_outcome(traw_query(cx, &probe_tracked, sql, params).await);
-        crate::close_db_conn(probe_conn, "durability_probe_query connection");
+        drop(probe_conn);
 
         match &out {
             Outcome::Err(e)

--- a/crates/mcp-agent-mail-db/src/snapshot.rs
+++ b/crates/mcp-agent-mail-db/src/snapshot.rs
@@ -155,6 +155,7 @@ pub fn record_snapshot_metadata(
     let bak = snapshot_bak_path(primary);
     let (row_counts, schema_version) =
         if let Ok(conn) = crate::DbConn::open_file(bak.display().to_string()) {
+            let conn = crate::guard_db_conn(conn, "snapshot metadata connection");
             (count_key_table_rows(&conn), read_schema_version(&conn))
         } else {
             (BTreeMap::new(), 0)

--- a/crates/mcp-agent-mail-db/src/sync.rs
+++ b/crates/mcp-agent-mail-db/src/sync.rs
@@ -3,13 +3,42 @@
 //! Exposes blocking DB queries used by UI loops and backgrounds threads
 //! that cannot easily integrate with the async `sqlmodel_pool`.
 
-use crate::DbConn;
 use crate::error::DbError;
 use crate::models::MessageRow;
 use crate::queries::{InboxRow, UNKNOWN_SENDER_DISPLAY};
-use sqlmodel_core::Value;
+use crate::{CanonicalDbConn, DbConn};
+use sqlmodel_core::{Row as SqlRow, Value};
 
 const MAX_SYNC_IN_CLAUSE_ITEMS: usize = 500;
+
+trait InboxReadConnection {
+    fn execute_inbox_raw(&self, sql: &str) -> Result<(), DbError>;
+    fn query_inbox_rows(&self, sql: &str, params: &[Value]) -> Result<Vec<SqlRow>, DbError>;
+}
+
+impl InboxReadConnection for DbConn {
+    fn execute_inbox_raw(&self, sql: &str) -> Result<(), DbError> {
+        self.execute_raw(sql)
+            .map_err(|error| DbError::Sqlite(error.to_string()))
+    }
+
+    fn query_inbox_rows(&self, sql: &str, params: &[Value]) -> Result<Vec<SqlRow>, DbError> {
+        self.query_sync(sql, params)
+            .map_err(|error| DbError::Sqlite(error.to_string()))
+    }
+}
+
+impl InboxReadConnection for CanonicalDbConn {
+    fn execute_inbox_raw(&self, sql: &str) -> Result<(), DbError> {
+        self.execute_raw(sql)
+            .map_err(|error| DbError::Sqlite(error.to_string()))
+    }
+
+    fn query_inbox_rows(&self, sql: &str, params: &[Value]) -> Result<Vec<SqlRow>, DbError> {
+        self.query_sync(sql, params)
+            .map_err(|error| DbError::Sqlite(error.to_string()))
+    }
+}
 
 /// Synchronously update the thread ID of a message.
 ///
@@ -160,6 +189,44 @@ pub fn fetch_inbox_ack_overdue_metadata_rows_from_conn(
     )
 }
 
+/// Fetch inbox rows from a canonical SQLite connection.
+///
+/// File-backed Agent Mail inbox reads use this path to avoid the FrankenSQLite
+/// read engine's file-lock tail latency. Callers configure the connection as
+/// query-only before invoking this helper.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn fetch_inbox_rows_from_canonical_conn(
+    conn: &CanonicalDbConn,
+    project_id: i64,
+    agent_id: i64,
+    since_ts: Option<i64>,
+    limit: usize,
+    urgent_only: bool,
+    unread_only: bool,
+    ack_required_only: bool,
+    ack_overdue_before: Option<i64>,
+    include_bodies: bool,
+) -> Result<Vec<InboxRow>, DbError> {
+    fetch_inbox_rows_from_conn_impl(
+        conn,
+        project_id,
+        agent_id,
+        since_ts,
+        limit,
+        InboxFetchOptions {
+            urgent_only,
+            unread_only,
+            ack_required_only,
+            ack_overdue_before,
+            body_policy: if include_bodies {
+                InboxBodyPolicy::Full
+            } else {
+                InboxBodyPolicy::MetadataOnly
+            },
+        },
+    )
+}
+
 #[derive(Clone, Copy)]
 enum InboxBodyPolicy {
     Full,
@@ -175,15 +242,15 @@ struct InboxFetchOptions {
     body_policy: InboxBodyPolicy,
 }
 
-fn fetch_inbox_rows_from_conn_impl(
-    conn: &DbConn,
+fn fetch_inbox_rows_from_conn_impl<C: InboxReadConnection>(
+    conn: &C,
     project_id: i64,
     agent_id: i64,
     since_ts: Option<i64>,
     limit: usize,
     options: InboxFetchOptions,
 ) -> Result<Vec<InboxRow>, DbError> {
-    let _ = conn.execute_raw("PRAGMA busy_timeout = 250");
+    let _ = conn.execute_inbox_raw("PRAGMA busy_timeout = 250");
     let body_select = match options.body_policy {
         InboxBodyPolicy::Full => "m.body_md",
         InboxBodyPolicy::MetadataOnly => "'' AS body_md",
@@ -223,9 +290,7 @@ fn fetch_inbox_rows_from_conn_impl(
     sql.push_str(" ORDER BY m.created_ts DESC LIMIT ?");
     params.push(Value::BigInt(limit_i64));
 
-    let rows = conn
-        .query_sync(&sql, &params)
-        .map_err(|e| DbError::Sqlite(e.to_string()))?;
+    let rows = conn.query_inbox_rows(&sql, &params)?;
 
     let mut out = Vec::with_capacity(rows.len());
     for row in rows {
@@ -974,6 +1039,68 @@ mod tests {
             metadata_rows[0].message.body_md.is_empty(),
             "metadata-only inbox reads should not materialize message bodies"
         );
+    }
+
+    #[test]
+    fn canonical_inbox_reader_returns_metadata_without_body() {
+        let dir = tempfile::tempdir().expect("create temporary directory");
+        let db_path = dir.path().join("inbox.sqlite3");
+        let conn =
+            DbConn::open_file(db_path.to_string_lossy().as_ref()).expect("open file-backed db");
+        conn.execute_raw(schema::PRAGMA_DB_INIT_SQL)
+            .expect("apply PRAGMAs");
+        block_on({
+            let conn = &conn;
+            move |cx| async move {
+                schema::migrate_to_latest_base(&cx, conn)
+                    .await
+                    .into_result()
+                    .expect("init schema migrations");
+            }
+        });
+
+        let pid = insert_project(&conn);
+        let sender_id = insert_agent(&conn, pid, "Sender");
+        let recipient_id = insert_agent(&conn, pid, "Recipient");
+        let msg_id = insert_message(&conn, pid, sender_id, "thread-1");
+        conn.execute_sync(
+            "UPDATE messages SET body_md = ? WHERE id = ?",
+            &[
+                Value::Text("canonical read should not hydrate this body".repeat(8)),
+                Value::BigInt(msg_id),
+            ],
+        )
+        .expect("update message body");
+        conn.execute_sync(
+            "INSERT INTO message_recipients (message_id, agent_id, kind) VALUES (?1, ?2, 'to')",
+            &[Value::BigInt(msg_id), Value::BigInt(recipient_id)],
+        )
+        .expect("insert recipient");
+        crate::close_db_conn(conn, "canonical inbox reader test setup");
+
+        let canonical = CanonicalDbConn::open_file(db_path.to_string_lossy().as_ref())
+            .expect("open canonical sqlite reader");
+        canonical
+            .execute_raw("PRAGMA query_only = ON")
+            .expect("make canonical reader query-only");
+        let rows = fetch_inbox_rows_from_canonical_conn(
+            &canonical,
+            pid,
+            recipient_id,
+            None,
+            10,
+            false,
+            false,
+            false,
+            None,
+            false,
+        )
+        .expect("fetch canonical inbox metadata");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].message.id, Some(msg_id));
+        assert_eq!(rows[0].message.subject, "test subject");
+        assert!(rows[0].message.body_md.is_empty());
     }
 
     // ── update_message_thread_id tests ───────────────────────────────

--- a/crates/mcp-agent-mail-db/src/sync.rs
+++ b/crates/mcp-agent-mail-db/src/sync.rs
@@ -3,42 +3,13 @@
 //! Exposes blocking DB queries used by UI loops and backgrounds threads
 //! that cannot easily integrate with the async `sqlmodel_pool`.
 
+use crate::DbConn;
 use crate::error::DbError;
 use crate::models::MessageRow;
 use crate::queries::{InboxRow, UNKNOWN_SENDER_DISPLAY};
-use crate::{CanonicalDbConn, DbConn};
-use sqlmodel_core::{Row as SqlRow, Value};
+use sqlmodel_core::Value;
 
 const MAX_SYNC_IN_CLAUSE_ITEMS: usize = 500;
-
-trait InboxReadConnection {
-    fn execute_inbox_raw(&self, sql: &str) -> Result<(), DbError>;
-    fn query_inbox_rows(&self, sql: &str, params: &[Value]) -> Result<Vec<SqlRow>, DbError>;
-}
-
-impl InboxReadConnection for DbConn {
-    fn execute_inbox_raw(&self, sql: &str) -> Result<(), DbError> {
-        self.execute_raw(sql)
-            .map_err(|error| DbError::Sqlite(error.to_string()))
-    }
-
-    fn query_inbox_rows(&self, sql: &str, params: &[Value]) -> Result<Vec<SqlRow>, DbError> {
-        self.query_sync(sql, params)
-            .map_err(|error| DbError::Sqlite(error.to_string()))
-    }
-}
-
-impl InboxReadConnection for CanonicalDbConn {
-    fn execute_inbox_raw(&self, sql: &str) -> Result<(), DbError> {
-        self.execute_raw(sql)
-            .map_err(|error| DbError::Sqlite(error.to_string()))
-    }
-
-    fn query_inbox_rows(&self, sql: &str, params: &[Value]) -> Result<Vec<SqlRow>, DbError> {
-        self.query_sync(sql, params)
-            .map_err(|error| DbError::Sqlite(error.to_string()))
-    }
-}
 
 /// Synchronously update the thread ID of a message.
 ///
@@ -189,44 +160,6 @@ pub fn fetch_inbox_ack_overdue_metadata_rows_from_conn(
     )
 }
 
-/// Fetch inbox rows from a canonical SQLite connection.
-///
-/// File-backed Agent Mail inbox reads use this path to avoid the FrankenSQLite
-/// read engine's file-lock tail latency. Callers configure the connection as
-/// query-only before invoking this helper.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn fetch_inbox_rows_from_canonical_conn(
-    conn: &CanonicalDbConn,
-    project_id: i64,
-    agent_id: i64,
-    since_ts: Option<i64>,
-    limit: usize,
-    urgent_only: bool,
-    unread_only: bool,
-    ack_required_only: bool,
-    ack_overdue_before: Option<i64>,
-    include_bodies: bool,
-) -> Result<Vec<InboxRow>, DbError> {
-    fetch_inbox_rows_from_conn_impl(
-        conn,
-        project_id,
-        agent_id,
-        since_ts,
-        limit,
-        InboxFetchOptions {
-            urgent_only,
-            unread_only,
-            ack_required_only,
-            ack_overdue_before,
-            body_policy: if include_bodies {
-                InboxBodyPolicy::Full
-            } else {
-                InboxBodyPolicy::MetadataOnly
-            },
-        },
-    )
-}
-
 #[derive(Clone, Copy)]
 enum InboxBodyPolicy {
     Full,
@@ -242,15 +175,15 @@ struct InboxFetchOptions {
     body_policy: InboxBodyPolicy,
 }
 
-fn fetch_inbox_rows_from_conn_impl<C: InboxReadConnection>(
-    conn: &C,
+fn fetch_inbox_rows_from_conn_impl(
+    conn: &DbConn,
     project_id: i64,
     agent_id: i64,
     since_ts: Option<i64>,
     limit: usize,
     options: InboxFetchOptions,
 ) -> Result<Vec<InboxRow>, DbError> {
-    let _ = conn.execute_inbox_raw("PRAGMA busy_timeout = 250");
+    let _ = conn.execute_raw("PRAGMA busy_timeout = 250");
     let body_select = match options.body_policy {
         InboxBodyPolicy::Full => "m.body_md",
         InboxBodyPolicy::MetadataOnly => "'' AS body_md",
@@ -290,7 +223,9 @@ fn fetch_inbox_rows_from_conn_impl<C: InboxReadConnection>(
     sql.push_str(" ORDER BY m.created_ts DESC LIMIT ?");
     params.push(Value::BigInt(limit_i64));
 
-    let rows = conn.query_inbox_rows(&sql, &params)?;
+    let rows = conn
+        .query_sync(&sql, &params)
+        .map_err(|e| DbError::Sqlite(e.to_string()))?;
 
     let mut out = Vec::with_capacity(rows.len());
     for row in rows {
@@ -1039,68 +974,6 @@ mod tests {
             metadata_rows[0].message.body_md.is_empty(),
             "metadata-only inbox reads should not materialize message bodies"
         );
-    }
-
-    #[test]
-    fn canonical_inbox_reader_returns_metadata_without_body() {
-        let dir = tempfile::tempdir().expect("create temporary directory");
-        let db_path = dir.path().join("inbox.sqlite3");
-        let conn =
-            DbConn::open_file(db_path.to_string_lossy().as_ref()).expect("open file-backed db");
-        conn.execute_raw(schema::PRAGMA_DB_INIT_SQL)
-            .expect("apply PRAGMAs");
-        block_on({
-            let conn = &conn;
-            move |cx| async move {
-                schema::migrate_to_latest_base(&cx, conn)
-                    .await
-                    .into_result()
-                    .expect("init schema migrations");
-            }
-        });
-
-        let pid = insert_project(&conn);
-        let sender_id = insert_agent(&conn, pid, "Sender");
-        let recipient_id = insert_agent(&conn, pid, "Recipient");
-        let msg_id = insert_message(&conn, pid, sender_id, "thread-1");
-        conn.execute_sync(
-            "UPDATE messages SET body_md = ? WHERE id = ?",
-            &[
-                Value::Text("canonical read should not hydrate this body".repeat(8)),
-                Value::BigInt(msg_id),
-            ],
-        )
-        .expect("update message body");
-        conn.execute_sync(
-            "INSERT INTO message_recipients (message_id, agent_id, kind) VALUES (?1, ?2, 'to')",
-            &[Value::BigInt(msg_id), Value::BigInt(recipient_id)],
-        )
-        .expect("insert recipient");
-        crate::close_db_conn(conn, "canonical inbox reader test setup");
-
-        let canonical = CanonicalDbConn::open_file(db_path.to_string_lossy().as_ref())
-            .expect("open canonical sqlite reader");
-        canonical
-            .execute_raw("PRAGMA query_only = ON")
-            .expect("make canonical reader query-only");
-        let rows = fetch_inbox_rows_from_canonical_conn(
-            &canonical,
-            pid,
-            recipient_id,
-            None,
-            10,
-            false,
-            false,
-            false,
-            None,
-            false,
-        )
-        .expect("fetch canonical inbox metadata");
-
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].message.id, Some(msg_id));
-        assert_eq!(rows[0].message.subject, "test subject");
-        assert!(rows[0].message.body_md.is_empty());
     }
 
     // ── update_message_thread_id tests ───────────────────────────────

--- a/crates/mcp-agent-mail-server/src/cleanup.rs
+++ b/crates/mcp-agent-mail-server/src/cleanup.rs
@@ -824,7 +824,10 @@ fn git_head_oid_for_workspace(workspace: &Path) -> Option<String> {
         return None;
     }
     // br-8ujfs.4.1 (D1): route through GitCmd.
+    // These probes only inspect history. Keep the in-process mutex, but do not
+    // create a flock sentinel in a workspace that may belong to another user.
     let output = mcp_agent_mail_core::git_cmd::GitCmd::new(workspace)
+        .skip_flock()
         .args(["rev-parse", "HEAD"])
         .run()
         .ok()?;
@@ -856,7 +859,10 @@ fn git_latest_commit_us(workspace: &Path, path_pattern: &str) -> Option<i64> {
     };
 
     // br-8ujfs.4.1 (D1): route through GitCmd.
+    // This is a read-only history lookup on an arbitrary project workspace.
+    // Avoid requiring write access to that workspace's Git metadata.
     let output = mcp_agent_mail_core::git_cmd::GitCmd::new(workspace)
+        .skip_flock()
         .args(["log", "-1", "--format=%ct", "--"])
         .arg(&pathspec)
         .run()

--- a/crates/mcp-agent-mail-server/src/lib.rs
+++ b/crates/mcp-agent-mail-server/src/lib.rs
@@ -2364,12 +2364,12 @@ fn open_sync_db_connection_with_busy_timeout(
         DbConn::open_file(&path)
     }
     .map_err(|err| std::io::Error::other(format!("open sqlite file {path}: {err}")))?;
-    conn.execute_raw(&format!("PRAGMA busy_timeout = {busy_timeout_ms};"))
-        .map_err(|err| {
-            std::io::Error::other(format!(
-                "configure sqlite busy_timeout={busy_timeout_ms} on {path}: {err}"
-            ))
-        })?;
+    if let Err(err) = conn.execute_raw(&format!("PRAGMA busy_timeout = {busy_timeout_ms};")) {
+        mcp_agent_mail_db::close_db_conn(conn, "sync database connection setup");
+        return Err(std::io::Error::other(format!(
+            "configure sqlite busy_timeout={busy_timeout_ms} on {path}: {err}"
+        )));
+    }
     Ok(conn)
 }
 
@@ -2384,11 +2384,12 @@ pub(crate) fn open_interactive_sync_db_connection(path: &str) -> std::io::Result
 
 pub(crate) fn open_health_probe_sync_db_connection(path: &str) -> std::io::Result<DbConn> {
     let conn = open_sync_db_connection_with_busy_timeout(path, HEALTH_SYNC_DB_BUSY_TIMEOUT_MS)?;
-    conn.execute_raw("PRAGMA query_only = ON;").map_err(|err| {
-        std::io::Error::other(format!(
+    if let Err(err) = conn.execute_raw("PRAGMA query_only = ON;") {
+        mcp_agent_mail_db::close_db_conn(conn, "health probe setup");
+        return Err(std::io::Error::other(format!(
             "configure sqlite query_only health probe on {path}: {err}"
-        ))
-    })?;
+        )));
+    }
     Ok(conn)
 }
 
@@ -14722,21 +14723,24 @@ fn readiness_check_quick(config: &mcp_agent_mail_core::Config) -> Result<(), Str
         None
     };
 
-    let conn = if is_memory {
-        DbConn::open_memory().map_err(|e| e.to_string())?
-    } else {
-        let sqlite_path = sqlite_path
-            .as_ref()
-            .ok_or_else(|| "cannot resolve sqlite path for readiness check".to_string())?;
-        if !sqlite_path.exists() {
-            return Err(format!(
-                "SQLite database is missing at {}; quick readiness refuses to initialize the mailbox",
-                sqlite_path.display()
-            ));
-        }
-        open_health_probe_sync_db_connection(sqlite_path.to_string_lossy().as_ref())
-            .map_err(|e| e.to_string())?
-    };
+    let conn = mcp_agent_mail_db::guard_db_conn(
+        if is_memory {
+            DbConn::open_memory().map_err(|e| e.to_string())?
+        } else {
+            let sqlite_path = sqlite_path
+                .as_ref()
+                .ok_or_else(|| "cannot resolve sqlite path for readiness check".to_string())?;
+            if !sqlite_path.exists() {
+                return Err(format!(
+                    "SQLite database is missing at {}; quick readiness refuses to initialize the mailbox",
+                    sqlite_path.display()
+                ));
+            }
+            open_health_probe_sync_db_connection(sqlite_path.to_string_lossy().as_ref())
+                .map_err(|e| e.to_string())?
+        },
+        "quick readiness check connection",
+    );
 
     if let Err(e) = conn.query_sync("SELECT 1", &[]) {
         let error = e.to_string();
@@ -14769,21 +14773,24 @@ fn readiness_check_request_path(config: &mcp_agent_mail_core::Config) -> Result<
         None
     };
 
-    let conn = if is_memory {
-        DbConn::open_memory().map_err(|e| e.to_string())?
-    } else {
-        let sqlite_path = sqlite_path
-            .as_ref()
-            .ok_or_else(|| "cannot resolve sqlite path for readiness check".to_string())?;
-        if !sqlite_path.exists() {
-            return Err(format!(
-                "SQLite database is missing at {}; readiness refuses to initialize the mailbox",
-                sqlite_path.display()
-            ));
-        }
-        open_health_probe_sync_db_connection(sqlite_path.to_string_lossy().as_ref())
-            .map_err(|e| e.to_string())?
-    };
+    let conn = mcp_agent_mail_db::guard_db_conn(
+        if is_memory {
+            DbConn::open_memory().map_err(|e| e.to_string())?
+        } else {
+            let sqlite_path = sqlite_path
+                .as_ref()
+                .ok_or_else(|| "cannot resolve sqlite path for readiness check".to_string())?;
+            if !sqlite_path.exists() {
+                return Err(format!(
+                    "SQLite database is missing at {}; readiness refuses to initialize the mailbox",
+                    sqlite_path.display()
+                ));
+            }
+            open_health_probe_sync_db_connection(sqlite_path.to_string_lossy().as_ref())
+                .map_err(|e| e.to_string())?
+        },
+        "readiness request connection",
+    );
 
     if let Err(e) = conn.query_sync("SELECT 1", &[]) {
         let error = e.to_string();

--- a/crates/mcp-agent-mail-server/src/lib.rs
+++ b/crates/mcp-agent-mail-server/src/lib.rs
@@ -15172,18 +15172,21 @@ fn readiness_check_with_integrity(
         }
     };
 
-    if let Err(e) = conn.query_sync("SELECT 1", &[]) {
-        let error = e.to_string();
-        if run_integrity_check && mcp_agent_mail_db::is_corruption_error_message(&error) {
-            return Err(format!(
-                "SQLite corruption detected during readiness check; automatic server-side recovery is disabled: {error}"
-            ));
+    let readiness_probe_result = (|| -> Result<_, String> {
+        if let Err(e) = conn.query_sync("SELECT 1", &[]) {
+            let error = e.to_string();
+            if run_integrity_check && mcp_agent_mail_db::is_corruption_error_message(&error) {
+                return Err(format!(
+                    "SQLite corruption detected during readiness check; automatic server-side recovery is disabled: {error}"
+                ));
+            }
+            return Err(error);
         }
-        return Err(error);
-    }
 
-    let startup_integrity_fingerprint = sqlite_startup_fingerprint(&conn, &config.database_url);
-    drop(conn);
+        Ok(sqlite_startup_fingerprint(&conn, &config.database_url))
+    })();
+    mcp_agent_mail_db::close_db_conn(conn.detach(), "startup readiness connection");
+    let startup_integrity_fingerprint = readiness_probe_result?;
 
     let skip_startup_integrity =
         startup_integrity_fingerprint

--- a/crates/mcp-agent-mail-tools/src/identity.rs
+++ b/crates/mcp-agent-mail-tools/src/identity.rs
@@ -722,7 +722,7 @@ fn health_check_semantic_readiness(config: &Config) -> SemanticReadinessResponse
         );
     }
 
-    let archive = mcp_agent_mail_db::scan_archive_message_inventory(&config.storage_root);
+    let archive = crate::tool_util::read_archive_inventory(&config.storage_root);
     if archive.projects == 0 && archive.agents == 0 && archive.unique_message_ids == 0 {
         return semantic_readiness_response(
             "ok",

--- a/crates/mcp-agent-mail-tools/src/lib.rs
+++ b/crates/mcp-agent-mail-tools/src/lib.rs
@@ -1665,7 +1665,7 @@ pub mod tool_util {
             std::fs::write(
                 message_dir.join(format!("message-{id}.md")),
                 format!(
-                    "---json\\n{{\"id\":{id},\"from\":\"Alice\",\"to\":[],\"subject\":\"cached\"}}\\n---\\nbody\\n"
+                    "---json\n{{\"id\":{id},\"from\":\"Alice\",\"to\":[],\"subject\":\"cached\"}}\n---\nbody\n"
                 ),
             )
             .expect("write message");

--- a/crates/mcp-agent-mail-tools/src/lib.rs
+++ b/crates/mcp-agent-mail-tools/src/lib.rs
@@ -64,6 +64,7 @@ pub mod tool_util {
     use serde_json::{Map, Value, json};
     use std::collections::BTreeSet;
     use std::path::{Path, PathBuf};
+    use std::sync::{LazyLock, Mutex};
 
     pub(crate) const MALFORMED_ATTACHMENTS_SENTINEL: &str = "[malformed-attachments-json]";
     pub(crate) const MALFORMED_RECIPIENTS_SENTINEL: &str = "[malformed-recipients-json]";
@@ -707,6 +708,59 @@ pub mod tool_util {
         project_identities: BTreeSet<mcp_agent_mail_db::MailboxProjectIdentity>,
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ReadArchiveInventoryCacheEntry {
+        storage_root: PathBuf,
+        head: git2::Oid,
+        inventory: mcp_agent_mail_db::ArchiveMessageInventory,
+    }
+
+    // Archive inventory scans parse every canonical message artifact. Reuse the
+    // result while the archive commit is unchanged; a new commit invalidates it.
+    static READ_ARCHIVE_INVENTORY_CACHE: LazyLock<Mutex<Option<ReadArchiveInventoryCacheEntry>>> =
+        LazyLock::new(|| Mutex::new(None));
+
+    fn read_archive_head(storage_root: &Path) -> Option<git2::Oid> {
+        git2::Repository::open(storage_root)
+            .ok()?
+            .head()
+            .ok()?
+            .target()
+    }
+
+    pub(crate) fn read_archive_inventory(
+        storage_root: &Path,
+    ) -> mcp_agent_mail_db::ArchiveMessageInventory {
+        let Some(head) = read_archive_head(storage_root) else {
+            return mcp_agent_mail_db::scan_archive_message_inventory(storage_root);
+        };
+
+        let mut cache = READ_ARCHIVE_INVENTORY_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(entry) = cache.as_ref()
+            && entry.storage_root == storage_root
+            && entry.head == head
+        {
+            return entry.inventory.clone();
+        }
+
+        let inventory = mcp_agent_mail_db::scan_archive_message_inventory(storage_root);
+        *cache = Some(ReadArchiveInventoryCacheEntry {
+            storage_root: storage_root.to_path_buf(),
+            head,
+            inventory: inventory.clone(),
+        });
+        inventory
+    }
+
+    #[cfg(test)]
+    fn reset_read_archive_inventory_cache() {
+        *READ_ARCHIVE_INVENTORY_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+
     fn query_read_db_inventory(
         conn: &mcp_agent_mail_db::DbConn,
     ) -> Result<ReadReconcileInventory, String> {
@@ -779,7 +833,7 @@ pub mod tool_util {
     }
 
     fn read_archive_inventory_has_state(storage_root: &Path) -> bool {
-        let archive = mcp_agent_mail_db::scan_archive_message_inventory(storage_root);
+        let archive = read_archive_inventory(storage_root);
         archive.projects > 0 || archive.agents > 0 || archive.unique_message_ids > 0
     }
 
@@ -800,7 +854,7 @@ pub mod tool_util {
             return Ok(false);
         }
 
-        let archive = mcp_agent_mail_db::scan_archive_message_inventory(storage_root);
+        let archive = read_archive_inventory(storage_root);
         if archive.projects == 0 && archive.agents == 0 && archive.unique_message_ids == 0 {
             return Ok(false);
         }
@@ -1597,6 +1651,73 @@ pub mod tool_util {
                     );
                 },
             );
+        }
+
+        fn write_inventory_message(storage_root: &Path, id: i64) {
+            let project_dir = storage_root.join("projects").join("cache-project");
+            let message_dir = project_dir.join("messages").join("2026").join("07");
+            std::fs::create_dir_all(&message_dir).expect("create message directory");
+            std::fs::write(
+                project_dir.join("project.json"),
+                r#"{"slug":"cache-project","human_key":"/cache-project"}"#,
+            )
+            .expect("write project metadata");
+            std::fs::write(
+                message_dir.join(format!("message-{id}.md")),
+                format!(
+                    "---json\\n{{\"id\":{id},\"from\":\"Alice\",\"to\":[],\"subject\":\"cached\"}}\\n---\\nbody\\n"
+                ),
+            )
+            .expect("write message");
+        }
+
+        fn commit_archive_tree(repo: &git2::Repository, message: &str) {
+            let mut index = repo.index().expect("open git index");
+            index
+                .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+                .expect("stage archive tree");
+            index.write().expect("write git index");
+            let tree_id = index.write_tree().expect("write git tree");
+            let tree = repo.find_tree(tree_id).expect("load git tree");
+            let signature =
+                git2::Signature::now("test", "test@example.com").expect("build git signature");
+            let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+            let parents = parent.iter().collect::<Vec<_>>();
+            repo.commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                message,
+                &tree,
+                &parents,
+            )
+            .expect("commit archive tree");
+        }
+
+        #[test]
+        fn read_archive_inventory_cache_refreshes_when_head_changes() {
+            let _guard = READ_POOL_TEST_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_archive_inventory_cache();
+
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            let repo = git2::Repository::init(&storage_root).expect("init archive repo");
+
+            write_inventory_message(&storage_root, 1);
+            commit_archive_tree(&repo, "add first message");
+            assert_eq!(read_archive_inventory(&storage_root).unique_message_ids, 1);
+            let first_head = read_archive_head(&storage_root).expect("first archive head");
+
+            write_inventory_message(&storage_root, 2);
+            commit_archive_tree(&repo, "add second message");
+            let second_head = read_archive_head(&storage_root).expect("second archive head");
+            assert_ne!(first_head, second_head);
+            assert_eq!(read_archive_inventory(&storage_root).unique_message_ids, 2);
+
+            reset_read_archive_inventory_cache();
         }
 
         #[test]

--- a/crates/mcp-agent-mail-tools/src/lib.rs
+++ b/crates/mcp-agent-mail-tools/src/lib.rs
@@ -65,6 +65,7 @@ pub mod tool_util {
     use std::collections::BTreeSet;
     use std::path::{Path, PathBuf};
     use std::sync::{LazyLock, Mutex};
+    use std::time::{Duration, Instant};
 
     pub(crate) const MALFORMED_ATTACHMENTS_SENTINEL: &str = "[malformed-attachments-json]";
     pub(crate) const MALFORMED_RECIPIENTS_SENTINEL: &str = "[malformed-recipients-json]";
@@ -720,12 +721,49 @@ pub mod tool_util {
     static READ_ARCHIVE_INVENTORY_CACHE: LazyLock<Mutex<Option<ReadArchiveInventoryCacheEntry>>> =
         LazyLock::new(|| Mutex::new(None));
 
+    /// Avoid re-running the complete durability verdict for every polling read.
+    /// A new archive commit invalidates this cache; the TTL only bounds
+    /// detection of a live SQLite failure that has no archive write in between.
+    const READ_SOURCE_DECISION_CACHE_TTL: Duration = Duration::from_secs(30);
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ReadSourceDecisionCacheKey {
+        database_url: String,
+        storage_root: PathBuf,
+        sqlite_path: PathBuf,
+        archive_head: Option<git2::Oid>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct ReadSourceDecisionCacheEntry {
+        key: ReadSourceDecisionCacheKey,
+        checked_at: Instant,
+        use_archive_snapshot: bool,
+    }
+
+    static READ_SOURCE_DECISION_CACHE: LazyLock<Mutex<Option<ReadSourceDecisionCacheEntry>>> =
+        LazyLock::new(|| Mutex::new(None));
+
     fn read_archive_head(storage_root: &Path) -> Option<git2::Oid> {
         git2::Repository::open(storage_root)
             .ok()?
             .head()
             .ok()?
             .target()
+    }
+
+    fn cached_read_source_decision(
+        entry: Option<&ReadSourceDecisionCacheEntry>,
+        key: &ReadSourceDecisionCacheKey,
+        now: Instant,
+    ) -> Option<bool> {
+        entry.and_then(|entry| {
+            (entry.key == *key
+                && now
+                    .checked_duration_since(entry.checked_at)
+                    .is_some_and(|elapsed| elapsed < READ_SOURCE_DECISION_CACHE_TTL))
+            .then_some(entry.use_archive_snapshot)
+        })
     }
 
     pub(crate) fn read_archive_inventory(
@@ -757,6 +795,13 @@ pub mod tool_util {
     #[cfg(test)]
     fn reset_read_archive_inventory_cache() {
         *READ_ARCHIVE_INVENTORY_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+
+    #[cfg(test)]
+    fn reset_read_source_decision_cache() {
+        *READ_SOURCE_DECISION_CACHE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
     }
@@ -832,7 +877,7 @@ pub mod tool_util {
         })
     }
 
-    fn read_archive_inventory_has_state(storage_root: &Path) -> bool {
+    pub(crate) fn read_archive_inventory_has_state(storage_root: &Path) -> bool {
         let archive = read_archive_inventory(storage_root);
         archive.projects > 0 || archive.agents > 0 || archive.unique_message_ids > 0
     }
@@ -845,7 +890,7 @@ pub mod tool_util {
             || sqlite_path.starts_with(storage_root)
     }
 
-    fn read_archive_is_ahead(
+    pub(crate) fn read_archive_is_ahead(
         storage_root: &Path,
         sqlite_path: &Path,
         conn: &mcp_agent_mail_db::DbConn,
@@ -911,7 +956,11 @@ pub mod tool_util {
     /// worse) according to a fast mailbox verdict. Returns `true` when read
     /// surfaces should fall back to archive snapshots instead of the
     /// potentially corrupt live file.
-    fn live_db_is_suspect(database_url: &str, storage_root: &Path, sqlite_path: &Path) -> bool {
+    pub(crate) fn live_db_is_suspect(
+        database_url: &str,
+        storage_root: &Path,
+        sqlite_path: &Path,
+    ) -> bool {
         if !archive_storage_root_is_authoritative_for_sqlite_path(storage_root, sqlite_path) {
             return false;
         }
@@ -949,6 +998,78 @@ pub mod tool_util {
         }
     }
 
+    pub(crate) fn should_use_archive_snapshot_for_read(
+        config: &Config,
+        resolved_path: &Path,
+        probe_context: &'static str,
+    ) -> bool {
+        let key = ReadSourceDecisionCacheKey {
+            database_url: config.database_url.clone(),
+            storage_root: config.storage_root.clone(),
+            sqlite_path: resolved_path.to_path_buf(),
+            archive_head: read_archive_head(&config.storage_root),
+        };
+        let now = Instant::now();
+        let mut cache = READ_SOURCE_DECISION_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(use_archive_snapshot) = cached_read_source_decision(cache.as_ref(), &key, now) {
+            return use_archive_snapshot;
+        }
+
+        let archive_has_state = archive_storage_root_is_authoritative_for_sqlite_path(
+            &config.storage_root,
+            resolved_path,
+        ) && read_archive_inventory_has_state(&config.storage_root);
+
+        let use_archive_snapshot = if !archive_has_state {
+            false
+        } else if !resolved_path.exists() {
+            true
+        } else if live_db_is_suspect(&config.database_url, &config.storage_root, resolved_path) {
+            true
+        } else {
+            match mcp_agent_mail_db::DbConn::open_file(resolved_path.to_string_lossy().as_ref()) {
+                Ok(conn) => {
+                    let conn = mcp_agent_mail_db::guard_db_conn(conn, probe_context);
+                    let archive_ahead =
+                        read_archive_is_ahead(&config.storage_root, resolved_path, &conn);
+                    drop(conn);
+                    match archive_ahead {
+                        Ok(true) => true,
+                        Err(error) if archive_has_state => {
+                            tracing::warn!(
+                                source = %resolved_path.display(),
+                                storage_root = %config.storage_root.display(),
+                                error = %error,
+                                "using archive-backed read snapshot because the live sqlite inventory probe failed"
+                            );
+                            true
+                        }
+                        Ok(false) | Err(_) => false,
+                    }
+                }
+                Err(error) if archive_has_state => {
+                    tracing::warn!(
+                        source = %resolved_path.display(),
+                        storage_root = %config.storage_root.display(),
+                        error = %error,
+                        "using archive-backed read snapshot because the live sqlite source could not be opened"
+                    );
+                    true
+                }
+                Err(_) => false,
+            }
+        };
+
+        *cache = Some(ReadSourceDecisionCacheEntry {
+            key,
+            checked_at: now,
+            use_archive_snapshot,
+        });
+        use_archive_snapshot
+    }
+
     fn open_read_db_pool() -> Result<Option<ToolReadPool>, String> {
         let config = Config::from_env();
         if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&config.database_url) {
@@ -964,55 +1085,11 @@ pub mod tool_util {
         }
 
         let resolved_path = PathBuf::from(&sqlite_path);
-        let archive_has_state = archive_storage_root_is_authoritative_for_sqlite_path(
-            &config.storage_root,
+        let use_archive_snapshot = should_use_archive_snapshot_for_read(
+            &config,
             &resolved_path,
-        ) && read_archive_inventory_has_state(&config.storage_root);
-
-        // When the durability verdict says the live DB is suspect or worse,
-        // force archive-snapshot reads even if the archive isn't strictly
-        // "ahead" of the DB by row count.
-        let durability_forces_snapshot = archive_has_state
-            && live_db_is_suspect(&config.database_url, &config.storage_root, &resolved_path);
-
-        let use_archive_snapshot = if durability_forces_snapshot {
-            true
-        } else {
-            match mcp_agent_mail_db::DbConn::open_file(&sqlite_path) {
-                Ok(conn) => {
-                    let conn = mcp_agent_mail_db::guard_db_conn(
-                        conn,
-                        "tool_util::open_read_db_pool archive-ahead probe",
-                    );
-                    let archive_ahead =
-                        read_archive_is_ahead(&config.storage_root, &resolved_path, &conn);
-                    drop(conn);
-                    match archive_ahead {
-                        Ok(true) => true,
-                        Err(error) if archive_has_state => {
-                            tracing::warn!(
-                                source = %resolved_path.display(),
-                                storage_root = %config.storage_root.display(),
-                                error = %error,
-                                "using archive-backed tool snapshot because the live sqlite inventory probe failed"
-                            );
-                            true
-                        }
-                        Ok(false) | Err(_) => false,
-                    }
-                }
-                Err(error) if archive_has_state => {
-                    tracing::warn!(
-                        source = %resolved_path.display(),
-                        storage_root = %config.storage_root.display(),
-                        error = %error,
-                        "using archive-backed tool snapshot because the live sqlite source could not be opened"
-                    );
-                    true
-                }
-                Err(_) => false,
-            }
-        };
+            "tool_util::open_read_db_pool archive-ahead probe",
+        );
 
         if !use_archive_snapshot {
             return Ok(None);
@@ -1718,6 +1795,55 @@ pub mod tool_util {
             assert_eq!(read_archive_inventory(&storage_root).unique_message_ids, 2);
 
             reset_read_archive_inventory_cache();
+        }
+
+        #[test]
+        fn read_source_decision_cache_requires_matching_head_and_freshness() {
+            let _guard = READ_POOL_TEST_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_source_decision_cache();
+
+            let now = Instant::now();
+            let key = ReadSourceDecisionCacheKey {
+                database_url: "sqlite:///tmp/read-cache.sqlite3".to_string(),
+                storage_root: PathBuf::from("/tmp/read-cache-storage"),
+                sqlite_path: PathBuf::from("/tmp/read-cache.sqlite3"),
+                archive_head: None,
+            };
+            let entry = ReadSourceDecisionCacheEntry {
+                key: key.clone(),
+                checked_at: now,
+                use_archive_snapshot: false,
+            };
+
+            assert_eq!(
+                cached_read_source_decision(Some(&entry), &key, now),
+                Some(false)
+            );
+
+            let changed_head = ReadSourceDecisionCacheKey {
+                archive_head: Some(
+                    git2::Oid::from_str("0123456789012345678901234567890123456789")
+                        .expect("parse archive head"),
+                ),
+                ..key.clone()
+            };
+            assert_eq!(
+                cached_read_source_decision(Some(&entry), &changed_head, now),
+                None
+            );
+
+            let stale = ReadSourceDecisionCacheEntry {
+                checked_at: now
+                    .checked_sub(READ_SOURCE_DECISION_CACHE_TTL + Duration::from_secs(1))
+                    .expect("monotonic clock must be older than the decision cache TTL"),
+                ..entry
+            };
+            assert_eq!(cached_read_source_decision(Some(&stale), &key, now), None);
+
+            reset_read_source_decision_cache();
         }
 
         #[test]

--- a/crates/mcp-agent-mail-tools/src/messaging.rs
+++ b/crates/mcp-agent-mail-tools/src/messaging.rs
@@ -3343,8 +3343,8 @@ pub async fn fetch_inbox(
     // The write-back MUST target the live DB, not the archive snapshot,
     // because snapshot pools are read-only reconstructions. If the live DB
     // is degraded the write will fail gracefully (already best-effort).
-    if !messages.is_empty() {
-        let ids: Vec<i64> = messages.iter().map(|m| m.id).collect();
+    let unread_message_ids = unread_message_ids(&messages);
+    if !unread_message_ids.is_empty() {
         let write_path = get_db_pool()
             .ok()
             .map(|live_pool| live_pool.sqlite_path().to_string());
@@ -3352,7 +3352,7 @@ pub async fn fetch_inbox(
             match mcp_agent_mail_db::sync::mark_messages_read_batch_sync(
                 live_sqlite_path,
                 agent_id,
-                &ids,
+                &unread_message_ids,
             ) {
                 Ok(Some(batch)) => {
                     apply_auto_read_timestamp(&mut messages, &batch.message_ids, batch.read_ts);
@@ -3366,7 +3366,7 @@ pub async fn fetch_inbox(
                 Err(e) => {
                     tracing::warn!(
                         agent_id = agent_id,
-                        count = ids.len(),
+                        count = unread_message_ids.len(),
                         error = %e,
                         "batch auto-mark-read on fetch_inbox failed"
                     );
@@ -3375,7 +3375,7 @@ pub async fn fetch_inbox(
         } else {
             tracing::warn!(
                 agent_id = agent_id,
-                count = ids.len(),
+                count = unread_message_ids.len(),
                 "skipping auto-mark-read because the live DB pool is unavailable (degraded mode)"
             );
         }
@@ -3404,6 +3404,14 @@ pub async fn fetch_inbox(
     phase.mark("json_serialization");
     emit_tail_latency_evidence(&phase.finish("ok"));
     Ok(response)
+}
+
+fn unread_message_ids(messages: &[InboxMessage]) -> Vec<i64> {
+    messages
+        .iter()
+        .filter(|message| message.read_ts.is_none())
+        .map(|message| message.id)
+        .collect()
 }
 
 fn apply_auto_read_timestamp(
@@ -5248,6 +5256,12 @@ mod tests {
                 body_md: None,
             },
         ];
+
+        assert_eq!(
+            unread_message_ids(&messages),
+            vec![1, 3],
+            "auto-read writes must target only messages that are still unread"
+        );
 
         let batch_read_ts = 1_770_354_000_000_000;
         apply_auto_read_timestamp(&mut messages, &[1, 2], batch_read_ts);

--- a/crates/mcp-agent-mail-tools/src/resources.rs
+++ b/crates/mcp-agent-mail-tools/src/resources.rs
@@ -99,137 +99,6 @@ fn is_missing_projects_table_error(message: &str) -> bool {
     lower.contains("no such table") && lower.contains("projects")
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-struct ResourceReconcileInventory {
-    projects: usize,
-    agents: usize,
-    messages: usize,
-    max_message_id: i64,
-    project_identities: std::collections::BTreeSet<mcp_agent_mail_db::MailboxProjectIdentity>,
-}
-
-fn query_resource_db_inventory(
-    conn: &mcp_agent_mail_db::DbConn,
-) -> Result<ResourceReconcileInventory, String> {
-    let present = conn
-        .query_sync(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
-            &[],
-        )
-        .map_err(|err| err.to_string())?
-        .into_iter()
-        .filter_map(|row| row.get_named::<String>("name").ok())
-        .collect::<std::collections::BTreeSet<_>>();
-
-    let query_count = |sql: &str, alias: &str| -> Result<usize, String> {
-        let rows = conn.query_sync(sql, &[]).map_err(|err| err.to_string())?;
-        let Some(row) = rows.first() else {
-            return Err(format!(
-                "no rows returned from resource inventory query for {alias}"
-            ));
-        };
-        Ok(row
-            .get_named::<i64>(alias)
-            .ok()
-            .and_then(|count| usize::try_from(count).ok())
-            .unwrap_or(0))
-    };
-
-    let projects = if present.contains("projects") {
-        query_count(
-            "SELECT COUNT(*) AS project_count FROM projects",
-            "project_count",
-        )?
-    } else {
-        0
-    };
-    let agents = if present.contains("agents") {
-        query_count("SELECT COUNT(*) AS agent_count FROM agents", "agent_count")?
-    } else {
-        0
-    };
-    let (messages, max_message_id) = if present.contains("messages") {
-        let rows = conn
-            .query_sync(
-                "SELECT COUNT(*) AS message_count, COALESCE(MAX(id), 0) AS max_id FROM messages",
-                &[],
-            )
-            .map_err(|err| err.to_string())?;
-        let Some(row) = rows.first() else {
-            return Err("no rows returned from resource message inventory query".to_string());
-        };
-        (
-            row.get_named::<i64>("message_count")
-                .ok()
-                .and_then(|count| usize::try_from(count).ok())
-                .unwrap_or(0),
-            row.get_named::<i64>("max_id").unwrap_or(0),
-        )
-    } else {
-        (0, 0)
-    };
-    let project_identities = if present.contains("projects") {
-        mcp_agent_mail_db::collect_db_project_identities(conn).map_err(|err| err.to_string())?
-    } else {
-        std::collections::BTreeSet::new()
-    };
-
-    Ok(ResourceReconcileInventory {
-        projects,
-        agents,
-        messages,
-        max_message_id,
-        project_identities,
-    })
-}
-
-fn resource_archive_inventory_has_state(storage_root: &Path) -> bool {
-    let archive = crate::tool_util::read_archive_inventory(storage_root);
-    archive.projects > 0 || archive.agents > 0 || archive.unique_message_ids > 0
-}
-
-fn resource_archive_is_ahead(
-    storage_root: &Path,
-    sqlite_path: &Path,
-    conn: &mcp_agent_mail_db::DbConn,
-) -> Result<bool, String> {
-    if !crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
-        storage_root,
-        sqlite_path,
-    ) {
-        return Ok(false);
-    }
-
-    let archive = crate::tool_util::read_archive_inventory(storage_root);
-    if archive.projects == 0 && archive.agents == 0 && archive.unique_message_ids == 0 {
-        return Ok(false);
-    }
-
-    let db_inventory = query_resource_db_inventory(conn)?;
-    let archive_message_count = archive.unique_message_ids;
-    let archive_max_id = archive.latest_message_id.unwrap_or(0);
-    let missing_archive_projects = mcp_agent_mail_db::archive_missing_project_identities(
-        &archive,
-        &db_inventory.project_identities,
-    );
-
-    let archive_metadata_ahead = mcp_agent_mail_db::pool::archive_metadata_advantage_is_decisive(
-        archive.projects,
-        archive.agents,
-        archive_message_count,
-        archive.latest_message_id,
-        db_inventory.projects,
-        db_inventory.agents,
-        db_inventory.messages,
-        db_inventory.max_message_id,
-        &missing_archive_projects,
-    );
-
-    Ok(archive_message_count > db_inventory.messages
-        || archive_max_id > db_inventory.max_message_id
-        || archive_metadata_ahead)
-}
-
 struct ResourceReadPool {
     pool: mcp_agent_mail_db::DbPool,
     _snapshot_dir: Option<mcp_agent_mail_db::pool::CanonicalSnapshotTempDir>,
@@ -252,44 +121,6 @@ impl std::ops::Deref for ResourceReadPool {
     }
 }
 
-/// Check whether the live `SQLite` database is suspect for resource reads.
-///
-/// Delegates to the fast mailbox verdict. When `DurabilityState` is
-/// `DegradedReadOnly` (or worse), resource reads should fall back to
-/// archive-based data instead of the potentially corrupt live file.
-fn resource_live_db_is_suspect(
-    database_url: &str,
-    storage_root: &Path,
-    sqlite_path: &Path,
-) -> bool {
-    if !crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
-        storage_root,
-        sqlite_path,
-    ) {
-        return false;
-    }
-
-    let verdict = mcp_agent_mail_db::compute_mailbox_verdict(
-        database_url,
-        storage_root,
-        &mcp_agent_mail_db::VerdictOptions::fast(),
-    );
-    let durability = mcp_agent_mail_db::DurabilityState::from_mailbox_state(verdict.state);
-    if mcp_agent_mail_db::verdict_prefers_archive_snapshot_reads_for_primary_read_surface(
-        &verdict,
-        sqlite_path,
-    ) {
-        tracing::info!(
-            verdict_state = %verdict.state,
-            durability_state = %durability,
-            "live SQLite is suspect; resource reads will prefer archive snapshots"
-        );
-        true
-    } else {
-        false
-    }
-}
-
 fn open_resource_read_pool() -> Result<Option<ResourceReadPool>, String> {
     let config = Config::from_env();
     if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&config.database_url) {
@@ -304,57 +135,11 @@ fn open_resource_read_pool() -> Result<Option<ResourceReadPool>, String> {
     }
 
     let resolved_path = PathBuf::from(&sqlite_path);
-    let archive_has_state = crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
-        &config.storage_root,
+    let use_archive_snapshot = crate::tool_util::should_use_archive_snapshot_for_read(
+        &config,
         &resolved_path,
-    ) && resource_archive_inventory_has_state(&config.storage_root);
-
-    // When the durability verdict says the live DB is suspect or worse,
-    // force archive-snapshot reads even if the archive isn't strictly
-    // "ahead" of the DB by row count.
-    let durability_forces_snapshot = archive_has_state
-        && resource_live_db_is_suspect(&config.database_url, &config.storage_root, &resolved_path);
-
-    let use_archive_snapshot = if !resolved_path.exists() {
-        archive_has_state
-    } else if durability_forces_snapshot {
-        true
-    } else {
-        match mcp_agent_mail_db::DbConn::open_file(&sqlite_path) {
-            Ok(conn) => {
-                let conn = mcp_agent_mail_db::guard_db_conn(
-                    conn,
-                    "resources::open_read_db_pool archive-ahead probe",
-                );
-                let archive_ahead =
-                    resource_archive_is_ahead(&config.storage_root, &resolved_path, &conn);
-                drop(conn);
-                match archive_ahead {
-                    Ok(true) => true,
-                    Err(error) if archive_has_state => {
-                        tracing::warn!(
-                            source = %resolved_path.display(),
-                            storage_root = %config.storage_root.display(),
-                            error = %error,
-                            "using archive-backed resource snapshot because the live sqlite inventory probe failed"
-                        );
-                        true
-                    }
-                    Ok(false) | Err(_) => false,
-                }
-            }
-            Err(error) if archive_has_state => {
-                tracing::warn!(
-                    source = %resolved_path.display(),
-                    storage_root = %config.storage_root.display(),
-                    error = %error,
-                    "using archive-backed resource snapshot because the live sqlite source could not be opened"
-                );
-                true
-            }
-            Err(_) => false,
-        }
-    };
+        "resources::open_read_db_pool archive-ahead probe",
+    );
 
     if !use_archive_snapshot {
         return Ok(None);
@@ -436,7 +221,7 @@ fn resource_live_database_missing_without_archive_state() -> bool {
         crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
             &config.storage_root,
             &resolved_path,
-        ) && resource_archive_inventory_has_state(&config.storage_root);
+        ) && crate::tool_util::read_archive_inventory_has_state(&config.storage_root);
     !resolved_path.exists() && !archive_has_authoritative_state
 }
 
@@ -7345,8 +7130,12 @@ mod resource_shape_tests {
                 let conn = mcp_agent_mail_db::DbConn::open_file(db_path.to_string_lossy().as_ref())
                     .expect("open live db");
                 assert!(
-                    !resource_archive_is_ahead(&Config::from_env().storage_root, &db_path, &conn)
-                        .expect("resource archive ahead probe"),
+                    !crate::tool_util::read_archive_is_ahead(
+                        &Config::from_env().storage_root,
+                        &db_path,
+                        &conn,
+                    )
+                    .expect("resource archive ahead probe"),
                     "newer live message evidence should suppress metadata-only archive fallback"
                 );
                 drop(conn);

--- a/crates/mcp-agent-mail-tools/src/resources.rs
+++ b/crates/mcp-agent-mail-tools/src/resources.rs
@@ -184,7 +184,7 @@ fn query_resource_db_inventory(
 }
 
 fn resource_archive_inventory_has_state(storage_root: &Path) -> bool {
-    let archive = mcp_agent_mail_db::scan_archive_message_inventory(storage_root);
+    let archive = crate::tool_util::read_archive_inventory(storage_root);
     archive.projects > 0 || archive.agents > 0 || archive.unique_message_ids > 0
 }
 
@@ -200,7 +200,7 @@ fn resource_archive_is_ahead(
         return Ok(false);
     }
 
-    let archive = mcp_agent_mail_db::scan_archive_message_inventory(storage_root);
+    let archive = crate::tool_util::read_archive_inventory(storage_root);
     if archive.projects == 0 && archive.agents == 0 && archive.unique_message_ids == 0 {
         return Ok(false);
     }


### PR DESCRIPTION
## Problem

Read-side tool and resource access opens the archive state on every request. `open_read_db_pool()` calls the archive scanner once to establish whether archive state exists and again to compare archive IDs with SQLite. On a shared hub with a large Git archive this means routine `fetch_inbox` traffic repeatedly parses the full archive, causing elevated CPU and request timeouts.

## Change

- cache `ArchiveMessageInventory` by global archive Git `HEAD` OID
- preserve the existing conservative full scan when the archive is not a valid Git repository or has no resolved `HEAD`
- use the shared helper for both tool and resource read paths
- add a regression test that commits a second archive message and proves the cache refreshes after `HEAD` changes

This retains archive-ahead detection after committed archive writes while avoiding repeated identical scans for normal reads.

## Validation

- `cargo +stable fmt --check`
- `git diff --check`

Local test execution needs the full sibling workspace dependency mesh referenced by the root Cargo patches; upstream PR CI is the appropriate complete build environment.