### PR TITLE
feat(reservations): add authoritative read-only conflict guard

### DIFF
--- a/crates/mcp-agent-mail-db/src/queries.rs
+++ b/crates/mcp-agent-mail-db/src/queries.rs
@@ -9230,6 +9230,168 @@ fn reservation_descendant_prefix(norm: &str) -> Option<String> {
     }
 }
 
+/// One active exclusive reservation captured with its authoritative holder name.
+///
+/// `agent_name` remains optional so consumers can fail closed on referential
+/// drift instead of silently dropping an unresolvable holder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReservationConflictSnapshotRow {
+    pub id: i64,
+    pub agent_name: Option<String>,
+    pub path_pattern: String,
+    pub expires_ts: i64,
+}
+
+/// Canonical, point-in-time input for a read-only reservation conflict check.
+#[derive(Debug, Clone)]
+pub struct ReservationConflictSnapshot {
+    pub project: ProjectRow,
+    pub captured_ts: i64,
+    pub reservations: Vec<ReservationConflictSnapshotRow>,
+}
+
+/// Capture active exclusive reservations and holder identities from one fresh
+/// database transaction without registration, cleanup, release, or archive IO.
+///
+/// The release ledger is read in the same snapshot and subtracted in Rust to
+/// retain canonical active-reservation semantics without FrankenSQLite's known
+/// O(N*M) anti-join behaviour on joined queries.
+pub async fn get_reservation_conflict_snapshot(
+    cx: &Cx,
+    pool: &DbPool,
+    project_key: &str,
+) -> Outcome<ReservationConflictSnapshot, DbError> {
+    run_with_mvcc_retry(cx, "get_reservation_conflict_snapshot", || async {
+        let captured_ts = now_micros();
+        let conn = match acquire_conn(cx, pool).await {
+            Outcome::Ok(c) => c,
+            Outcome::Err(e) => return Outcome::Err(e),
+            Outcome::Cancelled(r) => return Outcome::Cancelled(r),
+            Outcome::Panicked(p) => return Outcome::Panicked(p),
+        };
+        let tracked = tracked(&*conn);
+
+        // A fresh WAL snapshot is mandatory for guard correctness. This opens
+        // a transaction but performs no data mutation.
+        try_in_tx!(cx, &tracked, begin_immediate_tx(cx, &tracked).await);
+
+        let project_rows = try_in_tx!(
+            cx,
+            &tracked,
+            map_sql_outcome(
+                traw_query(
+                    cx,
+                    &tracked,
+                    "SELECT id, slug, human_key, created_at FROM projects \
+                     WHERE human_key = ? OR slug = ? \
+                     ORDER BY CASE WHEN human_key = ? THEN 0 ELSE 1 END LIMIT 1",
+                    &[
+                        Value::Text(project_key.to_string()),
+                        Value::Text(project_key.to_string()),
+                        Value::Text(project_key.to_string()),
+                    ],
+                )
+                .await,
+            )
+        );
+        let Some(project_row) = project_rows.first() else {
+            rollback_tx(cx, &tracked).await;
+            return Outcome::Err(DbError::not_found("Project", project_key));
+        };
+        let project = match decode_project_row(project_row) {
+            Ok(project) => project,
+            Err(error) => {
+                rollback_tx(cx, &tracked).await;
+                return Outcome::Err(error);
+            }
+        };
+        let project_id = project.id.unwrap_or(0);
+        if project_id <= 0 {
+            rollback_tx(cx, &tracked).await;
+            return Outcome::Err(DbError::Internal(format!(
+                "reservation conflict snapshot resolved invalid project id for {project_key}"
+            )));
+        }
+
+        let candidate_predicate = active_reservation_candidate_predicate_for("fr");
+        let candidate_sql = format!(
+            "SELECT fr.id, a.name, fr.path_pattern, fr.expires_ts \
+             FROM file_reservations fr \
+             LEFT JOIN agents a ON a.id = fr.agent_id AND a.project_id = fr.project_id \
+             WHERE fr.project_id = ? AND fr.\"exclusive\" = 1 \
+               AND {candidate_predicate} AND fr.expires_ts > ? ORDER BY fr.id"
+        );
+        let candidate_rows = try_in_tx!(
+            cx,
+            &tracked,
+            map_sql_outcome(
+                traw_query(
+                    cx,
+                    &tracked,
+                    &candidate_sql,
+                    &[Value::BigInt(project_id), Value::BigInt(captured_ts)],
+                )
+                .await,
+            )
+        );
+        let released_rows = try_in_tx!(
+            cx,
+            &tracked,
+            map_sql_outcome(traw_query(cx, &tracked, RELEASED_RESERVATION_IDS_SQL, &[]).await)
+        );
+        let released_ids: HashSet<i64> = released_rows
+            .iter()
+            .filter_map(|row| row.get(0).and_then(value_as_i64))
+            .collect();
+
+        let mut reservations = Vec::with_capacity(candidate_rows.len());
+        for row in &candidate_rows {
+            let Some(id) = row.get(0).and_then(value_as_i64) else {
+                rollback_tx(cx, &tracked).await;
+                return Outcome::Err(DbError::Internal(
+                    "missing reservation id in conflict snapshot".to_string(),
+                ));
+            };
+            if released_ids.contains(&id) {
+                continue;
+            }
+            let agent_name = row.get(1).and_then(|value| match value {
+                Value::Text(text) => Some(text.clone()),
+                _ => None,
+            });
+            let Some(path_pattern) = row.get(2).and_then(|value| match value {
+                Value::Text(text) => Some(text.clone()),
+                _ => None,
+            }) else {
+                rollback_tx(cx, &tracked).await;
+                return Outcome::Err(DbError::Internal(format!(
+                    "missing path_pattern for active reservation id={id}"
+                )));
+            };
+            let Some(expires_ts) = row.get(3).and_then(value_as_i64) else {
+                rollback_tx(cx, &tracked).await;
+                return Outcome::Err(DbError::Internal(format!(
+                    "missing expires_ts for active reservation id={id}"
+                )));
+            };
+            reservations.push(ReservationConflictSnapshotRow {
+                id,
+                agent_name,
+                path_pattern,
+                expires_ts,
+            });
+        }
+
+        try_in_tx!(cx, &tracked, commit_tx(cx, &tracked).await);
+        Outcome::Ok(ReservationConflictSnapshot {
+            project,
+            captured_ts,
+            reservations,
+        })
+    })
+    .await
+}
+
 /// Create file reservations
 #[allow(clippy::too_many_arguments)]
 pub async fn create_file_reservations(

--- a/crates/mcp-agent-mail-server/src/lib.rs
+++ b/crates/mcp-agent-mail-server/src/lib.rs
@@ -160,24 +160,25 @@ use mcp_agent_mail_db::{
     DbConn, DbPoolConfig, QueryTracker, active_tracker, create_pool, set_active_tracker,
 };
 use mcp_agent_mail_tools::{
-    AcknowledgeMessage, AcquireBuildSlot, AgentsListResource, CleanupPaneIdentities,
-    ConfigEnvironmentQueryResource, ConfigEnvironmentResource, CreateAgentIdentity, EnsureProduct,
-    EnsureProject, FetchInbox, FetchInboxProduct, FileReservationPaths, FileReservationsResource,
-    ForceReleaseFileReservation, HealthCheck, IdentityProjectResource, InboxResource,
-    InstallPrecommitGuard, ListAgents, ListContacts, MacroContactHandshake,
-    MacroFileReservationCycle, MacroPrepareThread, MacroStartSession, MailboxResource,
-    MailboxWithCommitsResource, MarkMessageRead, MessageDetailsResource, OutboxResource,
-    ProductDetailsResource, ProductsLink, ProjectDetailsResource, ProjectsListQueryResource,
-    ProjectsListResource, RegisterAgent, ReleaseBuildSlot, ReleaseFileReservations, RenewBuildSlot,
-    RenewFileReservations, ReplyMessage, RequestContact, ResolvePaneIdentity, RespondContact,
-    SearchMessages, SearchMessagesProduct, SendMessage, SetContactPolicy, SummarizeThread,
-    SummarizeThreadProduct, ThreadDetailsResource, ToolingCapabilitiesResource,
-    ToolingDiagnosticsQueryResource, ToolingDiagnosticsResource, ToolingDirectoryQueryResource,
-    ToolingDirectoryResource, ToolingLocksQueryResource, ToolingLocksResource,
-    ToolingMetricsCoreQueryResource, ToolingMetricsCoreResource, ToolingMetricsQueryResource,
-    ToolingMetricsResource, ToolingRecentResource, ToolingSchemasQueryResource,
-    ToolingSchemasResource, UninstallPrecommitGuard, ViewsAckOverdueResource,
-    ViewsAckRequiredResource, ViewsAcksStaleResource, ViewsUrgentUnreadResource, Whois, clusters,
+    AcknowledgeMessage, AcquireBuildSlot, AgentsListResource, CheckFileReservationConflicts,
+    CleanupPaneIdentities, ConfigEnvironmentQueryResource, ConfigEnvironmentResource,
+    CreateAgentIdentity, EnsureProduct, EnsureProject, FetchInbox, FetchInboxProduct,
+    FileReservationPaths, FileReservationsResource, ForceReleaseFileReservation, HealthCheck,
+    IdentityProjectResource, InboxResource, InstallPrecommitGuard, ListAgents, ListContacts,
+    MacroContactHandshake, MacroFileReservationCycle, MacroPrepareThread, MacroStartSession,
+    MailboxResource, MailboxWithCommitsResource, MarkMessageRead, MessageDetailsResource,
+    OutboxResource, ProductDetailsResource, ProductsLink, ProjectDetailsResource,
+    ProjectsListQueryResource, ProjectsListResource, RegisterAgent, ReleaseBuildSlot,
+    ReleaseFileReservations, RenewBuildSlot, RenewFileReservations, ReplyMessage, RequestContact,
+    ResolvePaneIdentity, RespondContact, SearchMessages, SearchMessagesProduct, SendMessage,
+    SetContactPolicy, SummarizeThread, SummarizeThreadProduct, ThreadDetailsResource,
+    ToolingCapabilitiesResource, ToolingDiagnosticsQueryResource, ToolingDiagnosticsResource,
+    ToolingDirectoryQueryResource, ToolingDirectoryResource, ToolingLocksQueryResource,
+    ToolingLocksResource, ToolingMetricsCoreQueryResource, ToolingMetricsCoreResource,
+    ToolingMetricsQueryResource, ToolingMetricsResource, ToolingRecentResource,
+    ToolingSchemasQueryResource, ToolingSchemasResource, UninstallPrecommitGuard,
+    ViewsAckOverdueResource, ViewsAckRequiredResource, ViewsAcksStaleResource,
+    ViewsUrgentUnreadResource, Whois, clusters,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
@@ -680,6 +681,13 @@ pub fn build_server(config: &mcp_agent_mail_core::Config) -> Server {
         "set_contact_policy",
         clusters::CONTACT,
         SetContactPolicy,
+    );
+    let server = add_tool(
+        server,
+        config,
+        "check_file_reservation_conflicts",
+        clusters::FILE_RESERVATIONS,
+        CheckFileReservationConflicts,
     );
     let server = add_tool(
         server,

--- a/crates/mcp-agent-mail-tools/src/lib.rs
+++ b/crates/mcp-agent-mail-tools/src/lib.rs
@@ -2496,6 +2496,10 @@ pub const TOOL_CLUSTER_MAP: &[(&str, &str)] = &[
     ("list_contacts", clusters::CONTACT),
     ("set_contact_policy", clusters::CONTACT),
     // File reservations
+    (
+        "check_file_reservation_conflicts",
+        clusters::FILE_RESERVATIONS,
+    ),
     ("file_reservation_paths", clusters::FILE_RESERVATIONS),
     ("release_file_reservations", clusters::FILE_RESERVATIONS),
     ("renew_file_reservations", clusters::FILE_RESERVATIONS),
@@ -2551,6 +2555,10 @@ mod tests {
         );
         assert_eq!(tool_cluster("send_message"), Some(clusters::MESSAGING));
         assert_eq!(tool_cluster("request_contact"), Some(clusters::CONTACT));
+        assert_eq!(
+            tool_cluster("check_file_reservation_conflicts"),
+            Some(clusters::FILE_RESERVATIONS)
+        );
         assert_eq!(
             tool_cluster("file_reservation_paths"),
             Some(clusters::FILE_RESERVATIONS)

--- a/crates/mcp-agent-mail-tools/src/metrics.rs
+++ b/crates/mcp-agent-mail-tools/src/metrics.rs
@@ -273,6 +273,13 @@ pub const TOOL_META_MAP: &[(&str, ToolMeta)] = &[
     ),
     // File reservations
     (
+        "check_file_reservation_conflicts",
+        ToolMeta {
+            capabilities: &["audit", "file_reservations", "read", "repository"],
+            complexity: "medium",
+        },
+    ),
+    (
         "file_reservation_paths",
         ToolMeta {
             capabilities: &["file_reservations", "repository"],

--- a/crates/mcp-agent-mail-tools/src/reservations.rs
+++ b/crates/mcp-agent-mail-tools/src/reservations.rs
@@ -100,7 +100,7 @@ pub struct ReservationConflictCheckResponse {
     pub output_truncated: bool,
     pub project: String,
     pub snapshot_ts: String,
-    pub authoritative_source: &'static str,
+    pub authoritative_source: String,
     pub read_only: bool,
 }
 
@@ -1591,7 +1591,7 @@ pub async fn check_file_reservation_conflicts(
         output_truncated,
         project: snapshot.project.slug,
         snapshot_ts: micros_to_iso(snapshot.captured_ts),
-        authoritative_source: "database_snapshot",
+        authoritative_source: "database_snapshot".to_string(),
         read_only: true,
     };
     serde_json::to_string(&response).map_err(|error| {

--- a/crates/mcp-agent-mail-tools/src/reservations.rs
+++ b/crates/mcp-agent-mail-tools/src/reservations.rs
@@ -89,6 +89,21 @@ pub struct ReservationResponse {
     pub conflicts: Vec<ReservationConflict>,
 }
 
+/// Pure read-only reservation conflict check response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReservationConflictCheckResponse {
+    pub conflict_free: bool,
+    pub conflicts: Vec<ReservationConflict>,
+    pub clear_paths: Vec<String>,
+    pub checked_paths: usize,
+    pub total_conflicting_reservations: usize,
+    pub output_truncated: bool,
+    pub project: String,
+    pub snapshot_ts: String,
+    pub authoritative_source: &'static str,
+    pub read_only: bool,
+}
+
 /// Release result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReleaseResult {
@@ -173,6 +188,79 @@ fn invalid_file_reservation_pattern(pattern: &str) -> Option<String> {
         ));
     }
     None
+}
+
+const MAX_CONFLICT_CHECK_PATHS: usize = 200;
+const MAX_CONFLICT_CHECK_PATH_BYTES: usize = 4_096;
+const MAX_CONFLICT_CHECK_PAYLOAD_BYTES: usize = 65_536;
+const MAX_CONFLICT_CHECK_SNAPSHOT_ROWS: usize = 100_000;
+const MAX_CONFLICT_HOLDERS_PER_PATH: usize = 50;
+const MAX_CONFLICT_HOLDERS_TOTAL: usize = 1_000;
+
+fn validate_conflict_check_paths(paths: &[String]) -> McpResult<()> {
+    if paths.is_empty() {
+        return Err(legacy_tool_error(
+            "EMPTY_PATHS",
+            "paths list cannot be empty",
+            true,
+            json!({"fail_closed": true, "do_not_edit": paths}),
+        ));
+    }
+    if paths.len() > MAX_CONFLICT_CHECK_PATHS {
+        return Err(legacy_tool_error(
+            "TOO_MANY_PATHS",
+            &format!(
+                "Maximum {MAX_CONFLICT_CHECK_PATHS} paths per conflict check, got {}",
+                paths.len()
+            ),
+            true,
+            json!({
+                "fail_closed": true,
+                "count": paths.len(),
+                "max": MAX_CONFLICT_CHECK_PATHS,
+                "do_not_edit": paths,
+            }),
+        ));
+    }
+
+    let mut payload_bytes = 0_usize;
+    for path in paths {
+        payload_bytes = payload_bytes.saturating_add(path.len());
+        if path.len() > MAX_CONFLICT_CHECK_PATH_BYTES {
+            return Err(legacy_tool_error(
+                "PATH_TOO_LONG",
+                &format!(
+                    "Path exceeds the {MAX_CONFLICT_CHECK_PATH_BYTES}-byte conflict-check limit"
+                ),
+                true,
+                json!({"fail_closed": true, "do_not_edit": paths}),
+            ));
+        }
+        if path.contains('\0') {
+            return Err(legacy_tool_error(
+                "INVALID_PATH",
+                "Path contains a NUL byte",
+                true,
+                json!({"fail_closed": true, "do_not_edit": paths}),
+            ));
+        }
+    }
+    if payload_bytes > MAX_CONFLICT_CHECK_PAYLOAD_BYTES {
+        return Err(legacy_tool_error(
+            "PAYLOAD_TOO_LARGE",
+            &format!(
+                "Combined paths exceed the {MAX_CONFLICT_CHECK_PAYLOAD_BYTES}-byte conflict-check limit"
+            ),
+            true,
+            json!({
+                "fail_closed": true,
+                "payload_bytes": payload_bytes,
+                "max": MAX_CONFLICT_CHECK_PAYLOAD_BYTES,
+                "do_not_edit": paths,
+            }),
+        ));
+    }
+    Ok(())
 }
 
 /// The single chokepoint every reservation mutation (acquire / renew / release /
@@ -1297,6 +1385,221 @@ fn acquire_outcome<T>(
         }
         other => db_outcome_to_mcp_result(other),
     }
+}
+
+/// Check paths against authoritative active exclusive reservations without
+/// creating, renewing, releasing, healing, registering, or writing anything.
+///
+/// The project, holder identities, active leases, expiry cutoff, and release
+/// ledger are captured from one database transaction. Any malformed stored
+/// reservation or unresolved holder fails closed for every requested path.
+#[tool(
+    description = "Check project-relative paths against authoritative active exclusive file reservations without mutating Agent Mail.\n\nThis is the guard-safe read API for pre-commit and pre-push checks. It reads one canonical database snapshot, ignores reservations owned by agent_name case-insensitively, and returns exact/glob/ancestor conflicts. Expired, released, and shared reservations do not block. Malformed request or stored patterns fail closed. The call never registers agents or projects, cleans up leases, releases reservations, heals archives, or writes mailbox state.\n\nParameters\n----------\nproject_key : str\n    Existing project human key or slug.\nagent_name : str\n    Existing caller identity; used only to ignore the caller's own reservations.\npaths : list[str]\n    One to 200 project-relative paths or glob patterns.\n\nReturns\n-------\ndict\n    { conflict_free, conflicts, clear_paths, checked_paths, total_conflicting_reservations, output_truncated, project, snapshot_ts, authoritative_source, read_only }"
+)]
+pub async fn check_file_reservation_conflicts(
+    ctx: &McpContext,
+    project_key: String,
+    agent_name: String,
+    paths: Vec<String>,
+) -> McpResult<String> {
+    validate_conflict_check_paths(&paths)?;
+
+    let project_key = project_key.trim();
+    if project_key.is_empty() || project_key.len() > MAX_CONFLICT_CHECK_PATH_BYTES {
+        return Err(legacy_tool_error(
+            "INVALID_PROJECT_KEY",
+            "project_key must be non-empty and at most 4096 bytes",
+            true,
+            json!({"fail_closed": true, "do_not_edit": paths}),
+        ));
+    }
+    let caller = agent_name.trim();
+    if caller.is_empty() || caller.len() > 256 || caller.contains('\0') {
+        return Err(legacy_tool_error(
+            "INVALID_AGENT_NAME",
+            "agent_name must be non-empty, NUL-free, and at most 256 bytes",
+            true,
+            json!({"fail_closed": true, "do_not_edit": paths}),
+        ));
+    }
+
+    let pool = get_db_pool()?;
+    let snapshot = acquire_outcome(
+        mcp_agent_mail_db::queries::get_reservation_conflict_snapshot(ctx.cx(), &pool, project_key)
+            .await,
+        &paths,
+        "check_file_reservation_conflicts",
+    )?;
+
+    if snapshot.reservations.len() > MAX_CONFLICT_CHECK_SNAPSHOT_ROWS {
+        return Err(legacy_tool_error(
+            "RESERVATION_SNAPSHOT_TOO_LARGE",
+            "Active reservation snapshot exceeds the safe conflict-check bound",
+            true,
+            json!({
+                "fail_closed": true,
+                "rows": snapshot.reservations.len(),
+                "max": MAX_CONFLICT_CHECK_SNAPSHOT_ROWS,
+                "do_not_edit": paths,
+            }),
+        ));
+    }
+
+    let mut normalized_paths = Vec::with_capacity(paths.len());
+    let mut seen_paths = HashSet::with_capacity(paths.len());
+    for path in &paths {
+        let Some(normalized) = relativize_path(&snapshot.project.human_key, path) else {
+            return Err(legacy_tool_error(
+                "INVALID_PATH",
+                "Path is outside the project root or contains invalid traversal",
+                true,
+                json!({"fail_closed": true, "do_not_edit": paths}),
+            ));
+        };
+        let compiled = CompiledPattern::cached(&normalized);
+        if normalized.is_empty()
+            || invalid_file_reservation_pattern(&normalized).is_some()
+            || !compiled.is_matchable()
+        {
+            return Err(legacy_tool_error(
+                "INVALID_PATH_PATTERN",
+                &format!("Malformed conflict-check path pattern: {path:?}"),
+                true,
+                json!({"fail_closed": true, "do_not_edit": paths}),
+            ));
+        }
+        if seen_paths.insert(normalized.clone()) {
+            normalized_paths.push(normalized);
+        }
+    }
+
+    let mut holder_by_reservation = HashMap::with_capacity(snapshot.reservations.len());
+    let mut indexed = Vec::with_capacity(snapshot.reservations.len());
+    for reservation in &snapshot.reservations {
+        let Some(holder) = reservation.agent_name.as_deref() else {
+            return Err(legacy_tool_error(
+                "UNRESOLVED_RESERVATION_HOLDER",
+                &format!(
+                    "Active reservation {} has no authoritative holder identity",
+                    reservation.id
+                ),
+                false,
+                json!({"fail_closed": true, "do_not_edit": paths}),
+            ));
+        };
+        if holder.eq_ignore_ascii_case(caller) {
+            continue;
+        }
+        let compiled = CompiledPattern::cached(&reservation.path_pattern);
+        if reservation.path_pattern.is_empty()
+            || reservation.path_pattern.len() > MAX_CONFLICT_CHECK_PATH_BYTES
+            || reservation.path_pattern.contains('\0')
+            || invalid_file_reservation_pattern(&reservation.path_pattern).is_some()
+            || !compiled.is_matchable()
+        {
+            return Err(legacy_tool_error(
+                "MALFORMED_ACTIVE_RESERVATION",
+                &format!(
+                    "Active reservation {} contains a malformed path pattern; conflict status is unverifiable",
+                    reservation.id
+                ),
+                false,
+                json!({
+                    "fail_closed": true,
+                    "reservation_id": reservation.id,
+                    "do_not_edit": paths,
+                }),
+            ));
+        }
+
+        holder_by_reservation.insert(
+            reservation.id,
+            (holder.to_string(), reservation.path_pattern.clone()),
+        );
+        indexed.push((
+            reservation.path_pattern.clone(),
+            ReservationRef {
+                // Reservation IDs are unique and provide a stable lookup key for
+                // holder metadata without another database read.
+                agent_id: reservation.id,
+                path_pattern: reservation.path_pattern.clone(),
+                exclusive: true,
+                expires_ts: reservation.expires_ts,
+            },
+        ));
+    }
+
+    let index = ReservationIndex::build(indexed.into_iter());
+    let mut conflicts = Vec::new();
+    let mut clear_paths = Vec::new();
+    let mut refs = Vec::new();
+    let mut total_conflicting_reservations = 0_usize;
+    let mut emitted_holders = 0_usize;
+    let mut output_truncated = false;
+
+    for path in &normalized_paths {
+        let compiled = CompiledPattern::cached(path);
+        index.find_conflicts(compiled.as_ref(), &mut refs);
+        refs.sort_unstable_by(|left, right| {
+            left.path_pattern
+                .cmp(&right.path_pattern)
+                .then_with(|| left.agent_id.cmp(&right.agent_id))
+        });
+        refs.dedup_by_key(|entry| entry.agent_id);
+        total_conflicting_reservations = total_conflicting_reservations.saturating_add(refs.len());
+
+        if refs.is_empty() {
+            clear_paths.push(path.clone());
+            continue;
+        }
+
+        let remaining_total = MAX_CONFLICT_HOLDERS_TOTAL.saturating_sub(emitted_holders);
+        let emit_count = refs
+            .len()
+            .min(MAX_CONFLICT_HOLDERS_PER_PATH)
+            .min(remaining_total);
+        if emit_count < refs.len() {
+            output_truncated = true;
+        }
+        let holders = refs
+            .iter()
+            .take(emit_count)
+            .filter_map(|entry| {
+                holder_by_reservation
+                    .get(&entry.agent_id)
+                    .map(|(holder, pattern)| ConflictHolder {
+                        agent: holder.clone(),
+                        path_pattern: pattern.clone(),
+                        exclusive: true,
+                        expires_ts: micros_to_iso(entry.expires_ts),
+                    })
+            })
+            .collect::<Vec<_>>();
+        emitted_holders = emitted_holders.saturating_add(holders.len());
+        conflicts.push(ReservationConflict {
+            path: path.clone(),
+            holders,
+        });
+    }
+
+    let response = ReservationConflictCheckResponse {
+        conflict_free: conflicts.is_empty(),
+        conflicts,
+        clear_paths,
+        checked_paths: normalized_paths.len(),
+        total_conflicting_reservations,
+        output_truncated,
+        project: snapshot.project.slug,
+        snapshot_ts: micros_to_iso(snapshot.captured_ts),
+        authoritative_source: "database_snapshot",
+        read_only: true,
+    };
+    serde_json::to_string(&response).map_err(|error| {
+        McpError::new(
+            McpErrorCode::InternalError,
+            format!("failed to serialize reservation conflict response: {error}"),
+        )
+    })
 }
 
 /// Request advisory file reservations on project-relative paths/globs.
@@ -2862,6 +3165,239 @@ mod tests {
             Outcome::Ok(agent) => agent,
             other => panic!("register_agent({name}) failed: {other:?}"),
         }
+    }
+
+    async fn create_test_reservation(
+        cx: &Cx,
+        pool: &DbPool,
+        project_id: i64,
+        agent_id: i64,
+        path: &str,
+        ttl_seconds: i64,
+        exclusive: bool,
+    ) -> mcp_agent_mail_db::FileReservationRow {
+        match queries::create_file_reservations(
+            cx,
+            pool,
+            project_id,
+            agent_id,
+            &[path],
+            ttl_seconds,
+            exclusive,
+            "conflict-check test",
+        )
+        .await
+        {
+            Outcome::Ok(mut rows) => rows.pop().expect("reservation row"),
+            other => panic!("create reservation {path:?} failed: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn conflict_check_is_authoritative_read_only_and_filters_non_blocking_rows() {
+        with_serialized_reservations(|| {
+            run_async(|cx| async move {
+                let pool = get_db_pool().expect("db pool");
+                let project_key = format!("/tmp/conflict-check-golden-{}", unique_suffix());
+                let project = ensure_project(&cx, &pool, &project_key).await;
+                let project_id = project.id.expect("project id");
+                let holder = register_agent(&cx, &pool, project_id, "GreenCastle").await;
+                let caller = register_agent(&cx, &pool, project_id, "BlueLake").await;
+                let holder_id = holder.id.expect("holder id");
+                let caller_id = caller.id.expect("caller id");
+
+                create_test_reservation(
+                    &cx,
+                    &pool,
+                    project_id,
+                    holder_id,
+                    "src/main.rs",
+                    3_600,
+                    true,
+                )
+                .await;
+                create_test_reservation(
+                    &cx,
+                    &pool,
+                    project_id,
+                    holder_id,
+                    "docs/**/*.md",
+                    3_600,
+                    true,
+                )
+                .await;
+                create_test_reservation(&cx, &pool, project_id, holder_id, "config", 3_600, true)
+                    .await;
+                create_test_reservation(&cx, &pool, project_id, caller_id, "own/**", 3_600, true)
+                    .await;
+                create_test_reservation(&cx, &pool, project_id, holder_id, "expired/**", -1, true)
+                    .await;
+                create_test_reservation(
+                    &cx,
+                    &pool,
+                    project_id,
+                    holder_id,
+                    "shared/**",
+                    3_600,
+                    false,
+                )
+                .await;
+                let released = create_test_reservation(
+                    &cx,
+                    &pool,
+                    project_id,
+                    holder_id,
+                    "released/**",
+                    3_600,
+                    true,
+                )
+                .await;
+                match queries::release_reservations(
+                    &cx,
+                    &pool,
+                    project_id,
+                    holder_id,
+                    None,
+                    Some(&[released.id.expect("released reservation id")]),
+                )
+                .await
+                {
+                    Outcome::Ok(rows) => assert_eq!(rows.len(), 1),
+                    other => panic!("release fixture failed: {other:?}"),
+                }
+
+                let before =
+                    match queries::list_file_reservations(&cx, &pool, project_id, false).await {
+                        Outcome::Ok(rows) => rows,
+                        other => panic!("before snapshot failed: {other:?}"),
+                    };
+                let ctx = McpContext::new(cx.clone(), 1);
+                let response: ReservationConflictCheckResponse = serde_json::from_str(
+                    &check_file_reservation_conflicts(
+                        &ctx,
+                        project_key,
+                        "bluelake".to_string(),
+                        vec![
+                            "src/main.rs".to_string(),
+                            "src/**".to_string(),
+                            "docs/guide/readme.md".to_string(),
+                            "config/app.toml".to_string(),
+                            "own/file.rs".to_string(),
+                            "expired/file.rs".to_string(),
+                            "released/file.rs".to_string(),
+                            "shared/file.rs".to_string(),
+                            "free/file.rs".to_string(),
+                        ],
+                    )
+                    .await
+                    .expect("conflict check"),
+                )
+                .expect("response json");
+
+                assert!(!response.conflict_free);
+                assert!(response.read_only);
+                assert_eq!(response.authoritative_source, "database_snapshot");
+                assert_eq!(response.checked_paths, 9);
+                let conflict_paths = response
+                    .conflicts
+                    .iter()
+                    .map(|conflict| conflict.path.as_str())
+                    .collect::<HashSet<_>>();
+                assert_eq!(
+                    conflict_paths,
+                    HashSet::from([
+                        "src/main.rs",
+                        "src/**",
+                        "docs/guide/readme.md",
+                        "config/app.toml",
+                    ])
+                );
+                assert!(response.conflicts.iter().all(|conflict| {
+                    conflict
+                        .holders
+                        .iter()
+                        .all(|holder| holder.agent == "GreenCastle" && holder.exclusive)
+                }));
+                assert_eq!(
+                    response.clear_paths,
+                    [
+                        "own/file.rs",
+                        "expired/file.rs",
+                        "released/file.rs",
+                        "shared/file.rs",
+                        "free/file.rs",
+                    ]
+                );
+
+                let after =
+                    match queries::list_file_reservations(&cx, &pool, project_id, false).await {
+                        Outcome::Ok(rows) => rows,
+                        other => panic!("after snapshot failed: {other:?}"),
+                    };
+                assert_eq!(
+                    before
+                        .iter()
+                        .map(|row| (row.id, row.released_ts, row.expires_ts))
+                        .collect::<Vec<_>>(),
+                    after
+                        .iter()
+                        .map(|row| (row.id, row.released_ts, row.expires_ts))
+                        .collect::<Vec<_>>(),
+                    "read-only conflict check must not change reservation state"
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn conflict_check_fails_closed_on_malformed_request_or_stored_pattern() {
+        with_serialized_reservations(|| {
+            run_async(|cx| async move {
+                let pool = get_db_pool().expect("db pool");
+                let project_key = format!("/tmp/conflict-check-invalid-{}", unique_suffix());
+                let project = ensure_project(&cx, &pool, &project_key).await;
+                let project_id = project.id.expect("project id");
+                let holder = register_agent(&cx, &pool, project_id, "GreenCastle").await;
+                register_agent(&cx, &pool, project_id, "BlueLake").await;
+                let ctx = McpContext::new(cx.clone(), 1);
+
+                let malformed_request = check_file_reservation_conflicts(
+                    &ctx,
+                    project_key.clone(),
+                    "BlueLake".to_string(),
+                    vec!["[broken".to_string()],
+                )
+                .await
+                .expect_err("malformed request must fail closed");
+                let malformed_request_data = malformed_request.data.expect("error data");
+                assert_eq!(malformed_request_data["error"]["data"]["fail_closed"], true);
+
+                create_test_reservation(
+                    &cx,
+                    &pool,
+                    project_id,
+                    holder.id.expect("holder id"),
+                    "[broken",
+                    3_600,
+                    true,
+                )
+                .await;
+                let malformed_stored = check_file_reservation_conflicts(
+                    &ctx,
+                    project_key,
+                    "BlueLake".to_string(),
+                    vec!["src/main.rs".to_string()],
+                )
+                .await
+                .expect_err("malformed stored reservation must fail closed");
+                let malformed_stored_data = malformed_stored.data.expect("error data");
+                assert_eq!(malformed_stored_data["error"]["data"]["fail_closed"], true);
+                assert_eq!(
+                    malformed_stored_data["error"]["type"],
+                    "MALFORMED_ACTIVE_RESERVATION"
+                );
+            });
+        });
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add `check_file_reservation_conflicts`, a bounded read-only MCP tool for authoritative pre-edit reservation checks.

## Contract

- Reads one canonical database snapshot for the project.
- Reports only active, unexpired, unreleased, exclusive reservations.
- Ignores the caller's own reservations case-insensitively.
- Reuses the existing `CompiledPattern` / reservation-index semantics for exact, glob, and ancestor conflicts.
- Fails closed on malformed requested or stored patterns and missing reservation-holder metadata.
- Bounds input paths, path bytes, snapshot rows, and emitted holder payloads; reports truncation explicitly.
- Performs no project/agent registration, cleanup, release, archive, or other data writes.

## Verification

- `cargo test -p mcp-agent-mail-tools conflict_check_ -- --nocapture`
  - 2 passed, 0 failed
  - exact, requested glob, stored glob, ancestor, case-insensitive own-ignore, expired, released, shared, free path, before/after state equality, malformed request/stored fail-closed
- `cargo check --workspace --all-targets`
  - passed (9m55s)
- `cargo clippy --workspace --all-targets -- -D warnings`
  - passed (4m28s)
- `cargo fmt --check`
  - passed
- `git diff --check`
  - passed

All compile/test validation ran against the repository's canonical sibling dependency graph on a dedicated disk-backed Cargo target. `ubs` was unavailable in the validation environment.
