### PR TITLE
fix(reads): single-flight reconstructed snapshots

### DIFF
--- a/crates/mcp-agent-mail-db/src/lib.rs
+++ b/crates/mcp-agent-mail-db/src/lib.rs
@@ -272,6 +272,7 @@ pub use pool::{
     classify_canary_outcome,
     create_pool,
     create_pool_without_startup_init,
+    create_query_only_pool,
     deferred_write_queue,
     ensure_sqlite_file_healthy,
     ensure_sqlite_file_healthy_with_archive,
@@ -300,8 +301,9 @@ pub use reconstruct::{
     ProjectIdentityMismatch, ReconstructStats, archive_missing_project_identities,
     collect_db_message_ids, collect_db_project_identities, compute_archive_drift_report,
     mailbox_project_identity_matches_db, reconstruct_from_archive,
-    reconstruct_from_archive_with_salvage, scan_archive_message_ids,
-    scan_archive_message_inventory,
+    reconstruct_from_archive_cancellable, reconstruct_from_archive_with_salvage,
+    reconstruct_from_archive_with_salvage_cancellable, scan_archive_message_ids,
+    scan_archive_message_inventory, scan_archive_message_inventory_cancellable,
 };
 pub use retry::{
     CIRCUIT_BREAKER, CIRCUIT_DB, CIRCUIT_GIT, CIRCUIT_LLM, CIRCUIT_SIGNAL, CircuitBreaker,

--- a/crates/mcp-agent-mail-db/src/pool.rs
+++ b/crates/mcp-agent-mail-db/src/pool.rs
@@ -2105,12 +2105,19 @@ pub struct DbPool {
     init_sql: Arc<String>,
     run_migrations: bool,
     skip_startup_init: bool,
+    open_mode: DbPoolOpenMode,
     stats_sampler: Arc<DbPoolStatsSampler>,
     /// Shared, process-wide monotonic message-id allocator for this database
     /// (mcp_agent_mail#176). Resolved once at construction so all `DbPool`
     /// wrappers of the same underlying connection pool share one high-water
     /// mark; see [`shared_message_id_allocator`].
     message_id_allocator: Arc<crate::id_floor::MessageIdAllocator>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DbPoolOpenMode {
+    Recovering,
+    QueryOnlyStrict,
 }
 
 /// Registry of per-database message-id allocators, keyed by the shared
@@ -2154,6 +2161,18 @@ fn shared_message_id_allocator(
 }
 
 impl DbPool {
+    fn connection_init_sql(config: &DbPoolConfig, query_only: bool) -> Arc<String> {
+        let mut sql = String::new();
+        if query_only {
+            sql.push_str("PRAGMA query_only = ON;\n");
+        }
+        sql.push_str(&schema::build_conn_pragmas(
+            config.max_connections,
+            config.cache_budget_kb,
+        ));
+        Arc::new(sql)
+    }
+
     fn from_shared_pool_with_options(
         config: &DbPoolConfig,
         pool: Arc<Pool<DbConn>>,
@@ -2161,10 +2180,7 @@ impl DbPool {
     ) -> DbResult<Self> {
         let sqlite_path = resolve_sqlite_path_with_absolute_fallback(&config.sqlite_path()?);
         let storage_root = config.resolved_storage_root();
-        let init_sql = Arc::new(schema::build_conn_pragmas(
-            config.max_connections,
-            config.cache_budget_kb,
-        ));
+        let init_sql = Self::connection_init_sql(config, false);
         let stats_sampler = Arc::new(DbPoolStatsSampler::new());
         let (message_id_allocator, cache_generation) = shared_message_id_allocator(&pool);
 
@@ -2176,6 +2192,7 @@ impl DbPool {
             init_sql,
             run_migrations: config.run_migrations,
             skip_startup_init,
+            open_mode: DbPoolOpenMode::Recovering,
             stats_sampler,
             message_id_allocator,
         })
@@ -2185,13 +2202,14 @@ impl DbPool {
         Self::from_shared_pool_with_options(config, pool, false)
     }
 
-    fn new_with_options(config: &DbPoolConfig, skip_startup_init: bool) -> DbResult<Self> {
+    fn new_with_options(
+        config: &DbPoolConfig,
+        skip_startup_init: bool,
+        query_only: bool,
+    ) -> DbResult<Self> {
         let sqlite_path = resolve_sqlite_path_with_absolute_fallback(&config.sqlite_path()?);
         let storage_root = config.resolved_storage_root();
-        let init_sql = Arc::new(schema::build_conn_pragmas(
-            config.max_connections,
-            config.cache_budget_kb,
-        ));
+        let init_sql = Self::connection_init_sql(config, query_only);
         let stats_sampler = Arc::new(DbPoolStatsSampler::new());
 
         let pool_config = PoolConfig::new(config.max_connections)
@@ -2213,6 +2231,11 @@ impl DbPool {
             init_sql,
             run_migrations: config.run_migrations,
             skip_startup_init,
+            open_mode: if query_only {
+                DbPoolOpenMode::QueryOnlyStrict
+            } else {
+                DbPoolOpenMode::Recovering
+            },
             stats_sampler,
             message_id_allocator,
         })
@@ -2220,7 +2243,7 @@ impl DbPool {
 
     /// Create a new pool (does not open connections until first acquire).
     pub fn new(config: &DbPoolConfig) -> DbResult<Self> {
-        Self::new_with_options(config, false)
+        Self::new_with_options(config, false, false)
     }
 
     /// Create a pool that skips one-time startup initialization on first acquire.
@@ -2228,7 +2251,16 @@ impl DbPool {
     /// Intended for read-only helper surfaces that open an already initialized
     /// mailbox under a live server and must avoid contending on startup repairs.
     pub fn new_without_startup_init(config: &DbPoolConfig) -> DbResult<Self> {
-        Self::new_with_options(config, true)
+        Self::new_with_options(config, true, false)
+    }
+
+    /// Create an uncached pool whose every connection is query-only.
+    ///
+    /// Reconstructed archive snapshots use this constructor so no resource or
+    /// tool path can mutate a shared cached candidate. Startup initialization
+    /// is skipped because the candidate was fully materialized before opening.
+    pub fn new_query_only(config: &DbPoolConfig) -> DbResult<Self> {
+        Self::new_with_options(config, true, true)
     }
 
     #[must_use]
@@ -2292,6 +2324,7 @@ impl DbPool {
         let init_sql = self.init_sql.clone();
         let run_migrations = self.run_migrations;
         let skip_startup_init = self.skip_startup_init;
+        let open_mode = self.open_mode;
         let cx2 = cx.clone();
 
         let start = Instant::now();
@@ -2308,6 +2341,7 @@ impl DbPool {
                 async move {
                     // Ensure parent directory exists for file-backed DBs.
                     if sqlite_path != ":memory:"
+                        && open_mode == DbPoolOpenMode::Recovering
                         && let Err(e) = ensure_sqlite_parent_dir_exists(&sqlite_path)
                     {
                         return Outcome::Err(e);
@@ -2360,6 +2394,14 @@ impl DbPool {
                             Ok(c) => c,
                             Err(e) => return Outcome::Err(e),
                         }
+                    } else if open_mode == DbPoolOpenMode::QueryOnlyStrict {
+                        // Immutable reconstructed candidates must fail closed.
+                        // In particular, do not call the normal opener here:
+                        // it may quarantine, reconstruct, or replace the path.
+                        match DbConn::open_file_read_only(&sqlite_path) {
+                            Ok(c) => c,
+                            Err(e) => return Outcome::Err(e),
+                        }
                     } else {
                         match open_sqlite_file_with_recovery(&sqlite_path) {
                             Ok(c) => c,
@@ -2396,6 +2438,7 @@ impl DbPool {
                         "pool connection init pragmas",
                     ) {
                         if sqlite_path == ":memory:"
+                            || open_mode == DbPoolOpenMode::QueryOnlyStrict
                             || !is_sqlite_recovery_error_message(&first_init_err.to_string())
                         {
                             crate::close_db_conn(conn, "pool connection init failed (non-recoverable)");
@@ -4627,6 +4670,15 @@ fn read_pragma_i64(conn: &DbConn, sql: &str, column: &str) -> Result<i64, SqlErr
     read_pragma_i64_from_row(row, sql, column)
 }
 
+/// Read the connection-local SQLite data-version counter.
+///
+/// Keeping one observer connection open lets callers cheaply detect commits
+/// performed by other connections without hashing the database family.
+#[allow(clippy::result_large_err)]
+pub fn sqlite_data_version(conn: &DbConn) -> Result<i64, SqlError> {
+    read_pragma_i64(conn, "PRAGMA data_version;", "data_version")
+}
+
 #[allow(clippy::result_large_err)]
 fn read_canonical_journal_mode(sqlite_path: &str) -> Result<String, SqlError> {
     if sqlite_path == ":memory:" {
@@ -5333,7 +5385,7 @@ fn sqlite_file_has_live_sidecars(path: &Path) -> bool {
 }
 
 #[must_use]
-pub(crate) fn sqlite_path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+pub fn sqlite_path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
     let mut suffixed = path.as_os_str().to_os_string();
     suffixed.push(suffix);
     PathBuf::from(suffixed)
@@ -8894,6 +8946,11 @@ pub fn create_pool_without_startup_init(config: &DbPoolConfig) -> DbResult<DbPoo
     DbPool::new_without_startup_init(config)
 }
 
+/// Create an uncached, query-only helper pool for an immutable SQLite file.
+pub fn create_query_only_pool(config: &DbPoolConfig) -> DbResult<DbPool> {
+    DbPool::new_query_only(config)
+}
+
 // ============================================================================
 // Synthetic canary namespace, metrics, and alert-isolation policy
 // (br-97gc6.5.2.6.5.4)
@@ -9791,6 +9848,191 @@ mod tests {
         );
     }
 
+    #[test]
+    fn query_only_pool_does_not_create_an_absent_candidate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("absent-candidate.sqlite3");
+        let pool = DbPool::new_query_only(&DbPoolConfig {
+            database_url: format!("sqlite:///{}", db_path.display()),
+            storage_root: Some(dir.path().join("archive")),
+            min_connections: 0,
+            max_connections: 1,
+            run_migrations: false,
+            warmup_connections: 0,
+            ..Default::default()
+        })
+        .expect("construct strict query-only pool");
+        let names_before = std::fs::read_dir(dir.path())
+            .expect("read directory before acquire")
+            .map(|entry| entry.expect("entry before acquire").file_name())
+            .collect::<BTreeSet<_>>();
+        let rt = asupersync::runtime::RuntimeBuilder::current_thread()
+            .build()
+            .expect("build runtime");
+        let cx = asupersync::Cx::for_testing();
+
+        assert!(
+            !matches!(rt.block_on(pool.acquire(&cx)), Outcome::Ok(_)),
+            "strict query-only acquire must reject an absent candidate"
+        );
+        assert!(!db_path.exists(), "acquire must not create the candidate");
+        let names_after = std::fs::read_dir(dir.path())
+            .expect("read directory after acquire")
+            .map(|entry| entry.expect("entry after acquire").file_name())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(names_after, names_before, "acquire must create no sidecars");
+    }
+
+    #[test]
+    fn query_only_pool_does_not_recreate_candidate_removed_before_first_acquire() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("raced-away-candidate.sqlite3");
+        let seed =
+            DbConn::open_file(db_path.to_string_lossy().as_ref()).expect("open candidate fixture");
+        seed.execute_raw(&schema::init_schema_sql_base())
+            .expect("initialize candidate fixture");
+        drop(seed);
+        let pool = DbPool::new_query_only(&DbPoolConfig {
+            database_url: format!("sqlite:///{}", db_path.display()),
+            storage_root: Some(dir.path().join("archive")),
+            min_connections: 0,
+            max_connections: 1,
+            run_migrations: false,
+            warmup_connections: 0,
+            ..Default::default()
+        })
+        .expect("construct strict query-only pool");
+        std::fs::remove_file(&db_path).expect("remove candidate before first acquire");
+        let names_before = std::fs::read_dir(dir.path())
+            .expect("read directory before raced acquire")
+            .map(|entry| entry.expect("entry before raced acquire").file_name())
+            .collect::<BTreeSet<_>>();
+        let rt = asupersync::runtime::RuntimeBuilder::current_thread()
+            .build()
+            .expect("build runtime");
+        let cx = asupersync::Cx::for_testing();
+
+        assert!(
+            !matches!(rt.block_on(pool.acquire(&cx)), Outcome::Ok(_)),
+            "strict query-only acquire must reject a raced-away candidate"
+        );
+        assert!(!db_path.exists(), "acquire must not recreate the candidate");
+        let names_after = std::fs::read_dir(dir.path())
+            .expect("read directory after raced acquire")
+            .map(|entry| entry.expect("entry after raced acquire").file_name())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(names_after, names_before, "acquire must create no sidecars");
+    }
+
+    #[test]
+    fn query_only_pool_fails_closed_without_mutating_corrupt_candidate_family() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("immutable-corrupt-candidate.sqlite3");
+        let original = b"not a sqlite database; immutable forensic bytes";
+        std::fs::write(&db_path, original).expect("write corrupt candidate");
+        let names_before = std::fs::read_dir(dir.path())
+            .expect("read candidate directory before acquire")
+            .map(|entry| entry.expect("candidate entry before acquire").file_name())
+            .collect::<BTreeSet<_>>();
+
+        let pool = DbPool::new_query_only(&DbPoolConfig {
+            database_url: format!("sqlite:///{}", db_path.display()),
+            storage_root: Some(dir.path().join("archive")),
+            min_connections: 0,
+            max_connections: 1,
+            run_migrations: false,
+            warmup_connections: 0,
+            ..Default::default()
+        })
+        .expect("construct strict query-only pool");
+        let rt = asupersync::runtime::RuntimeBuilder::current_thread()
+            .build()
+            .expect("build runtime");
+        let cx = asupersync::Cx::for_testing();
+        assert!(
+            !matches!(rt.block_on(pool.acquire(&cx)), Outcome::Ok(_)),
+            "strict query-only acquire must reject a corrupt candidate"
+        );
+
+        assert_eq!(
+            std::fs::read(&db_path).expect("read candidate after acquire"),
+            original,
+            "strict query-only acquire must preserve candidate bytes"
+        );
+        let names_after = std::fs::read_dir(dir.path())
+            .expect("read candidate directory after acquire")
+            .map(|entry| entry.expect("candidate entry after acquire").file_name())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            names_after, names_before,
+            "strict query-only acquire must not create quarantine, recovery, journal, or WAL artifacts"
+        );
+    }
+
+    #[test]
+    fn query_only_pool_keeps_valid_candidate_bytes_and_family_immutable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("immutable-valid-candidate.sqlite3");
+        let seed =
+            DbConn::open_file(db_path.to_string_lossy().as_ref()).expect("open candidate fixture");
+        seed.execute_raw(&schema::init_schema_sql_base())
+            .expect("initialize candidate fixture");
+        drop(seed);
+        let bytes_before = std::fs::read(&db_path).expect("read candidate before acquire");
+        let names_before = std::fs::read_dir(dir.path())
+            .expect("read candidate family before acquire")
+            .map(|entry| entry.expect("candidate entry before acquire").file_name())
+            .collect::<BTreeSet<_>>();
+
+        let pool = DbPool::new_query_only(&DbPoolConfig {
+            database_url: format!("sqlite:///{}", db_path.display()),
+            storage_root: Some(dir.path().join("archive")),
+            min_connections: 0,
+            max_connections: 1,
+            run_migrations: false,
+            warmup_connections: 0,
+            ..Default::default()
+        })
+        .expect("construct strict query-only pool");
+        let rt = asupersync::runtime::RuntimeBuilder::current_thread()
+            .build()
+            .expect("build runtime");
+        let cx = asupersync::Cx::for_testing();
+        let conn = rt
+            .block_on(pool.acquire(&cx))
+            .into_result()
+            .expect("acquire strict query-only connection");
+        let query_only = conn
+            .query_sync("PRAGMA query_only", &[])
+            .expect("read query-only pragma")[0]
+            .get_as::<i64>(0)
+            .expect("decode query-only pragma");
+        assert_eq!(query_only, 1, "connection must retain query-only defense");
+        conn.query_sync("SELECT COUNT(*) AS count FROM projects", &[])
+            .expect("read through strict query-only connection");
+        assert!(
+            conn.query_sync(
+                "INSERT INTO projects (slug, human_key, created_at) VALUES ('forbidden', '/forbidden', 0)",
+                &[],
+            )
+            .is_err(),
+            "strict query-only connection must reject writes"
+        );
+        drop(conn);
+        drop(pool);
+
+        assert_eq!(
+            std::fs::read(&db_path).expect("read candidate after acquire"),
+            bytes_before,
+            "strict query-only acquire must preserve valid candidate bytes"
+        );
+        let names_after = std::fs::read_dir(dir.path())
+            .expect("read candidate family after acquire")
+            .map(|entry| entry.expect("candidate entry after acquire").file_name())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(names_after, names_before);
+    }
+
     // ── DbPoolConfig coverage ─────────────────────────────────────────
 
     #[test]
@@ -10312,6 +10554,28 @@ mod tests {
         assert!(
             err.to_string().contains("did not expose integer column"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn sqlite_data_version_observer_detects_other_connection_commit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("data-version.sqlite3");
+        let observer = DbConn::open_file(db_path.to_string_lossy().as_ref())
+            .expect("open data-version observer");
+        let writer = DbConn::open_file(db_path.to_string_lossy().as_ref())
+            .expect("open data-version writer");
+        observer
+            .execute_raw("PRAGMA query_only = ON;")
+            .expect("make observer query-only");
+        let before = sqlite_data_version(&observer).expect("read initial data version");
+        writer
+            .execute_raw("CREATE TABLE committed_by_other_connection (id INTEGER PRIMARY KEY);")
+            .expect("commit schema change through writer");
+        let after = sqlite_data_version(&observer).expect("read advanced data version");
+        assert!(
+            after > before,
+            "other-connection commit must advance data_version"
         );
     }
 

--- a/crates/mcp-agent-mail-db/src/reconstruct.rs
+++ b/crates/mcp-agent-mail-db/src/reconstruct.rs
@@ -22,7 +22,7 @@
 use crate::error::{DbError, DbResult};
 use crate::schema;
 use serde::Serialize;
-use sqlmodel_core::{Error as SqlError, Value};
+use sqlmodel_core::{Error as SqlError, Row, Value};
 use sqlmodel_schema::Migration;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -90,6 +90,141 @@ static FAIL_SALVAGE_MERGE_AFTER_PROJECTS: std::sync::atomic::AtomicBool =
 static FAIL_SALVAGE_QUERY_MESSAGES: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// Full salvage values are materialized in pages whose worst-case payload is
+/// bounded by `SALVAGE_MAX_PAGE_VALUE_BYTES`.
+const SALVAGE_QUERY_PAGE_ROWS: i64 = 16;
+const SALVAGE_MAX_VARIABLE_VALUE_BYTES: i64 = 4 * 1024 * 1024;
+const SALVAGE_MAX_PAGE_VALUE_BYTES: i64 =
+    SALVAGE_QUERY_PAGE_ROWS * SALVAGE_MAX_VARIABLE_VALUE_BYTES;
+const SALVAGE_ID_MAP_MAX_ENTRIES: usize = 100_000;
+const RECONSTRUCT_RECIPIENT_ROWS_PER_MESSAGE_MAX: i64 = 10_000;
+
+#[cfg(test)]
+#[derive(Default)]
+struct SalvagePageTestStats {
+    owner: Option<std::thread::ThreadId>,
+    agent_pages: usize,
+    agent_rows: usize,
+    agent_max_page_rows: usize,
+    id_map_limit: Option<usize>,
+    page_value_byte_limit: Option<i64>,
+}
+
+#[cfg(test)]
+static SALVAGE_PAGE_TEST_STATS: std::sync::LazyLock<std::sync::Mutex<SalvagePageTestStats>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(SalvagePageTestStats::default()));
+
+#[cfg(test)]
+fn begin_salvage_page_test_observation() {
+    *SALVAGE_PAGE_TEST_STATS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = SalvagePageTestStats {
+        owner: Some(std::thread::current().id()),
+        ..SalvagePageTestStats::default()
+    };
+}
+
+#[cfg(test)]
+fn salvage_page_test_stats() -> (usize, usize, usize) {
+    let stats = SALVAGE_PAGE_TEST_STATS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    (
+        stats.agent_pages,
+        stats.agent_rows,
+        stats.agent_max_page_rows,
+    )
+}
+
+#[cfg(test)]
+fn finish_salvage_page_test_observation() -> (usize, usize, usize) {
+    let mut stats = SALVAGE_PAGE_TEST_STATS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let result = (
+        stats.agent_pages,
+        stats.agent_rows,
+        stats.agent_max_page_rows,
+    );
+    *stats = SalvagePageTestStats::default();
+    result
+}
+
+#[cfg(test)]
+fn set_salvage_test_id_map_limit(limit: usize) {
+    let mut stats = SALVAGE_PAGE_TEST_STATS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(stats.owner, Some(std::thread::current().id()));
+    stats.id_map_limit = Some(limit);
+}
+
+#[cfg(test)]
+fn set_salvage_test_page_value_byte_limit(limit: i64) {
+    let mut stats = SALVAGE_PAGE_TEST_STATS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(stats.owner, Some(std::thread::current().id()));
+    stats.page_value_byte_limit = Some(limit);
+}
+
+fn salvage_id_map_limit() -> usize {
+    #[cfg(test)]
+    {
+        let stats = SALVAGE_PAGE_TEST_STATS
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if stats.owner == Some(std::thread::current().id())
+            && let Some(limit) = stats.id_map_limit
+        {
+            return limit;
+        }
+    }
+    SALVAGE_ID_MAP_MAX_ENTRIES
+}
+
+fn salvage_page_value_byte_limit() -> i64 {
+    #[cfg(test)]
+    {
+        let stats = SALVAGE_PAGE_TEST_STATS
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if stats.owner == Some(std::thread::current().id())
+            && let Some(limit) = stats.page_value_byte_limit
+        {
+            return limit;
+        }
+    }
+    SALVAGE_MAX_PAGE_VALUE_BYTES
+}
+
+#[cfg(test)]
+fn observe_salvage_page(table: &str, rows: usize) {
+    let mut stats = SALVAGE_PAGE_TEST_STATS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if stats.owner == Some(std::thread::current().id()) && table == "agents" {
+        stats.agent_pages += 1;
+        stats.agent_max_page_rows = stats.agent_max_page_rows.max(rows);
+    }
+}
+
+#[cfg(not(test))]
+fn observe_salvage_page(_table: &str, _rows: usize) {}
+
+#[cfg(test)]
+fn observe_salvage_row(table: &str) {
+    let mut stats = SALVAGE_PAGE_TEST_STATS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if stats.owner == Some(std::thread::current().id()) && table == "agents" {
+        stats.agent_rows += 1;
+    }
+}
+
+#[cfg(not(test))]
+fn observe_salvage_row(_table: &str) {}
+
 fn is_real_directory(path: &Path) -> bool {
     std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_dir())
 }
@@ -99,6 +234,7 @@ fn is_real_file(path: &Path) -> bool {
 }
 
 const DUPLICATE_CANONICAL_WARNING_SAMPLE_LIMIT: usize = 5;
+const RECONSTRUCT_WARNING_MAX_ENTRIES: usize = 512;
 const MALFORMED_ATTACHMENTS_SENTINEL: &str = "[malformed-attachments-json]";
 const MALFORMED_RECIPIENTS_SENTINEL: &str = "[malformed-recipients-json]";
 const VALID_RECONSTRUCTED_ATTACHMENTS_POLICIES: &[&str] = &["auto", "inline", "file", "none"];
@@ -476,13 +612,23 @@ impl ArchiveMessageInventory {
 }
 
 impl ReconstructStats {
+    fn push_warning(&mut self, warning: String) {
+        if self.warnings.len() < RECONSTRUCT_WARNING_MAX_ENTRIES {
+            self.warnings.push(warning);
+        } else if self.warnings.len() == RECONSTRUCT_WARNING_MAX_ENTRIES {
+            self.warnings.push(format!(
+                "Additional reconstruction warnings omitted after the hard cap of {RECONSTRUCT_WARNING_MAX_ENTRIES} entries"
+            ));
+        }
+    }
+
     fn record_duplicate_canonical_message(&mut self, message_id: i64, file_path: &Path) {
         self.duplicate_canonical_message_files += 1;
         if self.duplicate_canonical_id_set.insert(message_id) {
             self.duplicate_canonical_message_ids += 1;
         }
         if self.duplicate_canonical_message_files <= DUPLICATE_CANONICAL_WARNING_SAMPLE_LIMIT {
-            self.warnings.push(format!(
+            self.push_warning(format!(
                 "Duplicate canonical message id {message_id} in {}; keeping the first archive artifact and skipping the duplicate",
                 file_path.display()
             ));
@@ -498,7 +644,7 @@ impl ReconstructStats {
     ) {
         self.cross_project_canonical_collisions += 1;
         if self.cross_project_canonical_collisions <= DUPLICATE_CANONICAL_WARNING_SAMPLE_LIMIT {
-            self.warnings.push(format!(
+            self.push_warning(format!(
                 "Cross-project canonical message id {message_id} collision in {}: \
                  existing message belongs to project_id {existing_project_id}, \
                  new archive artifact belongs to project_id {new_project_id}; \
@@ -520,7 +666,7 @@ impl ReconstructStats {
             .map(std::string::ToString::to_string)
             .collect::<Vec<_>>()
             .join(", ");
-        self.warnings.push(format!(
+        self.push_warning(format!(
             "Skipped {} duplicate canonical message file(s) across {} logical message id(s); sample ids: {}",
             self.duplicate_canonical_message_files,
             self.duplicate_canonical_message_ids,
@@ -532,7 +678,7 @@ impl ReconstructStats {
         if self.cross_project_canonical_collisions <= DUPLICATE_CANONICAL_WARNING_SAMPLE_LIMIT {
             return;
         }
-        self.warnings.push(format!(
+        self.push_warning(format!(
             "Preserved {} cross-project canonical id collision(s) under generated DB ids; only the first {} were itemized in warnings above",
             self.cross_project_canonical_collisions,
             DUPLICATE_CANONICAL_WARNING_SAMPLE_LIMIT
@@ -1117,24 +1263,31 @@ pub fn collect_db_project_identities(
 /// Scan canonical archive message files without writing to SQLite.
 #[must_use]
 pub fn scan_archive_message_inventory(storage_root: &Path) -> ArchiveMessageInventory {
+    scan_archive_message_inventory_cancellable(storage_root, &|| false).unwrap_or_default()
+}
+
+/// Cancellation-aware archive inventory scan for bounded snapshot workers.
+pub fn scan_archive_message_inventory_cancellable(
+    storage_root: &Path,
+    cancelled: &dyn Fn() -> bool,
+) -> DbResult<ArchiveMessageInventory> {
+    ensure_reconstruction_not_cancelled(cancelled)?;
     let mut inventory = ArchiveMessageInventory::default();
     let projects_dir = storage_root.join("projects");
-    if !is_real_directory(&projects_dir) {
-        return inventory;
+    if !inventory_path_is_real_directory(&projects_dir)? {
+        return Ok(inventory);
     }
 
-    let Ok(project_entries) = std::fs::read_dir(&projects_dir) else {
-        return inventory;
-    };
+    let project_entries = inventory_read_dir(&projects_dir)?;
 
     let mut seen_ids = BTreeSet::new();
     let mut duplicate_ids = BTreeSet::new();
 
-    for entry in project_entries.flatten() {
+    for entry in project_entries {
+        ensure_reconstruction_not_cancelled(cancelled)?;
+        let entry = inventory_dir_entry(entry, &projects_dir)?;
         let path = entry.path();
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
+        let file_type = inventory_entry_file_type(&entry)?;
         if !file_type.is_dir() || file_type.is_symlink() {
             continue;
         }
@@ -1142,17 +1295,63 @@ pub fn scan_archive_message_inventory(storage_root: &Path) -> ArchiveMessageInve
         if let Some(identity) = scan_archive_project_identity(&path) {
             inventory.project_identities.insert(identity);
         }
-        inventory.agents += count_project_archive_agents(&path);
+        inventory.agents += count_project_archive_agents(&path, cancelled)?;
         scan_project_archive_message_inventory(
             &path.join("messages"),
             &mut inventory,
             &mut seen_ids,
             &mut duplicate_ids,
-        );
+            cancelled,
+        )?;
     }
 
     inventory.duplicate_canonical_message_ids = duplicate_ids.len();
-    inventory
+    Ok(inventory)
+}
+
+fn inventory_io_error(operation: &str, path: &Path, error: std::io::Error) -> DbError {
+    DbError::Sqlite(format!(
+        "archive inventory: {operation} {}: {error}",
+        path.display()
+    ))
+}
+
+fn inventory_path_is_real_directory(path: &Path) -> DbResult<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_dir()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(inventory_io_error("inspect directory", path, error)),
+    }
+}
+
+fn inventory_path_is_real_file(path: &Path) -> DbResult<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_file()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(inventory_io_error("inspect file", path, error)),
+    }
+}
+
+fn inventory_read_dir(path: &Path) -> DbResult<std::fs::ReadDir> {
+    std::fs::read_dir(path).map_err(|error| inventory_io_error("read directory", path, error))
+}
+
+fn inventory_dir_entry(
+    entry: std::io::Result<std::fs::DirEntry>,
+    parent: &Path,
+) -> DbResult<std::fs::DirEntry> {
+    entry.map_err(|error| inventory_io_error("read directory entry under", parent, error))
+}
+
+fn inventory_entry_file_type(entry: &std::fs::DirEntry) -> DbResult<std::fs::FileType> {
+    inventory_file_type_result(entry.file_type(), &entry.path())
+}
+
+fn inventory_file_type_result(
+    file_type: std::io::Result<std::fs::FileType>,
+    path: &Path,
+) -> DbResult<std::fs::FileType> {
+    file_type.map_err(|error| inventory_io_error("inspect directory entry", path, error))
 }
 
 fn scan_archive_project_identity(project_path: &Path) -> Option<MailboxProjectIdentity> {
@@ -1180,28 +1379,30 @@ fn scan_archive_project_identity(project_path: &Path) -> Option<MailboxProjectId
     MailboxProjectIdentity::from_parts(fallback_slug, None, None)
 }
 
-fn count_project_archive_agents(project_dir: &Path) -> usize {
+fn count_project_archive_agents(
+    project_dir: &Path,
+    cancelled: &dyn Fn() -> bool,
+) -> DbResult<usize> {
     let agents_dir = project_dir.join("agents");
-    if !is_real_directory(&agents_dir) {
-        return 0;
+    if !inventory_path_is_real_directory(&agents_dir)? {
+        return Ok(0);
     }
 
-    let Ok(agent_entries) = std::fs::read_dir(&agents_dir) else {
-        return 0;
-    };
+    let agent_entries = inventory_read_dir(&agents_dir)?;
 
-    agent_entries
-        .flatten()
-        .filter_map(|entry| {
-            let Ok(file_type) = entry.file_type() else {
-                return None;
-            };
-            if !file_type.is_dir() || file_type.is_symlink() {
-                return None;
-            }
-            is_real_file(&entry.path().join("profile.json")).then_some(())
-        })
-        .count()
+    let mut count = 0;
+    for entry in agent_entries {
+        ensure_reconstruction_not_cancelled(cancelled)?;
+        let entry = inventory_dir_entry(entry, &agents_dir)?;
+        let file_type = inventory_entry_file_type(&entry)?;
+        if file_type.is_dir()
+            && !file_type.is_symlink()
+            && inventory_path_is_real_file(&entry.path().join("profile.json"))?
+        {
+            count += 1;
+        }
+    }
+    Ok(count)
 }
 
 fn scan_project_archive_message_inventory(
@@ -1209,20 +1410,20 @@ fn scan_project_archive_message_inventory(
     inventory: &mut ArchiveMessageInventory,
     seen_ids: &mut BTreeSet<i64>,
     duplicate_ids: &mut BTreeSet<i64>,
-) {
-    if !is_real_directory(messages_dir) {
-        return;
+    cancelled: &dyn Fn() -> bool,
+) -> DbResult<()> {
+    ensure_reconstruction_not_cancelled(cancelled)?;
+    if !inventory_path_is_real_directory(messages_dir)? {
+        return Ok(());
     }
 
-    let Ok(year_entries) = std::fs::read_dir(messages_dir) else {
-        return;
-    };
+    let year_entries = inventory_read_dir(messages_dir)?;
 
-    for year_entry in year_entries.flatten() {
+    for year_entry in year_entries {
+        ensure_reconstruction_not_cancelled(cancelled)?;
+        let year_entry = inventory_dir_entry(year_entry, messages_dir)?;
         let year_path = year_entry.path();
-        let Ok(year_type) = year_entry.file_type() else {
-            continue;
-        };
+        let year_type = inventory_entry_file_type(&year_entry)?;
         if !year_type.is_dir() || year_type.is_symlink() {
             continue;
         }
@@ -1233,14 +1434,12 @@ fn scan_project_archive_message_inventory(
             continue;
         }
 
-        let Ok(month_entries) = std::fs::read_dir(&year_path) else {
-            continue;
-        };
-        for month_entry in month_entries.flatten() {
+        let month_entries = inventory_read_dir(&year_path)?;
+        for month_entry in month_entries {
+            ensure_reconstruction_not_cancelled(cancelled)?;
+            let month_entry = inventory_dir_entry(month_entry, &year_path)?;
             let month_path = month_entry.path();
-            let Ok(month_type) = month_entry.file_type() else {
-                continue;
-            };
+            let month_type = inventory_entry_file_type(&month_entry)?;
             if !month_type.is_dir() || month_type.is_symlink() {
                 continue;
             }
@@ -1251,14 +1450,12 @@ fn scan_project_archive_message_inventory(
                 continue;
             }
 
-            let Ok(file_entries) = std::fs::read_dir(&month_path) else {
-                continue;
-            };
-            for file_entry in file_entries.flatten() {
+            let file_entries = inventory_read_dir(&month_path)?;
+            for file_entry in file_entries {
+                ensure_reconstruction_not_cancelled(cancelled)?;
+                let file_entry = inventory_dir_entry(file_entry, &month_path)?;
                 let file_path = file_entry.path();
-                let Ok(file_type) = file_entry.file_type() else {
-                    continue;
-                };
+                let file_type = inventory_entry_file_type(&file_entry)?;
                 if !file_type.is_file()
                     || file_type.is_symlink()
                     || file_path.extension().is_none_or(|ext| ext != "md")
@@ -1281,6 +1478,7 @@ fn scan_project_archive_message_inventory(
             }
         }
     }
+    Ok(())
 }
 
 fn scan_archive_message_id(file_path: &Path) -> DbResult<Option<i64>> {
@@ -1309,7 +1507,32 @@ fn scan_archive_message_id(file_path: &Path) -> DbResult<Option<i64>> {
 /// fails. Individual archive files that fail to parse are skipped (counted
 /// in `parse_errors`).
 pub fn reconstruct_from_archive(db_path: &Path, storage_root: &Path) -> DbResult<ReconstructStats> {
-    reconstruct_from_archive_impl(db_path, storage_root, false)
+    reconstruct_from_archive_cancellable(db_path, storage_root, &|| false)
+}
+
+const RECONSTRUCTION_CANCELLED_DETAIL: &str = "archive snapshot reconstruction cancelled";
+
+fn ensure_reconstruction_not_cancelled(cancelled: &dyn Fn() -> bool) -> DbResult<()> {
+    if cancelled() {
+        Err(DbError::ResourceBusy(
+            RECONSTRUCTION_CANCELLED_DETAIL.to_string(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Reconstruct the database from the Git archive with cooperative cancellation.
+///
+/// The callback is checked between archive artifacts and salvage rows. A
+/// cancelled build rolls back its current transaction and leaves the fresh
+/// candidate isolated from the live database.
+pub fn reconstruct_from_archive_cancellable(
+    db_path: &Path,
+    storage_root: &Path,
+    cancelled: &dyn Fn() -> bool,
+) -> DbResult<ReconstructStats> {
+    reconstruct_from_archive_impl(db_path, storage_root, false, cancelled)
 }
 
 fn ensure_unoccupied_reconstruction_target_family(db_path: &Path) -> DbResult<()> {
@@ -1373,7 +1596,9 @@ fn reconstruct_from_archive_impl(
     db_path: &Path,
     storage_root: &Path,
     create_empty_target: bool,
+    cancelled: &dyn Fn() -> bool,
 ) -> DbResult<ReconstructStats> {
+    ensure_reconstruction_not_cancelled(cancelled)?;
     let mut stats = ReconstructStats::default();
     crate::pool::validate_sqlite_target_path(db_path, "reconstruct sqlite target")
         .map_err(|error| DbError::Sqlite(format!("reconstruct: {error}")))?;
@@ -1384,6 +1609,7 @@ fn reconstruct_from_archive_impl(
         if is_real_directory(&projects_dir) {
             if let Ok(entries) = std::fs::read_dir(&projects_dir) {
                 for entry in entries.flatten() {
+                    ensure_reconstruction_not_cancelled(cancelled)?;
                     let path = entry.path();
                     let Ok(file_type) = entry.file_type() else {
                         continue;
@@ -1399,7 +1625,7 @@ fn reconstruct_from_archive_impl(
                 }
             }
         } else {
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "No projects directory found at {}",
                 projects_dir.display()
             ));
@@ -1408,7 +1634,7 @@ fn reconstruct_from_archive_impl(
             }
         }
     } else {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Storage root {} is missing or not a real directory",
             storage_root.display()
         ));
@@ -1418,7 +1644,7 @@ fn reconstruct_from_archive_impl(
     }
     project_dirs.sort_by(|a, b| a.0.cmp(&b.0));
     if project_dirs.is_empty() {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "No project archives found under {}",
             projects_dir.display()
         ));
@@ -1516,6 +1742,7 @@ fn reconstruct_from_archive_impl(
 
         // Phase 1: Replay projects discovered before opening the target DB.
         for (slug, project_path) in &project_dirs {
+            ensure_reconstruction_not_cancelled(cancelled)?;
             let now = crate::now_micros();
             let human_key = read_project_human_key(project_path, slug, &mut stats);
 
@@ -1535,7 +1762,14 @@ fn reconstruct_from_archive_impl(
             // Phase 2: Discover agents for this project
             let agents_dir = project_path.join("agents");
             if is_real_directory(&agents_dir) {
-                discover_agents(&conn, &agents_dir, pid, &mut agent_ids, &mut stats)?;
+                discover_agents(
+                    &conn,
+                    &agents_dir,
+                    pid,
+                    &mut agent_ids,
+                    &mut stats,
+                    cancelled,
+                )?;
             }
 
             // Phase 2b: Recover archived file reservations so robot/status reads can
@@ -1548,13 +1782,22 @@ fn reconstruct_from_archive_impl(
                     pid,
                     &mut agent_ids,
                     &mut stats,
+                    cancelled,
                 )?;
             }
 
             // Phase 3: Discover messages for this project
             let messages_dir = project_path.join("messages");
             if is_real_directory(&messages_dir) {
-                discover_messages(&conn, &messages_dir, pid, slug, &mut agent_ids, &mut stats)?;
+                discover_messages(
+                    &conn,
+                    &messages_dir,
+                    pid,
+                    slug,
+                    &mut agent_ids,
+                    &mut stats,
+                    cancelled,
+                )?;
             }
         }
 
@@ -1566,12 +1809,10 @@ fn reconstruct_from_archive_impl(
         // the archive). Reconstruct intentionally also leaves FTS-backed message
         // trigger follow-ups to the next live startup.
 
-        // Rebuild all index b-trees to ensure consistency after bulk inserts.
-        conn.execute_raw("REINDEX;")
-            .map_err(|e| DbError::Sqlite(format!("reconstruct: REINDEX: {e}")))?;
-
+        ensure_reconstruction_not_cancelled(cancelled)?;
         conn.execute_raw(&schema::schema_user_version_sql())
             .map_err(|e| DbError::Sqlite(format!("reconstruct: set user_version: {e}")))?;
+        ensure_reconstruction_not_cancelled(cancelled)?;
         Ok(())
     })();
 
@@ -1610,6 +1851,23 @@ pub fn reconstruct_from_archive_with_salvage(
     storage_root: &Path,
     salvage_db_path: Option<&Path>,
 ) -> DbResult<ReconstructStats> {
+    reconstruct_from_archive_with_salvage_cancellable(
+        db_path,
+        storage_root,
+        salvage_db_path,
+        &|| false,
+    )
+}
+
+/// Reconstruct from the archive and merge salvage state with cooperative
+/// cancellation between artifacts and rows.
+pub fn reconstruct_from_archive_with_salvage_cancellable(
+    db_path: &Path,
+    storage_root: &Path,
+    salvage_db_path: Option<&Path>,
+    cancelled: &dyn Fn() -> bool,
+) -> DbResult<ReconstructStats> {
+    ensure_reconstruction_not_cancelled(cancelled)?;
     if let Some(salvage_db_path) = salvage_db_path {
         probe_salvage_database_for_merge(salvage_db_path).map_err(|error| {
             DbError::Sqlite(format!(
@@ -1620,14 +1878,22 @@ pub fn reconstruct_from_archive_with_salvage(
     }
 
     let mut stats =
-        reconstruct_from_archive_impl(db_path, storage_root, salvage_db_path.is_some())?;
+        reconstruct_from_archive_impl(db_path, storage_root, salvage_db_path.is_some(), cancelled)?;
+    ensure_reconstruction_not_cancelled(cancelled)?;
     if let Some(salvage_db_path) = salvage_db_path {
-        merge_salvaged_database(db_path, salvage_db_path, &mut stats).map_err(|error| {
-            DbError::Sqlite(format!(
-                "reconstruct salvage merge from {} failed; refusing to promote the archive-only candidate because DB-only coordination state could be lost: {error}",
-                salvage_db_path.display()
-            ))
-        })?;
+        merge_salvaged_database(db_path, salvage_db_path, &mut stats, cancelled).map_err(
+            |error| match error {
+                DbError::ResourceBusy(ref detail)
+                    if detail == RECONSTRUCTION_CANCELLED_DETAIL =>
+                {
+                    error
+                }
+                _ => DbError::Sqlite(format!(
+                    "reconstruct salvage merge from {} failed; refusing to promote the archive-only candidate because DB-only coordination state could be lost: {error}",
+                    salvage_db_path.display()
+                )),
+            },
+        )?;
     }
     Ok(stats)
 }
@@ -1668,12 +1934,14 @@ fn discover_agents(
     project_id: i64,
     agent_ids: &mut HashMap<(i64, String), i64>,
     stats: &mut ReconstructStats,
+    cancelled: &dyn Fn() -> bool,
 ) -> DbResult<()> {
     let Ok(entries) = std::fs::read_dir(agents_dir) else {
         return Ok(());
     };
 
     for entry in entries.flatten() {
+        ensure_reconstruction_not_cancelled(cancelled)?;
         let path = entry.path();
         let Ok(file_type) = entry.file_type() else {
             continue;
@@ -1690,14 +1958,14 @@ fn discover_agents(
         };
         let Some(agent_name) = normalized_archive_agent_name(Some(&raw_agent_name)) else {
             stats.parse_errors += 1;
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Archive agent directory {} has empty/invalid name; skipping profile",
                 path.display()
             ));
             continue;
         };
         if agent_name != raw_agent_name {
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Archive agent directory {} has non-canonical name {raw_agent_name:?}; normalizing to {agent_name:?}",
                 path.display()
             ));
@@ -1711,9 +1979,7 @@ fn discover_agents(
             Ok(d) => d,
             Err(e) => {
                 stats.parse_errors += 1;
-                stats
-                    .warnings
-                    .push(format!("Cannot read {}: {e}", profile_path.display()));
+                stats.push_warning(format!("Cannot read {}: {e}", profile_path.display()));
                 continue;
             }
         };
@@ -1722,9 +1988,7 @@ fn discover_agents(
             Ok(v) => v,
             Err(e) => {
                 stats.parse_errors += 1;
-                stats
-                    .warnings
-                    .push(format!("Cannot parse {}: {e}", profile_path.display()));
+                stats.push_warning(format!("Cannot parse {}: {e}", profile_path.display()));
                 continue;
             }
         };
@@ -1733,7 +1997,7 @@ fn discover_agents(
         let agent_name = match profile_name {
             Some(profile_name) => {
                 if profile_name != agent_name {
-                    stats.warnings.push(format!(
+                    stats.push_warning(format!(
                         "Archive agent profile {} has name {profile_name:?} that disagrees with directory name {raw_agent_name:?}; using profile name",
                         profile_path.display()
                     ));
@@ -1821,6 +2085,7 @@ fn discover_messages(
     project_slug: &str,
     agent_ids: &mut HashMap<(i64, String), i64>,
     stats: &mut ReconstructStats,
+    cancelled: &dyn Fn() -> bool,
 ) -> DbResult<()> {
     // Walk year directories
     let Ok(years) = std::fs::read_dir(messages_dir) else {
@@ -1830,6 +2095,7 @@ fn discover_messages(
     let mut message_files: Vec<PathBuf> = Vec::new();
 
     for year_entry in years.flatten() {
+        ensure_reconstruction_not_cancelled(cancelled)?;
         let year_path = year_entry.path();
         let Ok(year_type) = year_entry.file_type() else {
             continue;
@@ -1842,6 +2108,7 @@ fn discover_messages(
             continue;
         };
         for month_entry in months.flatten() {
+            ensure_reconstruction_not_cancelled(cancelled)?;
             let month_path = month_entry.path();
             let Ok(month_type) = month_entry.file_type() else {
                 continue;
@@ -1854,6 +2121,7 @@ fn discover_messages(
                 continue;
             };
             for file_entry in files.flatten() {
+                ensure_reconstruction_not_cancelled(cancelled)?;
                 let file_path = file_entry.path();
                 let Ok(file_type) = file_entry.file_type() else {
                     continue;
@@ -1872,6 +2140,7 @@ fn discover_messages(
     message_files.sort();
 
     for file_path in &message_files {
+        ensure_reconstruction_not_cancelled(cancelled)?;
         match parse_and_insert_message(conn, file_path, project_id, project_slug, agent_ids, stats)
         {
             Ok(()) => {}
@@ -1882,7 +2151,7 @@ fn discover_messages(
                     return Err(e);
                 }
                 stats.parse_errors += 1;
-                stats.warnings.push(format!(
+                stats.push_warning(format!(
                     "Failed to reconstruct message from {}: {e}",
                     file_path.display()
                 ));
@@ -1994,7 +2263,7 @@ fn parse_and_insert_message(
     let thread_id = raw_thread_id.and_then(|raw| {
         let normalized = sanitize_reconstructed_thread_id(raw);
         if normalized.as_deref() != Some(raw) {
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Sanitized invalid thread_id {:?} in {} during reconstruction",
                 raw,
                 file_path.display()
@@ -2085,6 +2354,12 @@ fn ensure_agent_exists(
         return Ok(id);
     }
 
+    let aid = ensure_agent_exists_uncached(conn, project_id, name)?;
+    agent_ids.insert(key, aid);
+    Ok(aid)
+}
+
+fn ensure_agent_exists_uncached(conn: &DbConn, project_id: i64, name: &str) -> DbResult<i64> {
     let now = crate::now_micros();
     conn.execute_sync(
         "INSERT OR IGNORE INTO agents \
@@ -2099,16 +2374,14 @@ fn ensure_agent_exists(
     )
     .map_err(|e| DbError::Sqlite(format!("ensure agent {name}: {e}")))?;
 
-    let aid = query_last_insert_or_existing_id_composite(
+    query_last_insert_or_existing_id_composite(
         conn,
         "agents",
         "project_id",
         project_id,
         "name",
         name,
-    )?;
-    agent_ids.insert(key, aid);
-    Ok(aid)
+    )
 }
 
 fn insert_recipient(conn: &DbConn, message_id: i64, agent_id: i64, kind: &str) -> DbResult<()> {
@@ -2150,7 +2423,7 @@ fn normalize_salvaged_recipient_kind(
         "cc" => "cc".to_string(),
         "bcc" => "bcc".to_string(),
         _ => {
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Salvage recipient for message {message_id} had invalid kind {trimmed:?}; defaulting to \"to\""
             ));
             "to".to_string()
@@ -2179,7 +2452,7 @@ fn normalize_archive_attachments_json(
             serde_json::Value::Array(values.clone()).to_string()
         }
         Some(_) => {
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Archive message {message_label} has non-array attachments payload; preserving malformed attachment metadata sentinel"
             ));
             malformed_attachments_json()
@@ -2193,7 +2466,7 @@ fn normalize_archive_recipients_json(
     stats: &mut ReconstructStats,
 ) -> (String, Vec<String>, Vec<String>, Vec<String>) {
     if !reconstructed_recipients_payload_is_valid(msg) {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Archive message {message_label} has non-canonical recipient payload; preserving malformed recipient metadata sentinel"
         ));
         return (
@@ -2227,13 +2500,13 @@ fn parse_salvaged_attachments_json(
     match serde_json::from_str::<serde_json::Value>(&attachments_json) {
         Ok(serde_json::Value::Array(values)) => serde_json::Value::Array(values).to_string(),
         Ok(_) => {
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Salvage message {message_id} has non-array attachments payload; preserving malformed attachment metadata sentinel"
             ));
             malformed_attachments_json()
         }
         Err(err) => {
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Salvage message {message_id} has invalid attachments payload; preserving malformed attachment metadata sentinel: {err}"
             ));
             malformed_attachments_json()
@@ -2268,14 +2541,14 @@ fn parse_salvaged_recipients_json(
     let parsed: serde_json::Value = match serde_json::from_str(&recipients_json) {
         Ok(parsed) => parsed,
         Err(err) => {
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Salvage message {message_id} has invalid recipients_json; preserving malformed recipient metadata sentinel: {err}"
             ));
             return malformed();
         }
     };
     if !reconstructed_recipients_payload_is_valid(&parsed) {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Salvage message {message_id} has non-canonical recipients_json; preserving malformed recipient metadata sentinel"
         ));
         return malformed();
@@ -2293,6 +2566,40 @@ fn parse_salvaged_recipients_json(
 }
 
 fn sync_reconstructed_message_recipients_json(conn: &DbConn, message_id: i64) -> DbResult<()> {
+    let bounds = conn
+        .query_sync(
+            "SELECT COUNT(*) AS row_count, \
+                    COALESCE(SUM(\
+                        length(CAST(CASE WHEN a.id IS NULL THEN '[unknown-agent-' || mr.agent_id || ']' ELSE TRIM(a.name) END AS BLOB)) + \
+                        length(CAST(mr.kind AS BLOB))\
+                    ), 0) AS value_bytes \
+             FROM message_recipients mr \
+             LEFT JOIN agents a ON a.id = mr.agent_id \
+             WHERE mr.message_id = ?",
+            &[Value::BigInt(message_id)],
+        )
+        .map_err(|e| {
+            DbError::Sqlite(format!(
+                "reconstruct salvage: bound recipients_json rows for message {message_id}: {e}"
+            ))
+        })?;
+    let row_count = bounds[0].get_named::<i64>("row_count").map_err(|e| {
+        DbError::Sqlite(format!(
+            "reconstruct salvage: decode recipient row bound for message {message_id}: {e}"
+        ))
+    })?;
+    let value_bytes = bounds[0].get_named::<i64>("value_bytes").map_err(|e| {
+        DbError::Sqlite(format!(
+            "reconstruct salvage: decode recipient byte bound for message {message_id}: {e}"
+        ))
+    })?;
+    if row_count > RECONSTRUCT_RECIPIENT_ROWS_PER_MESSAGE_MAX
+        || value_bytes > SALVAGE_MAX_VARIABLE_VALUE_BYTES
+    {
+        return Err(DbError::Sqlite(format!(
+            "reconstruct salvage: message {message_id} has {row_count} recipient rows and {value_bytes} bytes of recipient values; caps are {RECONSTRUCT_RECIPIENT_ROWS_PER_MESSAGE_MAX} rows and {SALVAGE_MAX_VARIABLE_VALUE_BYTES} bytes"
+        )));
+    }
     let rows = conn
         .query_sync(
             "SELECT CASE WHEN a.id IS NULL THEN '[unknown-agent-' || mr.agent_id || ']' ELSE TRIM(a.name) END AS name, \
@@ -2391,7 +2698,7 @@ fn parse_archived_file_reservation(
         Ok(data) => data,
         Err(e) => {
             stats.parse_errors += 1;
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Cannot read reservation artifact {}: {e}",
                 file_path.display()
             ));
@@ -2403,7 +2710,7 @@ fn parse_archived_file_reservation(
         Ok(value) => value,
         Err(e) => {
             stats.parse_errors += 1;
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Cannot parse reservation artifact {}: {e}",
                 file_path.display()
             ));
@@ -2418,7 +2725,7 @@ fn parse_archived_file_reservation(
         .map(str::to_string)
     else {
         stats.parse_errors += 1;
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Reservation artifact {} is missing path_pattern/path",
             file_path.display()
         ));
@@ -2518,8 +2825,10 @@ fn discover_file_reservations(
     project_id: i64,
     agent_ids: &mut HashMap<(i64, String), i64>,
     stats: &mut ReconstructStats,
+    cancelled: &dyn Fn() -> bool,
 ) -> DbResult<()> {
     for file_path in reservation_artifact_paths(reservations_dir) {
+        ensure_reconstruction_not_cancelled(cancelled)?;
         let Some(reservation) = parse_archived_file_reservation(&file_path, stats) else {
             continue;
         };
@@ -2608,6 +2917,162 @@ fn table_columns(conn: &DbConn, table: &str) -> DbResult<HashSet<String>> {
     Ok(columns)
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SalvageStorageContract {
+    Text,
+    PositiveInteger,
+    NonNegativeInteger,
+    BooleanInteger,
+}
+
+impl SalvageStorageContract {
+    fn sql_predicate(self, column: &str) -> String {
+        match self {
+            Self::Text => format!("typeof({column}) = 'text'"),
+            Self::PositiveInteger => {
+                format!("typeof({column}) = 'integer' AND {column} > 0")
+            }
+            Self::NonNegativeInteger => {
+                format!("typeof({column}) = 'integer' AND {column} >= 0")
+            }
+            Self::BooleanInteger => {
+                format!("typeof({column}) = 'integer' AND {column} IN (0, 1)")
+            }
+        }
+    }
+
+    const fn description(self) -> &'static str {
+        match self {
+            Self::Text => "non-NULL TEXT",
+            Self::PositiveInteger => "positive INTEGER",
+            Self::NonNegativeInteger => "non-negative INTEGER",
+            Self::BooleanInteger => "INTEGER boolean in {0,1}",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SalvageProjectedColumn {
+    name: String,
+    storage: SalvageStorageContract,
+    nullable: bool,
+}
+
+impl SalvageProjectedColumn {
+    fn sql_predicate(&self) -> String {
+        let expected = self.storage.sql_predicate(&self.name);
+        if self.nullable {
+            format!("({} IS NULL OR ({expected}))", self.name)
+        } else {
+            format!("({expected})")
+        }
+    }
+
+    fn expected_description(&self) -> String {
+        if self.nullable {
+            format!("NULL or {}", self.storage.description())
+        } else {
+            self.storage.description().to_string()
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SalvageProjection {
+    select_sql: String,
+    columns: Vec<SalvageProjectedColumn>,
+}
+
+fn salvage_storage_contract(table: &str, column: &str) -> Option<SalvageStorageContract> {
+    use SalvageStorageContract::{BooleanInteger, NonNegativeInteger, PositiveInteger, Text};
+    match (table, column) {
+        ("projects", "id") => Some(PositiveInteger),
+        ("projects", "slug" | "human_key") => Some(Text),
+        ("projects", "created_at") => Some(NonNegativeInteger),
+
+        ("agents", "id" | "project_id") => Some(PositiveInteger),
+        (
+            "agents",
+            "name" | "program" | "model" | "task_description" | "attachments_policy"
+            | "contact_policy" | "registration_token",
+        ) => Some(Text),
+        ("agents", "inception_ts" | "last_active_ts") => Some(NonNegativeInteger),
+        ("agents", "reaper_exempt") => Some(BooleanInteger),
+
+        ("file_reservations", "id" | "project_id" | "agent_id") => Some(PositiveInteger),
+        ("file_reservations", "path_pattern" | "reason") => Some(Text),
+        ("file_reservations", "exclusive") => Some(BooleanInteger),
+        ("file_reservations", "created_ts" | "expires_ts" | "released_ts") => {
+            Some(NonNegativeInteger)
+        }
+
+        ("file_reservation_releases", "reservation_id") => Some(PositiveInteger),
+        ("file_reservation_releases", "released_ts") => Some(NonNegativeInteger),
+
+        ("agent_links", "a_project_id" | "a_agent_id" | "b_project_id" | "b_agent_id") => {
+            Some(PositiveInteger)
+        }
+        ("agent_links", "status" | "reason") => Some(Text),
+        ("agent_links", "created_ts" | "updated_ts" | "expires_ts") => Some(NonNegativeInteger),
+
+        ("products", "id") => Some(PositiveInteger),
+        ("products", "product_uid" | "name") => Some(Text),
+        ("products", "created_at") => Some(NonNegativeInteger),
+
+        ("product_project_links", "product_id" | "project_id") => Some(PositiveInteger),
+        ("product_project_links", "created_at") => Some(NonNegativeInteger),
+
+        ("proof_gate_consumed_nonces", "issuer_key" | "nonce") => Some(Text),
+        ("proof_gate_consumed_nonces", "retain_until" | "consumed_at") => Some(NonNegativeInteger),
+
+        ("messages", "id" | "project_id" | "sender_id") => Some(PositiveInteger),
+        (
+            "messages",
+            "thread_id" | "subject" | "body_md" | "importance" | "recipients_json" | "attachments",
+        ) => Some(Text),
+        ("messages", "ack_required") => Some(BooleanInteger),
+        ("messages", "created_ts") => Some(NonNegativeInteger),
+
+        ("message_recipients", "message_id" | "agent_id") => Some(PositiveInteger),
+        ("message_recipients", "kind") => Some(Text),
+        ("message_recipients", "read_ts" | "ack_ts") => Some(NonNegativeInteger),
+        _ => None,
+    }
+}
+
+fn build_salvage_projection(
+    table: &str,
+    select_sql: String,
+    required: &[&str],
+    optional_present: &[&str],
+    stats: &mut ReconstructStats,
+    salvage_db_path: &Path,
+) -> Option<SalvageProjection> {
+    let mut projected = Vec::with_capacity(required.len() + optional_present.len());
+    for (name, nullable) in required
+        .iter()
+        .map(|name| (*name, false))
+        .chain(optional_present.iter().map(|name| (*name, true)))
+    {
+        let Some(storage) = salvage_storage_contract(table, name) else {
+            stats.push_warning(format!(
+                "Salvage database {} table {table} selected column {name} without a pre-materialization storage contract",
+                salvage_db_path.display()
+            ));
+            return None;
+        };
+        projected.push(SalvageProjectedColumn {
+            name: name.to_string(),
+            storage,
+            nullable,
+        });
+    }
+    Some(SalvageProjection {
+        select_sql,
+        columns: projected,
+    })
+}
+
 fn build_salvage_select(
     table: &str,
     columns: &HashSet<String>,
@@ -2615,14 +3080,14 @@ fn build_salvage_select(
     optional: &[&str],
     stats: &mut ReconstructStats,
     salvage_db_path: &Path,
-) -> Option<String> {
+) -> Option<SalvageProjection> {
     let missing_required: Vec<&str> = required
         .iter()
         .copied()
         .filter(|column| !columns.contains(*column))
         .collect();
     if !missing_required.is_empty() {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Salvage database {} table {table} missing required column(s): {}",
             salvage_db_path.display(),
             missing_required.join(", ")
@@ -2634,21 +3099,27 @@ fn build_salvage_select(
         .iter()
         .map(|column| (*column).to_string())
         .collect::<Vec<_>>();
-    selected.extend(
-        optional
-            .iter()
-            .copied()
-            .filter(|column| columns.contains(*column))
-            .map(str::to_string),
-    );
-    Some(selected.join(", "))
+    let optional_present = optional
+        .iter()
+        .copied()
+        .filter(|column| columns.contains(*column))
+        .collect::<Vec<_>>();
+    selected.extend(optional_present.iter().map(|column| (*column).to_string()));
+    build_salvage_projection(
+        table,
+        selected.join(", "),
+        required,
+        &optional_present,
+        stats,
+        salvage_db_path,
+    )
 }
 
 fn build_salvage_agent_links_select(
     columns: &HashSet<String>,
     stats: &mut ReconstructStats,
     salvage_db_path: &Path,
-) -> Option<String> {
+) -> Option<SalvageProjection> {
     const CURRENT_REQUIRED: [&str; 4] =
         ["a_project_id", "a_agent_id", "b_project_id", "b_agent_id"];
     const LEGACY_REQUIRED: [&str; 3] = ["project_id", "from_agent_id", "to_agent_id"];
@@ -2678,14 +3149,20 @@ fn build_salvage_agent_links_select(
             "project_id AS b_project_id".to_string(),
             "to_agent_id AS b_agent_id".to_string(),
         ];
-        selected.extend(
-            OPTIONAL
-                .iter()
-                .copied()
-                .filter(|column| columns.contains(*column))
-                .map(str::to_string),
+        let optional_present = OPTIONAL
+            .iter()
+            .copied()
+            .filter(|column| columns.contains(*column))
+            .collect::<Vec<_>>();
+        selected.extend(optional_present.iter().map(|column| (*column).to_string()));
+        return build_salvage_projection(
+            "agent_links",
+            selected.join(", "),
+            &CURRENT_REQUIRED,
+            &optional_present,
+            stats,
+            salvage_db_path,
         );
-        return Some(selected.join(", "));
     }
 
     let missing_current = CURRENT_REQUIRED
@@ -2700,7 +3177,7 @@ fn build_salvage_agent_links_select(
         .filter(|column| !columns.contains(*column))
         .collect::<Vec<_>>()
         .join(", ");
-    stats.warnings.push(format!(
+    stats.push_warning(format!(
         "Salvage database {} table agent_links missing required columns for both current schema ({missing_current}) and legacy schema ({missing_legacy})",
         salvage_db_path.display()
     ));
@@ -3076,12 +3553,353 @@ fn enrich_existing_agent_from_salvage(
     Ok(())
 }
 
+fn salvage_keyset_where(key_columns: &[&str], cursor: Option<&[Value]>) -> (String, Vec<Value>) {
+    let Some(values) = cursor else {
+        return (String::new(), Vec::new());
+    };
+    let mut params = Vec::new();
+    let mut terms = Vec::with_capacity(key_columns.len());
+    for greater_index in 0..key_columns.len() {
+        let mut predicates = Vec::with_capacity(greater_index + 1);
+        for equal_index in 0..greater_index {
+            predicates.push(format!("{} = ?", key_columns[equal_index]));
+            params.push(values[equal_index].clone());
+        }
+        predicates.push(format!("{} > ?", key_columns[greater_index]));
+        params.push(values[greater_index].clone());
+        terms.push(format!("({})", predicates.join(" AND ")));
+    }
+    (format!("WHERE {}", terms.join(" OR ")), params)
+}
+
+fn salvage_row_key(row: &Row, table: &str, key_columns: &[&str]) -> DbResult<Vec<Value>> {
+    let key = key_columns
+        .iter()
+        .map(|column| {
+            row.get_by_name(column).cloned().ok_or_else(|| {
+                DbError::Sqlite(format!(
+                    "reconstruct salvage: {table} page omitted stable key column {column}"
+                ))
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+    if key.iter().any(Value::is_null) {
+        return Err(DbError::Sqlite(format!(
+            "reconstruct salvage: {table} page contains a NULL stable key"
+        )));
+    }
+    Ok(key)
+}
+
+fn insert_salvage_id_mapping(
+    map: &mut HashMap<i64, i64>,
+    source_id: i64,
+    target_id: i64,
+    map_name: &str,
+) -> DbResult<()> {
+    if let Some(existing) = map.get(&source_id) {
+        if *existing == target_id {
+            return Ok(());
+        }
+        return Err(DbError::Sqlite(format!(
+            "reconstruct salvage: {map_name} source id {source_id} mapped to conflicting target ids {existing} and {target_id}"
+        )));
+    }
+    let limit = salvage_id_map_limit();
+    if map.len() >= limit {
+        return Err(DbError::Sqlite(format!(
+            "reconstruct salvage: {map_name} exceeded its hard cap of {limit} entries; refusing unbounded identity remapping"
+        )));
+    }
+    map.insert(source_id, target_id);
+    Ok(())
+}
+
+fn for_each_salvage_row_keyset(
+    conn: &DbConn,
+    table: &str,
+    projection: &SalvageProjection,
+    key_columns: &[&str],
+    cancelled: &dyn Fn() -> bool,
+    mut visit: impl FnMut(&Row) -> DbResult<()>,
+) -> DbResult<()> {
+    if key_columns.is_empty() {
+        return Err(DbError::Sqlite(format!(
+            "reconstruct salvage: {table} keyset requires at least one stable key column"
+        )));
+    }
+    for key in key_columns {
+        if !projection.columns.iter().any(|column| column.name == *key) {
+            return Err(DbError::Sqlite(format!(
+                "reconstruct salvage: {table} keyset column {key} is absent from its guarded projection"
+            )));
+        }
+    }
+    let order_by = key_columns.join(", ");
+    let contract_violation = format!(
+        "CASE {} ELSE 0 END",
+        projection
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(index, column)| format!(
+                "WHEN NOT ({}) THEN {}",
+                column.sql_predicate(),
+                index + 1
+            ))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let oversized_value = format!(
+        "CASE {} ELSE 0 END",
+        projection
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(index, column)| format!(
+                "WHEN typeof({0}) IN ('text', 'blob') AND length(CAST({0} AS BLOB)) > {1} THEN {2}",
+                column.name,
+                SALVAGE_MAX_VARIABLE_VALUE_BYTES,
+                index + 1
+            ))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let projected_value_bytes = projection
+        .columns
+        .iter()
+        .map(|column| {
+            format!(
+                "CASE WHEN typeof({0}) IN ('text', 'blob') THEN COALESCE(length(CAST({0} AS BLOB)), 0) ELSE 0 END",
+                column.name
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" + ");
+    let mut cursor: Option<Vec<Value>> = None;
+    loop {
+        ensure_reconstruction_not_cancelled(cancelled)?;
+        let (where_clause, mut params) = salvage_keyset_where(key_columns, cursor.as_deref());
+        params.push(Value::BigInt(SALVAGE_QUERY_PAGE_ROWS));
+        // Fetch only scalar contract codes and byte lengths first. In
+        // particular, do not project the stable keys here: SQLite's dynamic
+        // typing permits a nominal INTEGER key to contain a huge TEXT/BLOB in
+        // a hostile legacy table. `typeof` and `length` inspect that value
+        // inside SQLite without returning its payload to Rust.
+        let metadata_sql = format!(
+            "SELECT {contract_violation} AS __salvage_contract_violation, \
+                    {oversized_value} AS __salvage_oversized_value, \
+                    {projected_value_bytes} AS __salvage_projected_bytes \
+             FROM (SELECT {} FROM {table}) AS salvage_page \
+             {where_clause} ORDER BY {order_by} LIMIT ?",
+            projection.select_sql
+        );
+        let metadata_rows = conn.query_sync(&metadata_sql, &params).map_err(|e| {
+            DbError::Sqlite(format!(
+                "reconstruct salvage: query {table} page metadata: {e}"
+            ))
+        })?;
+        if metadata_rows.is_empty() {
+            return Ok(());
+        }
+        let mut page_value_bytes = 0_i64;
+        for row in &metadata_rows {
+            ensure_reconstruction_not_cancelled(cancelled)?;
+            let oversized_code =
+                row.get_named::<i64>("__salvage_oversized_value")
+                    .map_err(|error| {
+                        DbError::Sqlite(format!(
+                            "reconstruct salvage: decode {table} oversized-value guard: {error}"
+                        ))
+                    })?;
+            if oversized_code > 0 {
+                let column = projection
+                    .columns
+                    .get(usize::try_from(oversized_code - 1).unwrap_or(usize::MAX))
+                    .map_or("<unknown>", |column| column.name.as_str());
+                return Err(DbError::Sqlite(format!(
+                    "reconstruct salvage: {table}.{column} exceeds the {SALVAGE_MAX_VARIABLE_VALUE_BYTES}-byte single-value cap; rejected from scalar metadata before full row materialization"
+                )));
+            }
+            let contract_code = row
+                .get_named::<i64>("__salvage_contract_violation")
+                .map_err(|error| {
+                    DbError::Sqlite(format!(
+                        "reconstruct salvage: decode {table} storage-contract guard: {error}"
+                    ))
+                })?;
+            if contract_code > 0 {
+                let column = projection
+                    .columns
+                    .get(usize::try_from(contract_code - 1).unwrap_or(usize::MAX));
+                let (name, expected) = column.map_or(
+                    ("<unknown>", "a declared storage contract".to_string()),
+                    |column| (column.name.as_str(), column.expected_description()),
+                );
+                return Err(DbError::Sqlite(format!(
+                    "reconstruct salvage: {table}.{name} violates its pre-materialization storage/range contract (expected {expected}); refusing dynamic-type payload before full row materialization"
+                )));
+            }
+            let row_bytes = row
+                .get_named::<i64>("__salvage_projected_bytes")
+                .map_err(|error| {
+                    DbError::Sqlite(format!(
+                        "reconstruct salvage: decode {table} projected byte size: {error}"
+                    ))
+                })?;
+            if row_bytes < 0 {
+                return Err(DbError::Sqlite(format!(
+                    "reconstruct salvage: {table} projected byte-size metadata overflowed"
+                )));
+            }
+            page_value_bytes = page_value_bytes.checked_add(row_bytes).ok_or_else(|| {
+                DbError::Sqlite(format!(
+                    "reconstruct salvage: {table} page projected byte-size metadata overflowed"
+                ))
+            })?;
+        }
+        let page_value_byte_limit = salvage_page_value_byte_limit();
+        if page_value_bytes > page_value_byte_limit {
+            return Err(DbError::Sqlite(format!(
+                "reconstruct salvage: {table} page projects {page_value_bytes} bytes of variable-width values, exceeding the {page_value_byte_limit}-byte page cap before full row materialization"
+            )));
+        }
+        ensure_reconstruction_not_cancelled(cancelled)?;
+        let sql = format!(
+            "SELECT * FROM (SELECT {} FROM {table}) AS salvage_page \
+             {where_clause} ORDER BY {order_by} LIMIT ?",
+            projection.select_sql
+        );
+        let rows = conn.query_sync(&sql, &params).map_err(|e| {
+            DbError::Sqlite(format!("reconstruct salvage: query {table} page: {e}"))
+        })?;
+        if rows.len() != metadata_rows.len() {
+            return Err(DbError::Sqlite(format!(
+                "reconstruct salvage: {table} changed between bounded metadata and value fetches"
+            )));
+        }
+        // The salvage connection holds one read transaction across all pages,
+        // so repeating the same WHERE/ORDER/LIMIT after scalar metadata yields
+        // the same stable rows without materializing keys during preflight.
+        observe_salvage_page(table, rows.len());
+        for row in &rows {
+            ensure_reconstruction_not_cancelled(cancelled)?;
+            visit(row)?;
+            observe_salvage_row(table);
+        }
+        cursor = Some(salvage_row_key(
+            rows.last().expect("non-empty salvage page has a last row"),
+            table,
+            key_columns,
+        )?);
+        if rows.len() < usize::try_from(SALVAGE_QUERY_PAGE_ROWS).unwrap_or(usize::MAX) {
+            return Ok(());
+        }
+    }
+}
+
+fn verify_reconstructed_foreign_keys_bounded(
+    conn: &DbConn,
+    cancelled: &dyn Fn() -> bool,
+) -> DbResult<()> {
+    // `PRAGMA foreign_key_check` returns every violation and `query_sync`
+    // materializes the complete result. Check each declared mailbox edge with
+    // a one-row anti-join instead, retaining transaction-local visibility and
+    // a constant result-memory bound on pathological salvage databases.
+    let checks = [
+        (
+            "product_project_links.product_id -> products.id",
+            "SELECT 1 FROM product_project_links child LEFT JOIN products parent ON parent.id = child.product_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "product_project_links.project_id -> projects.id",
+            "SELECT 1 FROM product_project_links child LEFT JOIN projects parent ON parent.id = child.project_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "agents.project_id -> projects.id",
+            "SELECT 1 FROM agents child LEFT JOIN projects parent ON parent.id = child.project_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "messages.project_id -> projects.id",
+            "SELECT 1 FROM messages child LEFT JOIN projects parent ON parent.id = child.project_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "messages.sender_id -> agents.id",
+            "SELECT 1 FROM messages child LEFT JOIN agents parent ON parent.id = child.sender_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "message_recipients.message_id -> messages.id",
+            "SELECT 1 FROM message_recipients child LEFT JOIN messages parent ON parent.id = child.message_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "message_recipients.agent_id -> agents.id",
+            "SELECT 1 FROM message_recipients child LEFT JOIN agents parent ON parent.id = child.agent_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "file_reservations.project_id -> projects.id",
+            "SELECT 1 FROM file_reservations child LEFT JOIN projects parent ON parent.id = child.project_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "file_reservations.agent_id -> agents.id",
+            "SELECT 1 FROM file_reservations child LEFT JOIN agents parent ON parent.id = child.agent_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "file_reservation_releases.reservation_id -> file_reservations.id",
+            "SELECT 1 FROM file_reservation_releases child LEFT JOIN file_reservations parent ON parent.id = child.reservation_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "agent_links.a_project_id -> projects.id",
+            "SELECT 1 FROM agent_links child LEFT JOIN projects parent ON parent.id = child.a_project_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "agent_links.a_agent_id -> agents.id",
+            "SELECT 1 FROM agent_links child LEFT JOIN agents parent ON parent.id = child.a_agent_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "agent_links.b_project_id -> projects.id",
+            "SELECT 1 FROM agent_links child LEFT JOIN projects parent ON parent.id = child.b_project_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "agent_links.b_agent_id -> agents.id",
+            "SELECT 1 FROM agent_links child LEFT JOIN agents parent ON parent.id = child.b_agent_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "project_sibling_suggestions.project_a_id -> projects.id",
+            "SELECT 1 FROM project_sibling_suggestions child LEFT JOIN projects parent ON parent.id = child.project_a_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "project_sibling_suggestions.project_b_id -> projects.id",
+            "SELECT 1 FROM project_sibling_suggestions child LEFT JOIN projects parent ON parent.id = child.project_b_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+        (
+            "inbox_stats.agent_id -> agents.id",
+            "SELECT 1 FROM inbox_stats child LEFT JOIN agents parent ON parent.id = child.agent_id WHERE parent.id IS NULL LIMIT 1",
+        ),
+    ];
+    for (edge, sql) in checks {
+        ensure_reconstruction_not_cancelled(cancelled)?;
+        let rows = conn.query_sync(sql, &[]).map_err(|error| {
+            DbError::Sqlite(format!(
+                "reconstruct salvage: verify foreign-key edge {edge}: {error}"
+            ))
+        })?;
+        if !rows.is_empty() {
+            return Err(DbError::Sqlite(format!(
+                "reconstruct salvage: foreign-key edge {edge} has an orphan; refusing promotion"
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_lines)]
 fn merge_salvaged_database(
     target_db_path: &Path,
     salvage_db_path: &Path,
     stats: &mut ReconstructStats,
+    cancelled: &dyn Fn() -> bool,
 ) -> DbResult<()> {
+    ensure_reconstruction_not_cancelled(cancelled)?;
     let target_conn =
         DbConn::open_file(target_db_path.to_string_lossy().as_ref()).map_err(|e| {
             DbError::Sqlite(format!(
@@ -3090,6 +3908,11 @@ fn merge_salvaged_database(
             ))
         })?;
     let salvage_conn = open_read_only_salvage_db(salvage_db_path)?;
+    salvage_conn.execute_raw("BEGIN;").map_err(|e| {
+        DbError::Sqlite(format!(
+            "reconstruct salvage: begin stable source snapshot: {e}"
+        ))
+    })?;
 
     let has_projects = table_exists(&salvage_conn, "projects")?;
     let has_agents = table_exists(&salvage_conn, "agents")?;
@@ -3113,7 +3936,7 @@ fn merge_salvaged_database(
         || has_product_project_links
         || has_proof_gate_consumed_nonces)
     {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Salvage database {} contained none of the expected mail/product tables",
             salvage_db_path.display()
         ));
@@ -3147,81 +3970,88 @@ fn merge_salvaged_database(
                     salvage_db_path.display()
                 ))
             })?;
-            let project_rows = salvage_conn
-                .query_sync(
-                    &format!("SELECT {project_select} FROM projects ORDER BY id"),
-                    &[],
-                )
-                .map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: query projects: {e}"))
-                })?;
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "projects",
+                &project_select,
+                &["id"],
+                cancelled,
+                |row| {
+                    let source_project_id = row.get_named::<i64>("id").map_err(|e| {
+                        DbError::Sqlite(format!("reconstruct salvage: decode project id: {e}"))
+                    })?;
+                    if source_project_id <= 0 {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: project has non-positive id {source_project_id}"
+                        )));
+                    }
+                    let slug = row.get_named::<String>("slug").map_err(|e| {
+                        DbError::Sqlite(format!(
+                            "reconstruct salvage: decode slug for project {source_project_id}: {e}"
+                        ))
+                    })?;
+                    let slug = slug.trim().to_string();
+                    if slug.is_empty() {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: project {source_project_id} has an empty stable slug"
+                        )));
+                    }
 
-            for row in &project_rows {
-                let source_project_id = row.get_named::<i64>("id").map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: decode project id: {e}"))
-                })?;
-                if source_project_id <= 0 {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: project has non-positive id {source_project_id}"
-                    )));
-                }
-                let slug = row.get_named::<String>("slug").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode slug for project {source_project_id}: {e}"
-                    ))
-                })?;
-                let slug = slug.trim().to_string();
-                if slug.is_empty() {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: project {source_project_id} has an empty stable slug"
-                    )));
-                }
+                    let human_key = row
+                        .get_named::<String>("human_key")
+                        .unwrap_or_else(|_| synthetic_project_placeholder_human_key(&slug));
+                    let created_at = row
+                        .get_named::<i64>("created_at")
+                        .unwrap_or_else(|_| crate::now_micros());
 
-                let human_key = row
-                    .get_named::<String>("human_key")
-                    .unwrap_or_else(|_| synthetic_project_placeholder_human_key(&slug));
-                let created_at = row
-                    .get_named::<i64>("created_at")
-                    .unwrap_or_else(|_| crate::now_micros());
-
-                if let Ok(target_project_id) =
-                    query_last_insert_or_existing_id(&target_conn, "projects", "slug", &slug)
-                {
-                    enrich_existing_project_from_salvage(
+                    if let Ok(target_project_id) =
+                        query_last_insert_or_existing_id(&target_conn, "projects", "slug", &slug)
+                    {
+                        enrich_existing_project_from_salvage(
+                            &target_conn,
+                            target_project_id,
+                            &slug,
+                            &slug,
+                            &human_key,
+                            created_at,
+                        )?;
+                        insert_salvage_id_mapping(
+                            &mut project_id_map,
+                            source_project_id,
+                            target_project_id,
+                            "project_id_map",
+                        )?;
+                        return Ok(());
+                    }
+                    // A basename-only match (for example `/shared` versus
+                    // `/srv/team-a/shared`) is not a stable project identity. Two
+                    // unrelated repositories routinely share a basename, and
+                    // merging them here would remap every salvaged child row to
+                    // the wrong project. Only exact slug or exact canonical
+                    // human-key matches may reuse an existing target row.
+                    if let Ok(target_project_id) = query_last_insert_or_existing_id(
                         &target_conn,
-                        target_project_id,
-                        &slug,
-                        &slug,
+                        "projects",
+                        "human_key",
                         &human_key,
-                        created_at,
-                    )?;
-                    project_id_map.insert(source_project_id, target_project_id);
-                    continue;
-                }
-                // A basename-only match (for example `/shared` versus
-                // `/srv/team-a/shared`) is not a stable project identity. Two
-                // unrelated repositories routinely share a basename, and
-                // merging them here would remap every salvaged child row to
-                // the wrong project. Only exact slug or exact canonical
-                // human-key matches may reuse an existing target row.
-                if let Ok(target_project_id) = query_last_insert_or_existing_id(
-                    &target_conn,
-                    "projects",
-                    "human_key",
-                    &human_key,
-                ) {
-                    enrich_existing_project_from_salvage(
-                        &target_conn,
-                        target_project_id,
-                        &slug,
-                        &slug,
-                        &human_key,
-                        created_at,
-                    )?;
-                    project_id_map.insert(source_project_id, target_project_id);
-                    continue;
-                }
-                target_conn
+                    ) {
+                        enrich_existing_project_from_salvage(
+                            &target_conn,
+                            target_project_id,
+                            &slug,
+                            &slug,
+                            &human_key,
+                            created_at,
+                        )?;
+                        insert_salvage_id_mapping(
+                            &mut project_id_map,
+                            source_project_id,
+                            target_project_id,
+                            "project_id_map",
+                        )?;
+                        return Ok(());
+                    }
+                    target_conn
                     .execute_sync(
                         "INSERT OR IGNORE INTO projects (slug, human_key, created_at) VALUES (?, ?, ?)",
                         &[
@@ -3233,11 +4063,18 @@ fn merge_salvaged_database(
                     .map_err(|e| {
                         DbError::Sqlite(format!("reconstruct salvage: insert project {slug}: {e}"))
                     })?;
-                let target_project_id =
-                    query_last_insert_or_existing_id(&target_conn, "projects", "slug", &slug)?;
-                project_id_map.insert(source_project_id, target_project_id);
-                stats.salvaged_projects += 1;
-            }
+                    let target_project_id =
+                        query_last_insert_or_existing_id(&target_conn, "projects", "slug", &slug)?;
+                    insert_salvage_id_mapping(
+                        &mut project_id_map,
+                        source_project_id,
+                        target_project_id,
+                        "project_id_map",
+                    )?;
+                    stats.salvaged_projects += 1;
+                    Ok(())
+                },
+            )?;
 
             #[cfg(test)]
             if FAIL_SALVAGE_MERGE_AFTER_PROJECTS.swap(false, std::sync::atomic::Ordering::SeqCst) {
@@ -3273,61 +4110,61 @@ fn merge_salvaged_database(
                     salvage_db_path.display()
                 ))
             })?;
-            let agent_rows = salvage_conn
-                .query_sync(
-                    &format!("SELECT {agent_select} FROM agents ORDER BY id"),
-                    &[],
-                )
-                .map_err(|e| DbError::Sqlite(format!("reconstruct salvage: query agents: {e}")))?;
-
-            for row in &agent_rows {
-                let source_agent_id = row.get_named::<i64>("id").map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: decode agent id: {e}"))
-                })?;
-                if source_agent_id <= 0 {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: agent has non-positive id {source_agent_id}"
-                    )));
-                }
-                let source_project_id = row.get_named::<i64>("project_id").map_err(|e| {
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "agents",
+                &agent_select,
+                &["id"],
+                cancelled,
+                |row| {
+                    let source_agent_id = row.get_named::<i64>("id").map_err(|e| {
+                        DbError::Sqlite(format!("reconstruct salvage: decode agent id: {e}"))
+                    })?;
+                    if source_agent_id <= 0 {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: agent has non-positive id {source_agent_id}"
+                        )));
+                    }
+                    let source_project_id = row.get_named::<i64>("project_id").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode project_id for agent {source_agent_id}: {e}"
                     ))
                 })?;
-                let target_project_id = *project_id_map.get(&source_project_id).ok_or_else(|| {
+                    let target_project_id = *project_id_map.get(&source_project_id).ok_or_else(|| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: agent {source_agent_id} referenced unmapped project id {source_project_id}"
                     ))
                 })?;
 
-                let name = row.get_named::<String>("name").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode name for agent {source_agent_id}: {e}"
-                    ))
-                })?;
-                let name = name.trim().to_string();
-                if name.is_empty() {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: agent {source_agent_id} has an empty stable name"
-                    )));
-                }
+                    let name = row.get_named::<String>("name").map_err(|e| {
+                        DbError::Sqlite(format!(
+                            "reconstruct salvage: decode name for agent {source_agent_id}: {e}"
+                        ))
+                    })?;
+                    let name = name.trim().to_string();
+                    if name.is_empty() {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: agent {source_agent_id} has an empty stable name"
+                        )));
+                    }
 
-                let salvaged_program_raw = row.get_named::<String>("program").ok();
-                let salvaged_model_raw = row.get_named::<String>("model").ok();
-                let salvaged_task_description = row
-                    .get_named::<String>("task_description")
-                    .unwrap_or_default();
-                let salvaged_inception_ts = row
-                    .get_named::<i64>("inception_ts")
-                    .unwrap_or_else(|_| crate::now_micros());
-                let salvaged_last_active_ts = row
-                    .get_named::<i64>("last_active_ts")
-                    .unwrap_or_else(|_| crate::now_micros());
-                let salvaged_attachments_policy_raw =
-                    row.get_named::<String>("attachments_policy").ok();
-                let salvaged_contact_policy_raw = row.get_named::<String>("contact_policy").ok();
-                let salvaged_reaper_exempt = if agent_columns.contains("reaper_exempt") {
-                    Some(
+                    let salvaged_program_raw = row.get_named::<String>("program").ok();
+                    let salvaged_model_raw = row.get_named::<String>("model").ok();
+                    let salvaged_task_description = row
+                        .get_named::<String>("task_description")
+                        .unwrap_or_default();
+                    let salvaged_inception_ts = row
+                        .get_named::<i64>("inception_ts")
+                        .unwrap_or_else(|_| crate::now_micros());
+                    let salvaged_last_active_ts = row
+                        .get_named::<i64>("last_active_ts")
+                        .unwrap_or_else(|_| crate::now_micros());
+                    let salvaged_attachments_policy_raw =
+                        row.get_named::<String>("attachments_policy").ok();
+                    let salvaged_contact_policy_raw =
+                        row.get_named::<String>("contact_policy").ok();
+                    let salvaged_reaper_exempt = if agent_columns.contains("reaper_exempt") {
+                        Some(
                         row.get_named::<i64>("reaper_exempt")
                             .map_err(|e| {
                                 DbError::Sqlite(format!(
@@ -3336,56 +4173,59 @@ fn merge_salvaged_database(
                             })?
                             != 0,
                     )
-                } else {
-                    None
-                };
-                let salvaged_registration_token = if agent_columns.contains("registration_token") {
-                    row.get_named::<Option<String>>("registration_token")
+                    } else {
+                        None
+                    };
+                    let salvaged_registration_token = if agent_columns
+                        .contains("registration_token")
+                    {
+                        row.get_named::<Option<String>>("registration_token")
                         .map_err(|e| {
                             DbError::Sqlite(format!(
                                 "reconstruct salvage: decode registration_token for agent {source_agent_id}: {e}"
                             ))
                         })?
-                } else {
-                    None
-                };
-                let salvage_agent_source = format!("salvage agent row {source_agent_id} ({name})");
-                let salvaged_program = normalize_reconstructed_required_agent_field(
-                    salvaged_program_raw.as_deref(),
-                    &salvage_agent_source,
-                    "program",
-                    "unknown",
-                    stats,
-                );
-                let salvaged_model = normalize_reconstructed_required_agent_field(
-                    salvaged_model_raw.as_deref(),
-                    &salvage_agent_source,
-                    "model",
-                    "unknown",
-                    stats,
-                );
-                let salvaged_attachments_policy = normalize_reconstructed_attachments_policy(
-                    salvaged_attachments_policy_raw.as_deref(),
-                    &salvage_agent_source,
-                    stats,
-                );
-                let salvaged_contact_policy = normalize_reconstructed_contact_policy(
-                    salvaged_contact_policy_raw.as_deref(),
-                    &salvage_agent_source,
-                    stats,
-                );
+                    } else {
+                        None
+                    };
+                    let salvage_agent_source =
+                        format!("salvage agent row {source_agent_id} ({name})");
+                    let salvaged_program = normalize_reconstructed_required_agent_field(
+                        salvaged_program_raw.as_deref(),
+                        &salvage_agent_source,
+                        "program",
+                        "unknown",
+                        stats,
+                    );
+                    let salvaged_model = normalize_reconstructed_required_agent_field(
+                        salvaged_model_raw.as_deref(),
+                        &salvage_agent_source,
+                        "model",
+                        "unknown",
+                        stats,
+                    );
+                    let salvaged_attachments_policy = normalize_reconstructed_attachments_policy(
+                        salvaged_attachments_policy_raw.as_deref(),
+                        &salvage_agent_source,
+                        stats,
+                    );
+                    let salvaged_contact_policy = normalize_reconstructed_contact_policy(
+                        salvaged_contact_policy_raw.as_deref(),
+                        &salvage_agent_source,
+                        stats,
+                    );
 
-                let existed = query_last_insert_or_existing_id_composite(
-                    &target_conn,
-                    "agents",
-                    "project_id",
-                    target_project_id,
-                    "name",
-                    &name,
-                )
-                .ok();
+                    let existed = query_last_insert_or_existing_id_composite(
+                        &target_conn,
+                        "agents",
+                        "project_id",
+                        target_project_id,
+                        "name",
+                        &name,
+                    )
+                    .ok();
 
-                target_conn
+                    target_conn
                 .execute_sync(
                     "INSERT OR IGNORE INTO agents \
                      (project_id, name, program, model, task_description, inception_ts, last_active_ts, attachments_policy, contact_policy, reaper_exempt, registration_token) \
@@ -3410,36 +4250,43 @@ fn merge_salvaged_database(
                     DbError::Sqlite(format!("reconstruct salvage: insert agent {name}: {e}"))
                 })?;
 
-                let target_agent_id = query_last_insert_or_existing_id_composite(
-                    &target_conn,
-                    "agents",
-                    "project_id",
-                    target_project_id,
-                    "name",
-                    &name,
-                )?;
-                agent_id_map.insert(source_agent_id, target_agent_id);
-                if existed.is_none() {
-                    stats.salvaged_agents += 1;
-                } else {
-                    enrich_existing_agent_from_salvage(
+                    let target_agent_id = query_last_insert_or_existing_id_composite(
                         &target_conn,
-                        target_agent_id,
+                        "agents",
+                        "project_id",
+                        target_project_id,
+                        "name",
                         &name,
-                        &salvaged_program,
-                        &salvaged_model,
-                        &salvaged_task_description,
-                        salvaged_inception_ts,
-                        salvaged_last_active_ts,
-                        &salvaged_attachments_policy,
-                        &salvaged_contact_policy,
-                        salvaged_reaper_exempt,
-                        salvaged_registration_token.as_deref(),
-                        agent_columns.contains("registration_token"),
-                        stats,
                     )?;
-                }
-            }
+                    insert_salvage_id_mapping(
+                        &mut agent_id_map,
+                        source_agent_id,
+                        target_agent_id,
+                        "agent_id_map",
+                    )?;
+                    if existed.is_none() {
+                        stats.salvaged_agents += 1;
+                    } else {
+                        enrich_existing_agent_from_salvage(
+                            &target_conn,
+                            target_agent_id,
+                            &name,
+                            &salvaged_program,
+                            &salvaged_model,
+                            &salvaged_task_description,
+                            salvaged_inception_ts,
+                            salvaged_last_active_ts,
+                            &salvaged_attachments_policy,
+                            &salvaged_contact_policy,
+                            salvaged_reaper_exempt,
+                            salvaged_registration_token.as_deref(),
+                            agent_columns.contains("registration_token"),
+                            stats,
+                        )?;
+                    }
+                    Ok(())
+                },
+            )?;
         }
 
         if has_file_reservations {
@@ -3467,61 +4314,56 @@ fn merge_salvaged_database(
                     salvage_db_path.display()
                 ))
             })?;
-            let reservation_rows = salvage_conn
-                .query_sync(
-                    &format!("SELECT {reservation_select} FROM file_reservations ORDER BY id"),
-                    &[],
-                )
-                .map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: query file_reservations: {e}"))
-                })?;
-            if !reservation_rows.is_empty()
-                && (project_id_map.is_empty() || agent_id_map.is_empty())
-            {
-                return Err(DbError::Sqlite(format!(
-                    "reconstruct salvage: {} has file_reservations rows but stable project/agent identity maps are unavailable",
-                    salvage_db_path.display()
-                )));
-            }
-
-            for row in &reservation_rows {
-                let source_reservation_id = row.get_named::<i64>("id").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode file reservation id: {e}"
-                    ))
-                })?;
-                if source_reservation_id <= 0 {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: file reservation has non-positive id {source_reservation_id}"
-                    )));
-                }
-                let source_project_id = row.get_named::<i64>("project_id").map_err(|e| {
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "file_reservations",
+                &reservation_select,
+                &["id"],
+                cancelled,
+                |row| {
+                    if project_id_map.is_empty() || agent_id_map.is_empty() {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: {} has file_reservations rows but stable project/agent identity maps are unavailable",
+                            salvage_db_path.display()
+                        )));
+                    }
+                    let source_reservation_id = row.get_named::<i64>("id").map_err(|e| {
+                        DbError::Sqlite(format!(
+                            "reconstruct salvage: decode file reservation id: {e}"
+                        ))
+                    })?;
+                    if source_reservation_id <= 0 {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: file reservation has non-positive id {source_reservation_id}"
+                        )));
+                    }
+                    let source_project_id = row.get_named::<i64>("project_id").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode project_id for reservation {source_reservation_id}: {e}"
                     ))
                 })?;
-                let source_agent_id = row.get_named::<i64>("agent_id").map_err(|e| {
+                    let source_agent_id = row.get_named::<i64>("agent_id").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode agent_id for reservation {source_reservation_id}: {e}"
                     ))
                 })?;
-                let target_project_id = *project_id_map.get(&source_project_id).ok_or_else(|| {
+                    let target_project_id = *project_id_map.get(&source_project_id).ok_or_else(|| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: reservation {source_reservation_id} referenced unmapped project id {source_project_id}"
                     ))
                 })?;
-                let target_agent_id = *agent_id_map.get(&source_agent_id).ok_or_else(|| {
+                    let target_agent_id = *agent_id_map.get(&source_agent_id).ok_or_else(|| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: reservation {source_reservation_id} referenced unmapped agent id {source_agent_id}"
                     ))
                 })?;
-                if agent_project_id(&target_conn, target_agent_id)? != Some(target_project_id) {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: reservation {source_reservation_id} maps agent {source_agent_id} outside project {source_project_id}; refusing cross-project ownership"
-                    )));
-                }
+                    if agent_project_id(&target_conn, target_agent_id)? != Some(target_project_id) {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: reservation {source_reservation_id} maps agent {source_agent_id} outside project {source_project_id}; refusing cross-project ownership"
+                        )));
+                    }
 
-                let path_pattern = row
+                    let path_pattern = row
                     .get_named::<String>("path_pattern")
                     .map_err(|e| {
                         DbError::Sqlite(format!(
@@ -3530,40 +4372,40 @@ fn merge_salvaged_database(
                     })?
                     .trim()
                     .to_string();
-                if path_pattern.is_empty() {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: reservation {source_reservation_id} has an empty path_pattern"
-                    )));
-                }
-                let exclusive = i64::from(
+                    if path_pattern.is_empty() {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: reservation {source_reservation_id} has an empty path_pattern"
+                        )));
+                    }
+                    let exclusive = i64::from(
                     row.get_named::<i64>("exclusive").map_err(|e| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: decode exclusive for reservation {source_reservation_id}: {e}"
                         ))
                     })? != 0,
                 );
-                let reason = row.get_named::<String>("reason").unwrap_or_default();
-                let created_ts = row.get_named::<i64>("created_ts").map_err(|e| {
+                    let reason = row.get_named::<String>("reason").unwrap_or_default();
+                    let created_ts = row.get_named::<i64>("created_ts").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode created_ts for reservation {source_reservation_id}: {e}"
                     ))
                 })?;
-                let expires_ts = row.get_named::<i64>("expires_ts").map_err(|e| {
+                    let expires_ts = row.get_named::<i64>("expires_ts").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode expires_ts for reservation {source_reservation_id}: {e}"
                     ))
                 })?;
-                let released_ts = row.get_named::<i64>("released_ts").ok();
+                    let released_ts = row.get_named::<i64>("released_ts").ok();
 
-                // Numeric ids are local to the source database. Resolve the
-                // logical reservation exclusively through remapped stable
-                // project/agent identities plus its immutable path/time key.
-                let existing_rows = target_conn
+                    // Numeric ids are local to the source database. Resolve the
+                    // logical reservation exclusively through remapped stable
+                    // project/agent identities plus its immutable path/time key.
+                    let existing_rows = target_conn
                     .query_sync(
                         "SELECT id, exclusive, reason, expires_ts, released_ts \
                          FROM file_reservations \
                          WHERE project_id = ? AND agent_id = ? AND path_pattern = ? AND created_ts = ? \
-                         ORDER BY id",
+                         ORDER BY id LIMIT 2",
                         &[
                             Value::BigInt(target_project_id),
                             Value::BigInt(target_agent_id),
@@ -3576,57 +4418,61 @@ fn merge_salvaged_database(
                             "reconstruct salvage: resolve reservation {source_reservation_id} by stable identity: {e}"
                         ))
                     })?;
-                if existing_rows.len() > 1 {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: reservation {source_reservation_id} has {} target rows for the same stable ownership key; refusing ambiguous promotion",
-                        existing_rows.len()
-                    )));
-                }
+                    if existing_rows.len() > 1 {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: reservation {source_reservation_id} has {} target rows for the same stable ownership key; refusing ambiguous promotion",
+                            existing_rows.len()
+                        )));
+                    }
 
-                let target_reservation_id = if let Some(existing) = existing_rows.first() {
-                    let target_reservation_id = existing.get_named::<i64>("id").map_err(|e| {
-                        DbError::Sqlite(format!(
-                            "reconstruct salvage: decode target reservation id: {e}"
-                        ))
-                    })?;
-                    let current_exclusive =
-                        i64::from(existing.get_named::<i64>("exclusive").unwrap_or(1) != 0);
-                    let current_reason = existing.get_named::<String>("reason").unwrap_or_default();
-                    let current_expires_ts = existing
-                        .get_named::<i64>("expires_ts")
-                        .unwrap_or(expires_ts);
-                    let current_released_ts = existing.get_named::<i64>("released_ts").ok();
-                    if current_exclusive != exclusive {
-                        return Err(DbError::Sqlite(format!(
-                            "reconstruct salvage: reservation {source_reservation_id} conflicts with target reservation {target_reservation_id} on exclusive ownership for the same stable key"
-                        )));
-                    }
-                    if !current_reason.is_empty() && !reason.is_empty() && current_reason != reason
-                    {
-                        return Err(DbError::Sqlite(format!(
-                            "reconstruct salvage: reservation {source_reservation_id} conflicts with target reservation {target_reservation_id} on reason metadata for the same stable key"
-                        )));
-                    }
-                    if current_released_ts.is_some()
-                        && released_ts.is_some()
-                        && current_released_ts != released_ts
-                    {
-                        return Err(DbError::Sqlite(format!(
-                            "reconstruct salvage: reservation {source_reservation_id} conflicts with target reservation {target_reservation_id} on terminal release timestamp"
-                        )));
-                    }
-                    let merged_reason = if current_reason.is_empty() {
-                        reason.clone()
-                    } else {
-                        current_reason.clone()
-                    };
-                    let merged_expires_ts = current_expires_ts.max(expires_ts);
-                    let merged_released_ts = current_released_ts.or(released_ts);
-                    if merged_reason != current_reason
-                        || merged_expires_ts != current_expires_ts
-                        || merged_released_ts != current_released_ts
-                    {
-                        target_conn
+                    let target_reservation_id = if let Some(existing) = existing_rows.first() {
+                        let target_reservation_id =
+                            existing.get_named::<i64>("id").map_err(|e| {
+                                DbError::Sqlite(format!(
+                                    "reconstruct salvage: decode target reservation id: {e}"
+                                ))
+                            })?;
+                        let current_exclusive =
+                            i64::from(existing.get_named::<i64>("exclusive").unwrap_or(1) != 0);
+                        let current_reason =
+                            existing.get_named::<String>("reason").unwrap_or_default();
+                        let current_expires_ts = existing
+                            .get_named::<i64>("expires_ts")
+                            .unwrap_or(expires_ts);
+                        let current_released_ts = existing.get_named::<i64>("released_ts").ok();
+                        if current_exclusive != exclusive {
+                            return Err(DbError::Sqlite(format!(
+                                "reconstruct salvage: reservation {source_reservation_id} conflicts with target reservation {target_reservation_id} on exclusive ownership for the same stable key"
+                            )));
+                        }
+                        if !current_reason.is_empty()
+                            && !reason.is_empty()
+                            && current_reason != reason
+                        {
+                            return Err(DbError::Sqlite(format!(
+                                "reconstruct salvage: reservation {source_reservation_id} conflicts with target reservation {target_reservation_id} on reason metadata for the same stable key"
+                            )));
+                        }
+                        if current_released_ts.is_some()
+                            && released_ts.is_some()
+                            && current_released_ts != released_ts
+                        {
+                            return Err(DbError::Sqlite(format!(
+                                "reconstruct salvage: reservation {source_reservation_id} conflicts with target reservation {target_reservation_id} on terminal release timestamp"
+                            )));
+                        }
+                        let merged_reason = if current_reason.is_empty() {
+                            reason.clone()
+                        } else {
+                            current_reason.clone()
+                        };
+                        let merged_expires_ts = current_expires_ts.max(expires_ts);
+                        let merged_released_ts = current_released_ts.or(released_ts);
+                        if merged_reason != current_reason
+                            || merged_expires_ts != current_expires_ts
+                            || merged_released_ts != current_released_ts
+                        {
+                            target_conn
                             .execute_sync(
                                 "UPDATE file_reservations SET reason = ?, expires_ts = ?, released_ts = ? WHERE id = ?",
                                 &[
@@ -3641,11 +4487,11 @@ fn merge_salvaged_database(
                                     "reconstruct salvage: merge reservation {source_reservation_id} state: {e}"
                                 ))
                             })?;
-                        stats.salvaged_reservations += 1;
-                    }
-                    target_reservation_id
-                } else {
-                    target_conn
+                            stats.salvaged_reservations += 1;
+                        }
+                        target_reservation_id
+                    } else {
+                        target_conn
                         .execute_sync(
                             "INSERT INTO file_reservations \
                              (project_id, agent_id, path_pattern, exclusive, reason, created_ts, expires_ts, released_ts) \
@@ -3666,11 +4512,18 @@ fn merge_salvaged_database(
                                 "reconstruct salvage: insert reservation {source_reservation_id}: {e}"
                             ))
                         })?;
-                    stats.salvaged_reservations += 1;
-                    query_last_insert_rowid(&target_conn)?
-                };
-                reservation_id_map.insert(source_reservation_id, target_reservation_id);
-            }
+                        stats.salvaged_reservations += 1;
+                        query_last_insert_rowid(&target_conn)?
+                    };
+                    insert_salvage_id_mapping(
+                        &mut reservation_id_map,
+                        source_reservation_id,
+                        target_reservation_id,
+                        "reservation_id_map",
+                    )?;
+                    Ok(())
+                },
+            )?;
         }
 
         if has_file_reservation_releases {
@@ -3695,37 +4548,31 @@ fn merge_salvaged_database(
                     salvage_db_path.display()
                 ))
             })?;
-            let release_rows = salvage_conn
-                .query_sync(
-                    &format!(
-                        "SELECT {release_select} FROM file_reservation_releases ORDER BY reservation_id"
-                    ),
-                    &[],
-                )
-                .map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: query file_reservation_releases: {e}"
-                    ))
-                })?;
-            for row in &release_rows {
-                let source_reservation_id =
-                    row.get_named::<i64>("reservation_id").map_err(|e| {
-                        DbError::Sqlite(format!(
-                            "reconstruct salvage: decode release reservation_id: {e}"
-                        ))
-                    })?;
-                let released_ts = row.get_named::<i64>("released_ts").map_err(|e| {
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "file_reservation_releases",
+                &release_select,
+                &["reservation_id"],
+                cancelled,
+                |row| {
+                    let source_reservation_id =
+                        row.get_named::<i64>("reservation_id").map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: decode release reservation_id: {e}"
+                            ))
+                        })?;
+                    let released_ts = row.get_named::<i64>("released_ts").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode release timestamp for reservation {source_reservation_id}: {e}"
                     ))
                 })?;
-                let target_reservation_id =
+                    let target_reservation_id =
                     *reservation_id_map.get(&source_reservation_id).ok_or_else(|| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: release references unmapped reservation id {source_reservation_id}"
                         ))
                     })?;
-                let existing_release_rows = target_conn
+                    let existing_release_rows = target_conn
                     .query_sync(
                         "SELECT released_ts FROM file_reservation_releases WHERE reservation_id = ?",
                         &[Value::BigInt(target_reservation_id)],
@@ -3735,20 +4582,20 @@ fn merge_salvaged_database(
                             "reconstruct salvage: query release for target reservation {target_reservation_id}: {e}"
                         ))
                     })?;
-                if let Some(existing) = existing_release_rows.first() {
-                    let current_released_ts = existing.get_named::<i64>("released_ts").map_err(|e| {
+                    if let Some(existing) = existing_release_rows.first() {
+                        let current_released_ts = existing.get_named::<i64>("released_ts").map_err(|e| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: decode target release for reservation {target_reservation_id}: {e}"
                         ))
                     })?;
-                    if current_released_ts != released_ts {
-                        return Err(DbError::Sqlite(format!(
-                            "reconstruct salvage: reservation {source_reservation_id} has conflicting terminal release ledger timestamps ({released_ts} versus {current_released_ts})"
-                        )));
+                        if current_released_ts != released_ts {
+                            return Err(DbError::Sqlite(format!(
+                                "reconstruct salvage: reservation {source_reservation_id} has conflicting terminal release ledger timestamps ({released_ts} versus {current_released_ts})"
+                            )));
+                        }
+                        return Ok(());
                     }
-                    continue;
-                }
-                let legacy_release_rows = target_conn
+                    let legacy_release_rows = target_conn
                     .query_sync(
                         "SELECT released_ts FROM file_reservations WHERE id = ?",
                         &[Value::BigInt(target_reservation_id)],
@@ -3758,16 +4605,16 @@ fn merge_salvaged_database(
                             "reconstruct salvage: query legacy release state for reservation {target_reservation_id}: {e}"
                         ))
                     })?;
-                if let Some(legacy_release) = legacy_release_rows
-                    .first()
-                    .and_then(|existing| existing.get_named::<i64>("released_ts").ok())
-                    && legacy_release != released_ts
-                {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: reservation {source_reservation_id} has conflicting row/ledger release timestamps ({legacy_release} versus {released_ts})"
-                    )));
-                }
-                target_conn
+                    if let Some(legacy_release) = legacy_release_rows
+                        .first()
+                        .and_then(|existing| existing.get_named::<i64>("released_ts").ok())
+                        && legacy_release != released_ts
+                    {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: reservation {source_reservation_id} has conflicting row/ledger release timestamps ({legacy_release} versus {released_ts})"
+                        )));
+                    }
+                    target_conn
                     .execute_sync(
                         "INSERT INTO file_reservation_releases (reservation_id, released_ts) VALUES (?, ?)",
                         &[
@@ -3780,8 +4627,10 @@ fn merge_salvaged_database(
                             "reconstruct salvage: insert release for reservation {source_reservation_id}: {e}"
                         ))
                     })?;
-                stats.salvaged_reservation_releases += 1;
-            }
+                    stats.salvaged_reservation_releases += 1;
+                    Ok(())
+                },
+            )?;
         }
 
         if has_agent_links {
@@ -3794,139 +4643,134 @@ fn merge_salvaged_database(
                             salvage_db_path.display()
                         ))
                     })?;
-            let agent_link_rows = salvage_conn
-                .query_sync(
-                    &format!(
-                        "SELECT {agent_link_select} FROM agent_links \
-                         ORDER BY a_project_id, a_agent_id, b_project_id, b_agent_id"
-                    ),
-                    &[],
-                )
-                .map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: query agent_links: {e}"))
-                })?;
-            if !agent_link_rows.is_empty() && (project_id_map.is_empty() || agent_id_map.is_empty())
-            {
-                return Err(DbError::Sqlite(format!(
-                    "reconstruct salvage: {} has agent_links rows but stable project/agent identity maps are unavailable",
-                    salvage_db_path.display()
-                )));
-            }
-
-            for row in &agent_link_rows {
-                let source_origin_project_id =
-                    row.get_named::<i64>("a_project_id").map_err(|e| {
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "agent_links",
+                &agent_link_select,
+                &["a_project_id", "a_agent_id", "b_project_id", "b_agent_id"],
+                cancelled,
+                |row| {
+                    if project_id_map.is_empty() || agent_id_map.is_empty() {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: {} has agent_links rows but stable project/agent identity maps are unavailable",
+                            salvage_db_path.display()
+                        )));
+                    }
+                    let source_origin_project_id =
+                        row.get_named::<i64>("a_project_id").map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: decode agent_link origin project: {e}"
+                            ))
+                        })?;
+                    let source_origin_agent_id =
+                        row.get_named::<i64>("a_agent_id").map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: decode agent_link origin agent: {e}"
+                            ))
+                        })?;
+                    let source_peer_project_id =
+                        row.get_named::<i64>("b_project_id").map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: decode agent_link peer project: {e}"
+                            ))
+                        })?;
+                    let source_peer_agent_id = row.get_named::<i64>("b_agent_id").map_err(|e| {
                         DbError::Sqlite(format!(
-                            "reconstruct salvage: decode agent_link origin project: {e}"
+                            "reconstruct salvage: decode agent_link peer agent: {e}"
                         ))
                     })?;
-                let source_origin_agent_id = row.get_named::<i64>("a_agent_id").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode agent_link origin agent: {e}"
-                    ))
-                })?;
-                let source_peer_project_id = row.get_named::<i64>("b_project_id").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode agent_link peer project: {e}"
-                    ))
-                })?;
-                let source_peer_agent_id = row.get_named::<i64>("b_agent_id").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode agent_link peer agent: {e}"
-                    ))
-                })?;
-                let target_origin_project_id = *project_id_map
+                    let target_origin_project_id = *project_id_map
                     .get(&source_origin_project_id)
                     .ok_or_else(|| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: agent_link references unmapped origin project {source_origin_project_id}"
                         ))
                     })?;
-                let target_origin_agent_id = *agent_id_map
+                    let target_origin_agent_id = *agent_id_map
                     .get(&source_origin_agent_id)
                     .ok_or_else(|| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: agent_link references unmapped origin agent {source_origin_agent_id}"
                         ))
                     })?;
-                let target_peer_project_id = *project_id_map
+                    let target_peer_project_id = *project_id_map
                     .get(&source_peer_project_id)
                     .ok_or_else(|| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: agent_link references unmapped peer project {source_peer_project_id}"
                         ))
                     })?;
-                let target_peer_agent_id =
+                    let target_peer_agent_id =
                     *agent_id_map.get(&source_peer_agent_id).ok_or_else(|| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: agent_link references unmapped peer agent {source_peer_agent_id}"
                         ))
                     })?;
-                if agent_project_id(&target_conn, target_origin_agent_id)?
-                    != Some(target_origin_project_id)
-                    || agent_project_id(&target_conn, target_peer_agent_id)?
-                        != Some(target_peer_project_id)
-                {
-                    return Err(DbError::Sqlite(
+                    if agent_project_id(&target_conn, target_origin_agent_id)?
+                        != Some(target_origin_project_id)
+                        || agent_project_id(&target_conn, target_peer_agent_id)?
+                            != Some(target_peer_project_id)
+                    {
+                        return Err(DbError::Sqlite(
                         "reconstruct salvage: agent_link ownership crosses a stable project boundary"
                             .to_string(),
                     ));
-                }
+                    }
 
-                let link_status = row
-                    .get_named::<String>("status")
-                    .unwrap_or_else(|_| "pending".to_string());
-                let reason = row.get_named::<String>("reason").unwrap_or_default();
-                let created_ts = row
-                    .get_named::<i64>("created_ts")
-                    .unwrap_or_else(|_| crate::now_micros());
-                let updated_ts = row.get_named::<i64>("updated_ts").unwrap_or(created_ts);
-                let expires_ts = row.get_named::<i64>("expires_ts").ok();
-                if created_ts <= 0 || updated_ts < created_ts {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: agent_link {source_origin_project_id}/{source_origin_agent_id}->{source_peer_project_id}/{source_peer_agent_id} has invalid timestamp ordering ({created_ts}, {updated_ts})"
-                    )));
-                }
+                    let link_status = row
+                        .get_named::<String>("status")
+                        .unwrap_or_else(|_| "pending".to_string());
+                    let reason = row.get_named::<String>("reason").unwrap_or_default();
+                    let created_ts = row
+                        .get_named::<i64>("created_ts")
+                        .unwrap_or_else(|_| crate::now_micros());
+                    let updated_ts = row.get_named::<i64>("updated_ts").unwrap_or(created_ts);
+                    let expires_ts = row.get_named::<i64>("expires_ts").ok();
+                    if created_ts <= 0 || updated_ts < created_ts {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: agent_link {source_origin_project_id}/{source_origin_agent_id}->{source_peer_project_id}/{source_peer_agent_id} has invalid timestamp ordering ({created_ts}, {updated_ts})"
+                        )));
+                    }
 
-                let existing_links = target_conn
-                    .query_sync(
-                        "SELECT id FROM agent_links \
+                    let existing_links = target_conn
+                        .query_sync(
+                            "SELECT id FROM agent_links \
                          WHERE a_project_id = ? AND a_agent_id = ? \
                            AND b_project_id = ? AND b_agent_id = ? LIMIT 2",
-                        &[
-                            Value::BigInt(target_origin_project_id),
-                            Value::BigInt(target_origin_agent_id),
-                            Value::BigInt(target_peer_project_id),
-                            Value::BigInt(target_peer_agent_id),
-                        ],
-                    )
-                    .map_err(|e| {
-                        DbError::Sqlite(format!(
-                            "reconstruct salvage: query existing agent_link: {e}"
-                        ))
-                    })?;
-                if existing_links.len() > 1 {
-                    return Err(DbError::Sqlite(
+                            &[
+                                Value::BigInt(target_origin_project_id),
+                                Value::BigInt(target_origin_agent_id),
+                                Value::BigInt(target_peer_project_id),
+                                Value::BigInt(target_peer_agent_id),
+                            ],
+                        )
+                        .map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: query existing agent_link: {e}"
+                            ))
+                        })?;
+                    if existing_links.len() > 1 {
+                        return Err(DbError::Sqlite(
                         "reconstruct salvage: multiple target agent_links share the same stable endpoint quartet"
                             .to_string(),
                     ));
-                }
-                let state_values = [
-                    Value::Text(link_status),
-                    Value::Text(reason),
-                    Value::BigInt(created_ts),
-                    Value::BigInt(updated_ts),
-                    expires_ts.map_or(Value::Null, Value::BigInt),
-                ];
-                if let Some(existing) = existing_links.first() {
-                    let target_link_id = existing.get_named::<i64>("id").map_err(|e| {
-                        DbError::Sqlite(format!(
-                            "reconstruct salvage: decode existing agent_link id: {e}"
-                        ))
-                    })?;
-                    let mut values = state_values.to_vec();
-                    values.push(Value::BigInt(target_link_id));
-                    target_conn
+                    }
+                    let state_values = [
+                        Value::Text(link_status),
+                        Value::Text(reason),
+                        Value::BigInt(created_ts),
+                        Value::BigInt(updated_ts),
+                        expires_ts.map_or(Value::Null, Value::BigInt),
+                    ];
+                    if let Some(existing) = existing_links.first() {
+                        let target_link_id = existing.get_named::<i64>("id").map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: decode existing agent_link id: {e}"
+                            ))
+                        })?;
+                        let mut values = state_values.to_vec();
+                        values.push(Value::BigInt(target_link_id));
+                        target_conn
                         .execute_sync(
                             "UPDATE agent_links SET status = ?, reason = ?, created_ts = ?, updated_ts = ?, expires_ts = ? WHERE id = ?",
                             &values,
@@ -3936,15 +4780,15 @@ fn merge_salvaged_database(
                                 "reconstruct salvage: restore state for agent_link {target_link_id}: {e}"
                             ))
                         })?;
-                } else {
-                    let mut values = vec![
-                        Value::BigInt(target_origin_project_id),
-                        Value::BigInt(target_origin_agent_id),
-                        Value::BigInt(target_peer_project_id),
-                        Value::BigInt(target_peer_agent_id),
-                    ];
-                    values.extend(state_values);
-                    target_conn
+                    } else {
+                        let mut values = vec![
+                            Value::BigInt(target_origin_project_id),
+                            Value::BigInt(target_origin_agent_id),
+                            Value::BigInt(target_peer_project_id),
+                            Value::BigInt(target_peer_agent_id),
+                        ];
+                        values.extend(state_values);
+                        target_conn
                         .execute_sync(
                             "INSERT INTO agent_links \
                              (a_project_id, a_agent_id, b_project_id, b_agent_id, status, reason, created_ts, updated_ts, expires_ts) \
@@ -3956,8 +4800,10 @@ fn merge_salvaged_database(
                                 "reconstruct salvage: insert agent_link {source_origin_project_id}/{source_origin_agent_id}->{source_peer_project_id}/{source_peer_agent_id}: {e}"
                             ))
                         })?;
-                }
-            }
+                    }
+                    Ok(())
+                },
+            )?;
         }
 
         if has_products {
@@ -3976,109 +4822,106 @@ fn merge_salvaged_database(
                     salvage_db_path.display()
                 ))
             })?;
-            let product_rows = salvage_conn
-                .query_sync(
-                    &format!("SELECT {product_select} FROM products ORDER BY id"),
-                    &[],
-                )
-                .map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: query products: {e}"))
-                })?;
-
-            for row in &product_rows {
-                let source_product_id = row.get_named::<i64>("id").map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: decode product id: {e}"))
-                })?;
-                if source_product_id <= 0 {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: product has non-positive id {source_product_id}"
-                    )));
-                }
-                let product_uid = row.get_named::<String>("product_uid").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode uid for product {source_product_id}: {e}"
-                    ))
-                })?;
-                let product_uid = product_uid.trim().to_string();
-                if product_uid.is_empty() {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: product {source_product_id} has an empty stable uid"
-                    )));
-                }
-                let name = row.get_named::<String>("name").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode name for product {source_product_id}: {e}"
-                    ))
-                })?;
-                let name = name.trim().to_string();
-                if name.is_empty() {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: product {source_product_id} has an empty name"
-                    )));
-                }
-
-                let uid_rows = target_conn
-                    .query_sync(
-                        "SELECT id, name FROM products WHERE product_uid = ? LIMIT 2",
-                        &[Value::Text(product_uid.clone())],
-                    )
-                    .map_err(|e| {
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "products",
+                &product_select,
+                &["id"],
+                cancelled,
+                |row| {
+                    let source_product_id = row.get_named::<i64>("id").map_err(|e| {
+                        DbError::Sqlite(format!("reconstruct salvage: decode product id: {e}"))
+                    })?;
+                    if source_product_id <= 0 {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: product has non-positive id {source_product_id}"
+                        )));
+                    }
+                    let product_uid = row.get_named::<String>("product_uid").map_err(|e| {
                         DbError::Sqlite(format!(
-                            "reconstruct salvage: query product uid {product_uid}: {e}"
+                            "reconstruct salvage: decode uid for product {source_product_id}: {e}"
                         ))
                     })?;
-                let name_rows = target_conn
-                    .query_sync(
-                        "SELECT id, product_uid FROM products WHERE name = ? LIMIT 2",
-                        &[Value::Text(name.clone())],
-                    )
-                    .map_err(|e| {
+                    let product_uid = product_uid.trim().to_string();
+                    if product_uid.is_empty() {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: product {source_product_id} has an empty stable uid"
+                        )));
+                    }
+                    let name = row.get_named::<String>("name").map_err(|e| {
                         DbError::Sqlite(format!(
-                            "reconstruct salvage: query product name {name:?}: {e}"
+                            "reconstruct salvage: decode name for product {source_product_id}: {e}"
                         ))
                     })?;
+                    let name = name.trim().to_string();
+                    if name.is_empty() {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: product {source_product_id} has an empty name"
+                        )));
+                    }
 
-                let target_product_id = if let Some(existing) = uid_rows.first() {
-                    let existing_id = existing.get_named::<i64>("id").map_err(|e| {
-                        DbError::Sqlite(format!(
-                            "reconstruct salvage: decode existing product {product_uid} id: {e}"
-                        ))
-                    })?;
-                    let existing_name = existing.get_named::<String>("name").map_err(|e| {
+                    let uid_rows = target_conn
+                        .query_sync(
+                            "SELECT id, name FROM products WHERE product_uid = ? LIMIT 2",
+                            &[Value::Text(product_uid.clone())],
+                        )
+                        .map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: query product uid {product_uid}: {e}"
+                            ))
+                        })?;
+                    let name_rows = target_conn
+                        .query_sync(
+                            "SELECT id, product_uid FROM products WHERE name = ? LIMIT 2",
+                            &[Value::Text(name.clone())],
+                        )
+                        .map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: query product name {name:?}: {e}"
+                            ))
+                        })?;
+
+                    let target_product_id = if let Some(existing) = uid_rows.first() {
+                        let existing_id = existing.get_named::<i64>("id").map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: decode existing product {product_uid} id: {e}"
+                            ))
+                        })?;
+                        let existing_name = existing.get_named::<String>("name").map_err(|e| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: decode existing product {product_uid} name: {e}"
                         ))
                     })?;
-                    if existing_name.trim() != name {
-                        return Err(DbError::Sqlite(format!(
-                            "reconstruct salvage: stable product uid {product_uid:?} has conflicting names {:?} and {name:?}; refusing ambiguous product identity",
-                            existing_name.trim()
-                        )));
-                    }
-                    if let Some(named) = name_rows.first() {
-                        let named_id = named.get_named::<i64>("id").map_err(|e| {
-                            DbError::Sqlite(format!(
-                                "reconstruct salvage: decode product name {name:?} id: {e}"
-                            ))
-                        })?;
-                        if named_id != existing_id {
+                        if existing_name.trim() != name {
                             return Err(DbError::Sqlite(format!(
-                                "reconstruct salvage: product uid {product_uid:?} and name {name:?} resolve to different target rows; refusing cross-binding"
+                                "reconstruct salvage: stable product uid {product_uid:?} has conflicting names {:?} and {name:?}; refusing ambiguous product identity",
+                                existing_name.trim()
                             )));
                         }
-                    }
-                    existing_id
-                } else {
-                    if let Some(existing) = name_rows.first() {
-                        let existing_uid = existing
-                            .get_named::<String>("product_uid")
-                            .unwrap_or_default();
-                        return Err(DbError::Sqlite(format!(
-                            "reconstruct salvage: product name {name:?} is already bound to stable uid {:?}, not {product_uid:?}; refusing name-based identity fallback",
-                            existing_uid.trim()
-                        )));
-                    }
-                    target_conn
+                        if let Some(named) = name_rows.first() {
+                            let named_id = named.get_named::<i64>("id").map_err(|e| {
+                                DbError::Sqlite(format!(
+                                    "reconstruct salvage: decode product name {name:?} id: {e}"
+                                ))
+                            })?;
+                            if named_id != existing_id {
+                                return Err(DbError::Sqlite(format!(
+                                    "reconstruct salvage: product uid {product_uid:?} and name {name:?} resolve to different target rows; refusing cross-binding"
+                                )));
+                            }
+                        }
+                        existing_id
+                    } else {
+                        if let Some(existing) = name_rows.first() {
+                            let existing_uid = existing
+                                .get_named::<String>("product_uid")
+                                .unwrap_or_default();
+                            return Err(DbError::Sqlite(format!(
+                                "reconstruct salvage: product name {name:?} is already bound to stable uid {:?}, not {product_uid:?}; refusing name-based identity fallback",
+                                existing_uid.trim()
+                            )));
+                        }
+                        target_conn
                         .execute_sync(
                             "INSERT INTO products (product_uid, name, created_at) VALUES (?, ?, ?)",
                             &[
@@ -4095,15 +4938,22 @@ fn merge_salvaged_database(
                                 "reconstruct salvage: insert product {product_uid}: {e}"
                             ))
                         })?;
-                    query_last_insert_or_existing_id(
-                        &target_conn,
-                        "products",
-                        "product_uid",
-                        &product_uid,
-                    )?
-                };
-                product_id_map.insert(source_product_id, target_product_id);
-            }
+                        query_last_insert_or_existing_id(
+                            &target_conn,
+                            "products",
+                            "product_uid",
+                            &product_uid,
+                        )?
+                    };
+                    insert_salvage_id_mapping(
+                        &mut product_id_map,
+                        source_product_id,
+                        target_product_id,
+                        "product_id_map",
+                    )?;
+                    Ok(())
+                },
+            )?;
         }
 
         if has_product_project_links {
@@ -4122,47 +4972,37 @@ fn merge_salvaged_database(
                     salvage_db_path.display()
                 ))
             })?;
-            let product_link_rows = salvage_conn
-                .query_sync(
-                    &format!(
-                        "SELECT {product_link_select} FROM product_project_links \
-                             ORDER BY product_id, project_id"
-                    ),
-                    &[],
-                )
-                .map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: query product_project_links: {e}"
-                    ))
-                })?;
-            if !product_link_rows.is_empty()
-                && (product_id_map.is_empty() || project_id_map.is_empty())
-            {
-                return Err(DbError::Sqlite(format!(
-                    "reconstruct salvage: {} has product_project_links rows but stable product/project identity maps are unavailable",
-                    salvage_db_path.display()
-                )));
-            }
-
-            for row in &product_link_rows {
-                let source_product_id = row.get_named::<i64>("product_id").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode product_project_link product id: {e}"
-                    ))
-                })?;
-                let source_project_id = row.get_named::<i64>("project_id").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode product_project_link project id: {e}"
-                    ))
-                })?;
-                let target_product_id = *product_id_map
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "product_project_links",
+                &product_link_select,
+                &["product_id", "project_id"],
+                cancelled,
+                |row| {
+                    if product_id_map.is_empty() || project_id_map.is_empty() {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: {} has product_project_links rows but stable product/project identity maps are unavailable",
+                            salvage_db_path.display()
+                        )));
+                    }
+                    let source_product_id = row.get_named::<i64>("product_id").map_err(|e| {
+                        DbError::Sqlite(format!(
+                            "reconstruct salvage: decode product_project_link product id: {e}"
+                        ))
+                    })?;
+                    let source_project_id = row.get_named::<i64>("project_id").map_err(|e| {
+                        DbError::Sqlite(format!(
+                            "reconstruct salvage: decode product_project_link project id: {e}"
+                        ))
+                    })?;
+                    let target_product_id = *product_id_map
                             .get(&source_product_id)
                             .ok_or_else(|| {
                                 DbError::Sqlite(format!(
                                     "reconstruct salvage: product_project_link references unmapped product {source_product_id}"
                                 ))
                             })?;
-                let target_project_id = *project_id_map
+                    let target_project_id = *project_id_map
                             .get(&source_project_id)
                             .ok_or_else(|| {
                                 DbError::Sqlite(format!(
@@ -4170,7 +5010,7 @@ fn merge_salvaged_database(
                                 ))
                             })?;
 
-                target_conn
+                    target_conn
                         .execute_sync(
                             "INSERT OR IGNORE INTO product_project_links (product_id, project_id, created_at) VALUES (?, ?, ?)",
                             &[
@@ -4188,7 +5028,9 @@ fn merge_salvaged_database(
                                  {source_product_id}->{source_project_id}: {e}"
                             ))
                         })?;
-            }
+                    Ok(())
+                },
+            )?;
         }
 
         if has_proof_gate_consumed_nonces {
@@ -4207,99 +5049,93 @@ fn merge_salvaged_database(
                     salvage_db_path.display()
                 ))
             })?;
-            let nonce_rows = salvage_conn
-                .query_sync(
-                    &format!(
-                        "SELECT {nonce_select} FROM proof_gate_consumed_nonces ORDER BY issuer_key, nonce"
-                    ),
-                    &[],
-                )
-                .map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: query proof_gate_consumed_nonces: {e}"
-                    ))
-                })?;
-
-            for row in &nonce_rows {
-                let issuer_key = row
-                    .get_named::<String>("issuer_key")
-                    .map_err(|e| {
-                        DbError::Sqlite(format!(
-                            "reconstruct salvage: decode proof nonce issuer key: {e}"
-                        ))
-                    })?
-                    .trim()
-                    .to_string();
-                let nonce = row
-                    .get_named::<String>("nonce")
-                    .map_err(|e| {
-                        DbError::Sqlite(format!(
-                            "reconstruct salvage: decode proof nonce value: {e}"
-                        ))
-                    })?
-                    .trim()
-                    .to_string();
-                if issuer_key.is_empty() || nonce.is_empty() {
-                    return Err(DbError::Sqlite(
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "proof_gate_consumed_nonces",
+                &nonce_select,
+                &["issuer_key", "nonce"],
+                cancelled,
+                |row| {
+                    let issuer_key = row
+                        .get_named::<String>("issuer_key")
+                        .map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: decode proof nonce issuer key: {e}"
+                            ))
+                        })?
+                        .trim()
+                        .to_string();
+                    let nonce = row
+                        .get_named::<String>("nonce")
+                        .map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: decode proof nonce value: {e}"
+                            ))
+                        })?
+                        .trim()
+                        .to_string();
+                    if issuer_key.is_empty() || nonce.is_empty() {
+                        return Err(DbError::Sqlite(
                         "reconstruct salvage: consumed proof nonce has an empty stable issuer/nonce key"
                             .to_string(),
                     ));
-                }
-                let retain_until = row.get_named::<i64>("retain_until").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode retain_until for proof nonce: {e}"
-                    ))
-                })?;
-                let consumed_at = row.get_named::<i64>("consumed_at").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode consumed_at for proof nonce: {e}"
-                    ))
-                })?;
-                let existing = target_conn
-                    .query_sync(
-                        "SELECT retain_until, consumed_at FROM proof_gate_consumed_nonces \
-                         WHERE issuer_key = ? AND nonce = ? LIMIT 2",
-                        &[Value::Text(issuer_key.clone()), Value::Text(nonce.clone())],
-                    )
-                    .map_err(|e| {
-                        DbError::Sqlite(format!(
-                            "reconstruct salvage: query existing consumed proof nonce: {e}"
-                        ))
-                    })?;
-                if let Some(existing) = existing.first() {
-                    let current_retain_until = existing
-                        .get_named::<i64>("retain_until")
-                        .unwrap_or_default();
-                    let current_consumed_at =
-                        existing.get_named::<i64>("consumed_at").unwrap_or_default();
-                    if current_retain_until != retain_until || current_consumed_at != consumed_at {
-                        return Err(DbError::Sqlite(format!(
-                            "reconstruct salvage: consumed proof nonce ({issuer_key:?}, {nonce:?}) has conflicting durable timestamps; refusing to weaken replay prevention"
-                        )));
                     }
-                    continue;
-                }
-                target_conn
-                    .execute_sync(
-                        "INSERT INTO proof_gate_consumed_nonces \
-                         (issuer_key, nonce, retain_until, consumed_at) VALUES (?, ?, ?, ?)",
-                        &[
-                            Value::Text(issuer_key),
-                            Value::Text(nonce),
-                            Value::BigInt(retain_until),
-                            Value::BigInt(consumed_at),
-                        ],
-                    )
-                    .map_err(|e| {
+                    let retain_until = row.get_named::<i64>("retain_until").map_err(|e| {
                         DbError::Sqlite(format!(
-                            "reconstruct salvage: insert consumed proof nonce: {e}"
+                            "reconstruct salvage: decode retain_until for proof nonce: {e}"
                         ))
                     })?;
-            }
+                    let consumed_at = row.get_named::<i64>("consumed_at").map_err(|e| {
+                        DbError::Sqlite(format!(
+                            "reconstruct salvage: decode consumed_at for proof nonce: {e}"
+                        ))
+                    })?;
+                    let existing = target_conn
+                        .query_sync(
+                            "SELECT retain_until, consumed_at FROM proof_gate_consumed_nonces \
+                         WHERE issuer_key = ? AND nonce = ? LIMIT 2",
+                            &[Value::Text(issuer_key.clone()), Value::Text(nonce.clone())],
+                        )
+                        .map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: query existing consumed proof nonce: {e}"
+                            ))
+                        })?;
+                    if let Some(existing) = existing.first() {
+                        let current_retain_until = existing
+                            .get_named::<i64>("retain_until")
+                            .unwrap_or_default();
+                        let current_consumed_at =
+                            existing.get_named::<i64>("consumed_at").unwrap_or_default();
+                        if current_retain_until != retain_until
+                            || current_consumed_at != consumed_at
+                        {
+                            return Err(DbError::Sqlite(format!(
+                                "reconstruct salvage: consumed proof nonce ({issuer_key:?}, {nonce:?}) has conflicting durable timestamps; refusing to weaken replay prevention"
+                            )));
+                        }
+                        return Ok(());
+                    }
+                    target_conn
+                        .execute_sync(
+                            "INSERT INTO proof_gate_consumed_nonces \
+                         (issuer_key, nonce, retain_until, consumed_at) VALUES (?, ?, ?, ?)",
+                            &[
+                                Value::Text(issuer_key),
+                                Value::Text(nonce),
+                                Value::BigInt(retain_until),
+                                Value::BigInt(consumed_at),
+                            ],
+                        )
+                        .map_err(|e| {
+                            DbError::Sqlite(format!(
+                                "reconstruct salvage: insert consumed proof nonce: {e}"
+                            ))
+                        })?;
+                    Ok(())
+                },
+            )?;
         }
-
-        let mut reconstructed_recipient_agent_ids: HashMap<(i64, String), i64> = HashMap::new();
-        let mut recipient_json_updates = BTreeSet::new();
 
         if has_messages {
             let message_columns = table_columns(&salvage_conn, "messages")?;
@@ -4333,95 +5169,99 @@ fn merge_salvaged_database(
                         .to_owned(),
                 ));
             }
-
-            let message_rows = salvage_conn
-                .query_sync(
-                    &format!("SELECT {message_select} FROM messages ORDER BY id"),
-                    &[],
-                )
-                .map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: query messages: {e}"))
-                })?;
-
-            for row in &message_rows {
-                let source_message_id = row.get_named::<i64>("id").map_err(|e| {
-                    DbError::Sqlite(format!("reconstruct salvage: decode message id: {e}"))
-                })?;
-                if source_message_id <= 0 {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: message has non-positive id {source_message_id}"
-                    )));
-                }
-                let source_project_id = row.get_named::<i64>("project_id").map_err(|e| {
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "messages",
+                &message_select,
+                &["id"],
+                cancelled,
+                |row| {
+                    let source_message_id = row.get_named::<i64>("id").map_err(|e| {
+                        DbError::Sqlite(format!("reconstruct salvage: decode message id: {e}"))
+                    })?;
+                    if source_message_id <= 0 {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: message has non-positive id {source_message_id}"
+                        )));
+                    }
+                    let source_project_id = row.get_named::<i64>("project_id").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode project_id for message {source_message_id}: {e}"
                     ))
                 })?;
-                let target_project_id = *project_id_map.get(&source_project_id).ok_or_else(|| {
+                    let target_project_id = *project_id_map.get(&source_project_id).ok_or_else(|| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: message {source_message_id} referenced unmapped project id {source_project_id}"
                     ))
                 })?;
-                let source_sender_id = row.get_named::<i64>("sender_id").map_err(|e| {
+                    let source_sender_id = row.get_named::<i64>("sender_id").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode sender_id for message {source_message_id}: {e}"
                     ))
                 })?;
-                let target_sender_id = *agent_id_map.get(&source_sender_id).ok_or_else(|| {
+                    let target_sender_id = *agent_id_map.get(&source_sender_id).ok_or_else(|| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: message {source_message_id} referenced unmapped sender id {source_sender_id}"
                     ))
                 })?;
-                if agent_project_id(&target_conn, target_sender_id)? != Some(target_project_id) {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: message {source_message_id} maps sender {source_sender_id} outside project {source_project_id}; refusing cross-project ownership"
-                    )));
-                }
+                    if agent_project_id(&target_conn, target_sender_id)? != Some(target_project_id)
+                    {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: message {source_message_id} maps sender {source_sender_id} outside project {source_project_id}; refusing cross-project ownership"
+                        )));
+                    }
 
-                if message_project_id(&target_conn, source_message_id)? == Some(target_project_id) {
-                    message_id_map.insert(source_message_id, source_message_id);
-                    continue;
-                }
+                    if message_project_id(&target_conn, source_message_id)?
+                        == Some(target_project_id)
+                    {
+                        insert_salvage_id_mapping(
+                            &mut message_id_map,
+                            source_message_id,
+                            source_message_id,
+                            "message_id_map",
+                        )?;
+                        return Ok(());
+                    }
 
-                let thread_id = row
-                    .get_named::<String>("thread_id")
-                    .ok()
-                    .and_then(|raw: String| sanitize_reconstructed_thread_id(raw.as_str()));
-                let thread_value = thread_id.map_or(Value::Null, Value::Text);
-                let (recipients_json, to_names, cc_names, bcc_names) =
-                    parse_salvaged_recipients_json(
-                        row.get_named::<String>("recipients_json").ok(),
+                    let thread_id = row
+                        .get_named::<String>("thread_id")
+                        .ok()
+                        .and_then(|raw: String| sanitize_reconstructed_thread_id(raw.as_str()));
+                    let thread_value = thread_id.map_or(Value::Null, Value::Text);
+                    let (recipients_json, to_names, cc_names, bcc_names) =
+                        parse_salvaged_recipients_json(
+                            row.get_named::<String>("recipients_json").ok(),
+                            source_message_id,
+                            stats,
+                        );
+                    let attachments = parse_salvaged_attachments_json(
+                        row.get_named::<String>("attachments").ok(),
                         source_message_id,
                         stats,
                     );
-                let attachments = parse_salvaged_attachments_json(
-                    row.get_named::<String>("attachments").ok(),
-                    source_message_id,
-                    stats,
-                );
-                let values = [
-                    Value::BigInt(target_project_id),
-                    Value::BigInt(target_sender_id),
-                    thread_value,
-                    Value::Text(row.get_named::<String>("subject").unwrap_or_default()),
-                    Value::Text(row.get_named::<String>("body_md").unwrap_or_default()),
-                    Value::Text(
-                        row.get_named::<String>("importance")
-                            .unwrap_or_else(|_| "normal".to_string()),
-                    ),
-                    Value::BigInt(i64::from(
-                        row.get_named::<i64>("ack_required").unwrap_or(0) != 0,
-                    )),
-                    Value::BigInt(
-                        row.get_named::<i64>("created_ts")
-                            .unwrap_or_else(|_| crate::now_micros()),
-                    ),
-                    Value::Text(recipients_json),
-                    Value::Text(attachments),
-                ];
-                let existing_project_id = message_project_id(&target_conn, source_message_id)?;
-                let target_message_id = if let Some(existing_project_id) = existing_project_id {
-                    target_conn
+                    let values = [
+                        Value::BigInt(target_project_id),
+                        Value::BigInt(target_sender_id),
+                        thread_value,
+                        Value::Text(row.get_named::<String>("subject").unwrap_or_default()),
+                        Value::Text(row.get_named::<String>("body_md").unwrap_or_default()),
+                        Value::Text(
+                            row.get_named::<String>("importance")
+                                .unwrap_or_else(|_| "normal".to_string()),
+                        ),
+                        Value::BigInt(i64::from(
+                            row.get_named::<i64>("ack_required").unwrap_or(0) != 0,
+                        )),
+                        Value::BigInt(
+                            row.get_named::<i64>("created_ts")
+                                .unwrap_or_else(|_| crate::now_micros()),
+                        ),
+                        Value::Text(recipients_json),
+                        Value::Text(attachments),
+                    ];
+                    let existing_project_id = message_project_id(&target_conn, source_message_id)?;
+                    let target_message_id = if let Some(existing_project_id) = existing_project_id {
+                        target_conn
                         .execute_sync(
                             "INSERT INTO messages \
                              (project_id, sender_id, thread_id, subject, body_md, importance, ack_required, created_ts, recipients_json, attachments) \
@@ -4433,17 +5273,17 @@ fn merge_salvaged_database(
                                 "reconstruct salvage: remap cross-project message {source_message_id}: {e}"
                             ))
                         })?;
-                    let remapped_id = query_last_insert_rowid(&target_conn)?;
-                    stats.salvaged_message_id_remaps += 1;
-                    stats.warnings.push(format!(
+                        let remapped_id = query_last_insert_rowid(&target_conn)?;
+                        stats.salvaged_message_id_remaps += 1;
+                        stats.push_warning(format!(
                         "Salvage message id {source_message_id} belonged to remapped project {target_project_id}, but the archive candidate already used that numeric id for project {existing_project_id}; preserved it as message {remapped_id}"
                     ));
-                    remapped_id
-                } else {
-                    let mut values_with_id = Vec::with_capacity(values.len() + 1);
-                    values_with_id.push(Value::BigInt(source_message_id));
-                    values_with_id.extend(values);
-                    target_conn
+                        remapped_id
+                    } else {
+                        let mut values_with_id = Vec::with_capacity(values.len() + 1);
+                        values_with_id.push(Value::BigInt(source_message_id));
+                        values_with_id.extend(values);
+                        target_conn
                         .execute_sync(
                             "INSERT INTO messages \
                              (id, project_id, sender_id, thread_id, subject, body_md, importance, ack_required, created_ts, recipients_json, attachments) \
@@ -4455,25 +5295,33 @@ fn merge_salvaged_database(
                                 "reconstruct salvage: insert message {source_message_id}: {e}"
                             ))
                         })?;
-                    source_message_id
-                };
-                message_id_map.insert(source_message_id, target_message_id);
-                stats.salvaged_messages += 1;
+                        source_message_id
+                    };
+                    insert_salvage_id_mapping(
+                        &mut message_id_map,
+                        source_message_id,
+                        target_message_id,
+                        "message_id_map",
+                    )?;
+                    stats.salvaged_messages += 1;
 
-                for (names, kind) in [(&to_names, "to"), (&cc_names, "cc"), (&bcc_names, "bcc")] {
-                    for name in names {
-                        let agent_id = ensure_agent_exists(
-                            &target_conn,
-                            target_project_id,
-                            name,
-                            &mut reconstructed_recipient_agent_ids,
-                        )?;
-                        insert_recipient(&target_conn, target_message_id, agent_id, kind)?;
-                        stats.salvaged_recipients += 1;
-                        recipient_json_updates.insert(target_message_id);
+                    for (names, kind) in [(&to_names, "to"), (&cc_names, "cc"), (&bcc_names, "bcc")]
+                    {
+                        for name in names {
+                            ensure_reconstruction_not_cancelled(cancelled)?;
+                            let agent_id = ensure_agent_exists_uncached(
+                                &target_conn,
+                                target_project_id,
+                                name,
+                            )?;
+                            insert_recipient(&target_conn, target_message_id, agent_id, kind)?;
+                            stats.salvaged_recipients += 1;
+                        }
                     }
-                }
-            }
+                    sync_reconstructed_message_recipients_json(&target_conn, target_message_id)?;
+                    Ok(())
+                },
+            )?;
         }
 
         if has_recipients {
@@ -4492,43 +5340,44 @@ fn merge_salvaged_database(
                     salvage_db_path.display()
                 ))
             })?;
-            let recipient_rows = salvage_conn
-                .query_sync(
-                &format!(
-                    "SELECT {recipient_select} FROM message_recipients ORDER BY message_id, agent_id, kind"
-                ),
-                &[],
-            )
-            .map_err(|e| DbError::Sqlite(format!("reconstruct salvage: query recipients: {e}")))?;
-
-            for row in &recipient_rows {
-                let source_message_id = row.get_named::<i64>("message_id").map_err(|e| {
-                    DbError::Sqlite(format!(
-                        "reconstruct salvage: decode recipient message_id: {e}"
-                    ))
-                })?;
-                let source_agent_id = row.get_named::<i64>("agent_id").map_err(|e| {
+            // Source recipient rows are ordered by message identity. Keep only
+            // the current target id so recipients_json is rebuilt once per
+            // message without reviving the old unbounded pending-id set.
+            let mut recipient_message_pending_sync = None;
+            for_each_salvage_row_keyset(
+                &salvage_conn,
+                "message_recipients",
+                &recipient_select,
+                &["message_id", "agent_id", "kind"],
+                cancelled,
+                |row| {
+                    let source_message_id = row.get_named::<i64>("message_id").map_err(|e| {
+                        DbError::Sqlite(format!(
+                            "reconstruct salvage: decode recipient message_id: {e}"
+                        ))
+                    })?;
+                    let source_agent_id = row.get_named::<i64>("agent_id").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode agent_id for message {source_message_id}: {e}"
                     ))
                 })?;
-                let target_agent_id = *agent_id_map.get(&source_agent_id).ok_or_else(|| {
+                    let target_agent_id = *agent_id_map.get(&source_agent_id).ok_or_else(|| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: recipient for message {source_message_id} references unmapped agent id {source_agent_id}"
                     ))
                 })?;
-                let target_agent_project_id = agent_project_id(&target_conn, target_agent_id)?
+                    let target_agent_project_id = agent_project_id(&target_conn, target_agent_id)?
                     .ok_or_else(|| {
                         DbError::Sqlite(format!(
                             "reconstruct salvage: mapped target agent {target_agent_id} is missing"
                         ))
                     })?;
-                let target_message_id = *message_id_map.get(&source_message_id).ok_or_else(|| {
+                    let target_message_id = *message_id_map.get(&source_message_id).ok_or_else(|| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: recipient references unmapped source-local message id {source_message_id}; refusing to attach state without a decoded salvage message identity"
                     ))
                 })?;
-                let target_message_project_id = message_project_id(
+                    let target_message_project_id = message_project_id(
                     &target_conn,
                     target_message_id,
                 )?
@@ -4537,22 +5386,29 @@ fn merge_salvaged_database(
                         "reconstruct salvage: mapped target message {target_message_id} is missing"
                     ))
                 })?;
-                if target_agent_project_id != target_message_project_id {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: recipient agent {source_agent_id} for message {source_message_id} maps outside the message project; refusing cross-project recipient state"
-                    )));
-                }
-                let raw_kind = row.get_named::<String>("kind").ok();
-                let kind = normalize_salvaged_recipient_kind(
-                    raw_kind.as_deref(),
-                    target_message_id,
-                    stats,
-                );
-                let read_ts = row.get_named::<i64>("read_ts").ok();
-                let ack_ts = row.get_named::<i64>("ack_ts").ok();
-                recipient_json_updates.insert(target_message_id);
-
-                let existing_rows = target_conn
+                    if target_agent_project_id != target_message_project_id {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: recipient agent {source_agent_id} for message {source_message_id} maps outside the message project; refusing cross-project recipient state"
+                        )));
+                    }
+                    if recipient_message_pending_sync != Some(target_message_id) {
+                        if let Some(previous_message_id) = recipient_message_pending_sync.take() {
+                            sync_reconstructed_message_recipients_json(
+                                &target_conn,
+                                previous_message_id,
+                            )?;
+                        }
+                        recipient_message_pending_sync = Some(target_message_id);
+                    }
+                    let raw_kind = row.get_named::<String>("kind").ok();
+                    let kind = normalize_salvaged_recipient_kind(
+                        raw_kind.as_deref(),
+                        target_message_id,
+                        stats,
+                    );
+                    let read_ts = row.get_named::<i64>("read_ts").ok();
+                    let ack_ts = row.get_named::<i64>("ack_ts").ok();
+                    let existing_rows = target_conn
                     .query_sync(
                         "SELECT kind, read_ts, ack_ts FROM message_recipients \
                          WHERE message_id = ? AND agent_id = ? LIMIT 2",
@@ -4567,14 +5423,14 @@ fn merge_salvaged_database(
                         ))
                     })?;
 
-                if existing_rows.len() > 1 {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: message {target_message_id} and agent {target_agent_id} have multiple rows despite their stable recipient primary key"
-                    )));
-                }
+                    if existing_rows.len() > 1 {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: message {target_message_id} and agent {target_agent_id} have multiple rows despite their stable recipient primary key"
+                        )));
+                    }
 
-                if existing_rows.is_empty() {
-                    target_conn
+                    if existing_rows.is_empty() {
+                        target_conn
                         .execute_sync(
                             "INSERT INTO message_recipients (message_id, agent_id, kind, read_ts, ack_ts) \
                              VALUES (?, ?, ?, ?, ?)",
@@ -4591,29 +5447,29 @@ fn merge_salvaged_database(
                                 "reconstruct salvage: insert recipient for message {source_message_id}->{target_message_id}: {e}"
                             ))
                         })?;
-                    stats.salvaged_recipients += 1;
-                    continue;
-                }
+                        stats.salvaged_recipients += 1;
+                        return Ok(());
+                    }
 
-                let existing_row = &existing_rows[0];
-                let current_kind = existing_row.get_named::<String>("kind").map_err(|e| {
+                    let existing_row = &existing_rows[0];
+                    let current_kind = existing_row.get_named::<String>("kind").map_err(|e| {
                     DbError::Sqlite(format!(
                         "reconstruct salvage: decode recipient kind for message {target_message_id}: {e}"
                     ))
                 })?;
-                if current_kind != kind {
-                    return Err(DbError::Sqlite(format!(
-                        "reconstruct salvage: recipient ({target_message_id}, {target_agent_id}) has conflicting kinds {current_kind:?} and {kind:?}; refusing a primary-key collision"
-                    )));
-                }
-                let current_read_ts = existing_row
-                    .get_named::<Option<i64>>("read_ts")
-                    .unwrap_or_default();
-                let current_ack_ts = existing_row
-                    .get_named::<Option<i64>>("ack_ts")
-                    .unwrap_or_default();
-                if current_read_ts != read_ts || current_ack_ts != ack_ts {
-                    target_conn
+                    if current_kind != kind {
+                        return Err(DbError::Sqlite(format!(
+                            "reconstruct salvage: recipient ({target_message_id}, {target_agent_id}) has conflicting kinds {current_kind:?} and {kind:?}; refusing a primary-key collision"
+                        )));
+                    }
+                    let current_read_ts = existing_row
+                        .get_named::<Option<i64>>("read_ts")
+                        .unwrap_or_default();
+                    let current_ack_ts = existing_row
+                        .get_named::<Option<i64>>("ack_ts")
+                        .unwrap_or_default();
+                    if current_read_ts != read_ts || current_ack_ts != ack_ts {
+                        target_conn
                         .execute_sync(
                             "UPDATE message_recipients SET \
                                  read_ts = ?, ack_ts = ? \
@@ -4630,13 +5486,14 @@ fn merge_salvaged_database(
                                 "reconstruct salvage: update recipient state for message {source_message_id}->{target_message_id}: {e}"
                             ))
                         })?;
-                    stats.salvaged_recipients += 1;
-                }
+                        stats.salvaged_recipients += 1;
+                    }
+                    Ok(())
+                },
+            )?;
+            if let Some(message_id) = recipient_message_pending_sync {
+                sync_reconstructed_message_recipients_json(&target_conn, message_id)?;
             }
-        }
-
-        for message_id in recipient_json_updates {
-            sync_reconstructed_message_recipients_json(&target_conn, message_id)?;
         }
 
         // ATC telemetry now lives in the independent sidecar DB (atc.sqlite3),
@@ -4646,6 +5503,7 @@ fn merge_salvaged_database(
         // telemetry is, by design, droppable/resettable. `rollups_salvaged`
         // therefore stays 0.
 
+        ensure_reconstruction_not_cancelled(cancelled)?;
         let cross_project_reservations = target_conn
             .query_sync(
                 "SELECT fr.id AS id \
@@ -4666,6 +5524,7 @@ fn merge_salvaged_database(
             )));
         }
 
+        ensure_reconstruction_not_cancelled(cancelled)?;
         let cross_project_recipients = target_conn
             .query_sync(
                 "SELECT mr.message_id AS message_id, mr.agent_id AS agent_id \
@@ -4688,23 +5547,9 @@ fn merge_salvaged_database(
             )));
         }
 
-        let foreign_key_failures = target_conn
-            .query_sync("PRAGMA foreign_key_check", &[])
-            .map_err(|e| {
-                DbError::Sqlite(format!(
-                    "reconstruct salvage: run post-merge foreign_key_check: {e}"
-                ))
-            })?;
-        if !foreign_key_failures.is_empty() {
-            return Err(DbError::Sqlite(format!(
-                "reconstruct salvage: post-merge foreign_key_check reported {} violation(s); refusing promotion",
-                foreign_key_failures.len()
-            )));
-        }
+        verify_reconstructed_foreign_keys_bounded(&target_conn, cancelled)?;
 
-        target_conn
-            .execute_raw("REINDEX;")
-            .map_err(|e| DbError::Sqlite(format!("reconstruct salvage: REINDEX: {e}")))?;
+        ensure_reconstruction_not_cancelled(cancelled)?;
         Ok(())
     })();
 
@@ -4722,7 +5567,7 @@ fn merge_salvaged_database(
     }
     drop(target_conn);
     if let Err(e) = crate::pool::wal_checkpoint_truncate_path(target_db_path) {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Salvage merge committed, but WAL checkpoint failed for {}: {e}",
             target_db_path.display()
         ));
@@ -4745,7 +5590,7 @@ fn read_project_human_key(project_path: &Path, slug: &str, stats: &mut Reconstru
     let fallback = synthetic_project_placeholder_human_key(slug);
 
     if !is_real_file(&metadata_path) {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Missing {}; using fallback human_key '{}'",
             metadata_path.display(),
             fallback
@@ -4757,7 +5602,7 @@ fn read_project_human_key(project_path: &Path, slug: &str, stats: &mut Reconstru
         Ok(s) => s,
         Err(e) => {
             stats.parse_errors += 1;
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Cannot read {}: {e}; using fallback human_key '{}'",
                 metadata_path.display(),
                 fallback
@@ -4770,7 +5615,7 @@ fn read_project_human_key(project_path: &Path, slug: &str, stats: &mut Reconstru
         Ok(v) => v,
         Err(e) => {
             stats.parse_errors += 1;
-            stats.warnings.push(format!(
+            stats.push_warning(format!(
                 "Cannot parse {}: {e}; using fallback human_key '{}'",
                 metadata_path.display(),
                 fallback
@@ -4786,7 +5631,7 @@ fn read_project_human_key(project_path: &Path, slug: &str, stats: &mut Reconstru
         .filter(|s| !s.is_empty())
     else {
         stats.parse_errors += 1;
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Missing/empty human_key in {}; using fallback human_key '{}'",
             metadata_path.display(),
             fallback
@@ -4796,7 +5641,7 @@ fn read_project_human_key(project_path: &Path, slug: &str, stats: &mut Reconstru
 
     if !Path::new(human_key).is_absolute() {
         stats.parse_errors += 1;
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Non-absolute human_key '{}' in {}; using fallback human_key '{}'",
             human_key,
             metadata_path.display(),
@@ -4812,7 +5657,7 @@ fn read_project_human_key(project_path: &Path, slug: &str, stats: &mut Reconstru
         .filter(|s| !s.is_empty())
         && metadata_slug != slug
     {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Project metadata slug mismatch in {}: dir slug='{}', metadata slug='{}'",
             metadata_path.display(),
             slug,
@@ -4898,7 +5743,7 @@ fn normalize_reconstructed_required_agent_field(
     };
     let normalized = raw.trim();
     if normalized.is_empty() {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Reconstruct {source} had empty {field}; defaulting to {fallback:?}"
         ));
         fallback.to_string()
@@ -4919,7 +5764,7 @@ fn normalize_reconstructed_attachments_policy(
     if VALID_RECONSTRUCTED_ATTACHMENTS_POLICIES.contains(&normalized.as_str()) {
         normalized
     } else {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Reconstruct {source} had invalid attachments_policy {raw:?}; defaulting to \"auto\""
         ));
         "auto".to_string()
@@ -4938,7 +5783,7 @@ fn normalize_reconstructed_contact_policy(
     if VALID_RECONSTRUCTED_CONTACT_POLICIES.contains(&normalized.as_str()) {
         normalized
     } else {
-        stats.warnings.push(format!(
+        stats.push_warning(format!(
             "Reconstruct {source} had invalid contact_policy {raw:?}; defaulting to \"auto\""
         ));
         "auto".to_string()
@@ -5064,6 +5909,25 @@ fn extract_id_from_rows(rows: &[sqlmodel_core::Row]) -> Option<i64> {
 mod tests {
     use super::*;
 
+    fn guarded_salvage_projection(
+        conn: &DbConn,
+        table: &str,
+        required: &[&str],
+        optional: &[&str],
+    ) -> SalvageProjection {
+        let columns = table_columns(conn, table).expect("inspect hostile salvage columns");
+        let mut stats = ReconstructStats::default();
+        build_salvage_select(
+            table,
+            &columns,
+            required,
+            optional,
+            &mut stats,
+            Path::new(":memory:"),
+        )
+        .expect("build guarded salvage projection")
+    }
+
     fn message_one_recipients_json(conn: &DbConn) -> serde_json::Value {
         let rows = conn
             .query_sync("SELECT recipients_json FROM messages WHERE id = 1", &[])
@@ -5088,6 +5952,612 @@ mod tests {
         assert!(!is_reconstruct_benign_migration_error(
             "no such table: agents"
         ));
+    }
+
+    #[test]
+    fn cx_cancellation_rolls_back_partial_message_replay() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let storage_root = temp.path().join("archive");
+        let project_dir = storage_root.join("projects").join("cancel-project");
+        let message_dir = project_dir.join("messages").join("2026").join("07");
+        std::fs::create_dir_all(&message_dir).expect("create message directory");
+        std::fs::write(
+            project_dir.join("project.json"),
+            r#"{"slug":"cancel-project","human_key":"/cancel-project"}"#,
+        )
+        .expect("write project metadata");
+
+        for message_id in 1..=128 {
+            std::fs::write(
+                message_dir.join(format!(
+                    "2026-07-18T00-00-{message_id:03}Z__cancel__{message_id}.md"
+                )),
+                format!(
+                    "---json\n{{\"id\":{message_id},\"from\":\"RedPeak\",\"to\":[],\"subject\":\"message {message_id}\",\"created_ts\":0}}\n---\nbody\n"
+                ),
+            )
+            .expect("write message artifact");
+        }
+
+        let checks = AtomicUsize::new(0);
+        let cx = asupersync::Cx::for_testing();
+        let db_path = temp.path().join("cancelled.sqlite3");
+        let error = reconstruct_from_archive_cancellable(&db_path, &storage_root, &|| {
+            if checks.fetch_add(1, Ordering::SeqCst) >= 150 {
+                cx.set_cancel_requested(true);
+            }
+            cx.is_cancel_requested()
+        })
+        .expect_err("mid-replay cancellation must abort reconstruction");
+        assert!(
+            matches!(error, DbError::ResourceBusy(ref detail) if detail == RECONSTRUCTION_CANCELLED_DETAIL),
+            "unexpected cancellation error: {error}"
+        );
+        assert!(
+            checks.load(Ordering::SeqCst) > 150,
+            "the callback must be exercised after artifact discovery reaches message replay"
+        );
+        assert!(cx.is_cancel_requested());
+
+        let conn = DbConn::open_file(db_path.to_string_lossy().as_ref())
+            .expect("open cancelled candidate");
+        let project_tables = conn
+            .query_sync(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'projects'",
+                &[],
+            )
+            .expect("inspect rolled-back schema");
+        assert!(
+            project_tables.is_empty(),
+            "cancellation must roll back the partial archive replay transaction"
+        );
+    }
+
+    #[test]
+    fn cancellation_rolls_back_partial_salvage_merge() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let storage_root = temp.path().join("archive");
+        std::fs::create_dir_all(storage_root.join("projects")).expect("create empty archive");
+        let salvage_path = temp.path().join("salvage.sqlite3");
+        let salvage = DbConn::open_file(salvage_path.to_string_lossy().as_ref())
+            .expect("open salvage fixture");
+        salvage
+            .execute_raw(&crate::schema::init_schema_sql_base())
+            .expect("initialize salvage schema");
+        salvage
+            .query_sync(
+                "INSERT INTO projects (id, slug, human_key, created_at)
+                 VALUES (100, 'salvage-project', '/salvage-project', 1)",
+                &[],
+            )
+            .expect("insert salvage project");
+        salvage
+            .query_sync(
+                "INSERT INTO agents
+                 (id, project_id, name, program, model, task_description, inception_ts,
+                  last_active_ts, attachments_policy, contact_policy)
+                 VALUES (10, 100, 'RedPeak', 'test', 'test', '', 1, 1, 'auto', 'auto')",
+                &[],
+            )
+            .expect("insert salvage agent");
+        for message_id in 1..=600 {
+            salvage
+                .query_sync(
+                    "INSERT INTO messages
+                     (id, project_id, sender_id, thread_id, subject, body_md, importance,
+                      ack_required, created_ts, attachments, recipients_json)
+                     VALUES (?, 100, 10, NULL, ?, 'body', 'normal', 0, ?, '[]',
+                             '{\"to\":[],\"cc\":[],\"bcc\":[]}')",
+                    &[
+                        Value::BigInt(message_id),
+                        Value::Text(format!("message {message_id}")),
+                        Value::BigInt(message_id),
+                    ],
+                )
+                .expect("insert salvage message");
+        }
+        drop(salvage);
+
+        let checks = AtomicUsize::new(0);
+        let candidate = temp.path().join("candidate.sqlite3");
+        let error = reconstruct_from_archive_with_salvage_cancellable(
+            &candidate,
+            &storage_root,
+            Some(&salvage_path),
+            &|| checks.fetch_add(1, Ordering::SeqCst) >= 300,
+        )
+        .expect_err("mid-salvage cancellation must abort reconstruction");
+        assert!(
+            matches!(error, DbError::ResourceBusy(ref detail) if detail == RECONSTRUCTION_CANCELLED_DETAIL),
+            "unexpected cancellation error: {error}"
+        );
+        assert!(
+            checks.load(Ordering::SeqCst) > 300,
+            "cancellation callback must cross a bounded salvage query-page boundary"
+        );
+
+        let conn = DbConn::open_file(candidate.to_string_lossy().as_ref())
+            .expect("open cancelled candidate");
+        let project_count = conn
+            .query_sync("SELECT COUNT(*) AS count FROM projects", &[])
+            .expect("count candidate projects")[0]
+            .get_named::<i64>("count")
+            .expect("project count");
+        let message_count = conn
+            .query_sync("SELECT COUNT(*) AS count FROM messages", &[])
+            .expect("count candidate messages")[0]
+            .get_named::<i64>("count")
+            .expect("message count");
+        assert_eq!(project_count, 0, "cancelled salvage leaked a project row");
+        assert_eq!(message_count, 0, "cancelled salvage leaked message rows");
+    }
+
+    #[test]
+    fn cancellation_during_agent_salvage_keeps_non_message_pages_bounded() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let storage_root = temp.path().join("archive");
+        std::fs::create_dir_all(storage_root.join("projects")).expect("create empty archive");
+        let salvage_path = temp.path().join("agent-salvage.sqlite3");
+        let salvage = DbConn::open_file(salvage_path.to_string_lossy().as_ref())
+            .expect("open salvage fixture");
+        salvage
+            .execute_raw(&crate::schema::init_schema_sql_base())
+            .expect("initialize salvage schema");
+        salvage
+            .query_sync(
+                "INSERT INTO projects (id, slug, human_key, created_at)
+                 VALUES (100, 'agent-salvage-project', '/agent-salvage-project', 1)",
+                &[],
+            )
+            .expect("insert salvage project");
+        for agent_id in 1..=700 {
+            salvage
+                .query_sync(
+                    "INSERT INTO agents
+                     (id, project_id, name, program, model, task_description, inception_ts,
+                      last_active_ts, attachments_policy, contact_policy)
+                     VALUES (?, 100, ?, 'test', 'test', '', 1, 1, 'auto', 'auto')",
+                    &[
+                        Value::BigInt(agent_id),
+                        Value::Text(format!("Agent{agent_id:04}")),
+                    ],
+                )
+                .expect("insert salvage agent");
+        }
+        drop(salvage);
+
+        begin_salvage_page_test_observation();
+        let candidate = temp.path().join("agent-candidate.sqlite3");
+        let error = reconstruct_from_archive_with_salvage_cancellable(
+            &candidate,
+            &storage_root,
+            Some(&salvage_path),
+            &|| salvage_page_test_stats().1 >= 300,
+        )
+        .expect_err("mid-agent salvage cancellation must abort reconstruction");
+        let (agent_pages, agent_rows, max_page_rows) = finish_salvage_page_test_observation();
+        assert!(
+            matches!(error, DbError::ResourceBusy(ref detail) if detail == RECONSTRUCTION_CANCELLED_DETAIL),
+            "unexpected cancellation error: {error}"
+        );
+        assert_eq!(
+            agent_rows, 300,
+            "cancellation must stop at the requested bounded-progress threshold"
+        );
+        assert_eq!(
+            agent_pages,
+            agent_rows.div_ceil(usize::try_from(SALVAGE_QUERY_PAGE_ROWS).unwrap_or(usize::MAX)),
+            "cancellation must not query beyond the page containing the threshold"
+        );
+        assert!(
+            max_page_rows <= usize::try_from(SALVAGE_QUERY_PAGE_ROWS).unwrap_or(usize::MAX),
+            "agent salvage query materialized {max_page_rows} rows in one page"
+        );
+        assert!(
+            agent_rows < 700,
+            "agent salvage must stop before full materialization"
+        );
+
+        let conn = DbConn::open_file(candidate.to_string_lossy().as_ref())
+            .expect("open cancelled candidate");
+        let project_count = conn
+            .query_sync("SELECT COUNT(*) AS count FROM projects", &[])
+            .expect("count candidate projects")[0]
+            .get_named::<i64>("count")
+            .expect("project count");
+        let agent_count = conn
+            .query_sync("SELECT COUNT(*) AS count FROM agents", &[])
+            .expect("count candidate agents")[0]
+            .get_named::<i64>("count")
+            .expect("agent count");
+        assert_eq!(project_count, 0, "cancelled salvage leaked a project row");
+        assert_eq!(agent_count, 0, "cancelled salvage leaked agent rows");
+    }
+
+    #[test]
+    fn salvage_rejects_oversized_values_before_materializing_the_value_page() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let storage_root = temp.path().join("archive");
+        std::fs::create_dir_all(storage_root.join("projects")).expect("create empty archive");
+        let salvage_path = temp.path().join("oversized-salvage.sqlite3");
+        let salvage = DbConn::open_file(salvage_path.to_string_lossy().as_ref())
+            .expect("open oversized salvage fixture");
+        salvage
+            .execute_raw(&crate::schema::init_schema_sql_base())
+            .expect("initialize oversized salvage schema");
+        salvage
+            .query_sync(
+                "INSERT INTO projects (id, slug, human_key, created_at)
+                 VALUES (100, 'oversized-project', '/oversized-project', 1)",
+                &[],
+            )
+            .expect("insert oversized salvage project");
+        salvage
+            .query_sync(
+                "INSERT INTO agents
+                 (id, project_id, name, program, model, task_description, inception_ts,
+                  last_active_ts, attachments_policy, contact_policy)
+                VALUES (1, 100, 'LargeAgent', 'test', 'test', ?, 1, 1, 'auto', 'auto')",
+                &[Value::Text(
+                    "x".repeat(
+                        usize::try_from(SALVAGE_MAX_VARIABLE_VALUE_BYTES + 1)
+                            .expect("single-value cap fits usize"),
+                    ),
+                )],
+            )
+            .expect("insert oversized salvage agent");
+        drop(salvage);
+
+        begin_salvage_page_test_observation();
+        let candidate = temp.path().join("oversized-candidate.sqlite3");
+        let error = reconstruct_from_archive_with_salvage_cancellable(
+            &candidate,
+            &storage_root,
+            Some(&salvage_path),
+            &|| false,
+        )
+        .expect_err("oversized salvage row must fail closed");
+        let (agent_pages, agent_rows, max_page_rows) = finish_salvage_page_test_observation();
+        assert!(
+            matches!(error, DbError::Sqlite(ref detail)
+                if detail.contains("agents.task_description")
+                    && detail.contains("single-value cap")),
+            "unexpected oversized-row error: {error}"
+        );
+        assert_eq!((agent_pages, agent_rows, max_page_rows), (0, 0, 0));
+        let conn = DbConn::open_file(candidate.to_string_lossy().as_ref())
+            .expect("open oversized rejected candidate");
+        let agent_count = conn
+            .query_sync("SELECT COUNT(*) AS count FROM agents", &[])
+            .expect("count oversized rejected agents")[0]
+            .get_named::<i64>("count")
+            .expect("oversized rejected agent count");
+        let project_count = conn
+            .query_sync("SELECT COUNT(*) AS count FROM projects", &[])
+            .expect("count oversized rejected projects")[0]
+            .get_named::<i64>("count")
+            .expect("oversized rejected project count");
+        assert_eq!(project_count, 0, "oversized salvage leaked a project row");
+        assert_eq!(agent_count, 0, "oversized salvage leaked an agent row");
+    }
+
+    #[test]
+    fn salvage_guard_rejects_oversized_dynamic_integer_key_before_full_fetch() {
+        let conn = DbConn::open_memory().expect("open hostile integer-key fixture");
+        conn.execute_raw("CREATE TABLE projects (id BLOB NOT NULL, slug TEXT NOT NULL)")
+            .expect("create hostile projects table");
+        conn.execute_raw(&format!(
+            "INSERT INTO projects (id, slug) VALUES (zeroblob({}), 'hostile-project')",
+            SALVAGE_MAX_VARIABLE_VALUE_BYTES + 1
+        ))
+        .expect("insert oversized dynamic integer key");
+        let projection = guarded_salvage_projection(&conn, "projects", &["id", "slug"], &[]);
+        let visits = std::cell::Cell::new(0_usize);
+
+        let error =
+            for_each_salvage_row_keyset(&conn, "projects", &projection, &["id"], &|| false, |_| {
+                visits.set(visits.get() + 1);
+                Ok(())
+            })
+            .expect_err("oversized BLOB in nominal INTEGER key must fail closed");
+
+        assert_eq!(visits.get(), 0, "hostile key reached the full-row visitor");
+        assert!(
+            matches!(error, DbError::Sqlite(ref detail)
+                if detail.contains("projects.id") && detail.contains("single-value cap")),
+            "unexpected hostile integer-key error: {error}"
+        );
+    }
+
+    #[test]
+    fn salvage_guard_rejects_oversized_composite_text_key_before_full_fetch() {
+        let conn = DbConn::open_memory().expect("open hostile composite-key fixture");
+        conn.execute_raw(
+            "CREATE TABLE proof_gate_consumed_nonces (
+                issuer_key TEXT NOT NULL,
+                nonce TEXT NOT NULL,
+                retain_until INTEGER NOT NULL,
+                consumed_at INTEGER NOT NULL
+            )",
+        )
+        .expect("create hostile nonce table");
+        conn.execute_raw(&format!(
+            "INSERT INTO proof_gate_consumed_nonces
+             (issuer_key, nonce, retain_until, consumed_at)
+             VALUES (CAST(zeroblob({}) AS TEXT), 'nonce', 1, 1)",
+            SALVAGE_MAX_VARIABLE_VALUE_BYTES + 1
+        ))
+        .expect("insert oversized composite text key");
+        let projection = guarded_salvage_projection(
+            &conn,
+            "proof_gate_consumed_nonces",
+            &["issuer_key", "nonce", "retain_until", "consumed_at"],
+            &[],
+        );
+        let visits = std::cell::Cell::new(0_usize);
+
+        let error = for_each_salvage_row_keyset(
+            &conn,
+            "proof_gate_consumed_nonces",
+            &projection,
+            &["issuer_key", "nonce"],
+            &|| false,
+            |_| {
+                visits.set(visits.get() + 1);
+                Ok(())
+            },
+        )
+        .expect_err("oversized composite TEXT key must fail closed");
+
+        assert_eq!(visits.get(), 0, "hostile key reached the full-row visitor");
+        assert!(
+            matches!(error, DbError::Sqlite(ref detail)
+                if detail.contains("proof_gate_consumed_nonces.issuer_key")
+                    && detail.contains("single-value cap")),
+            "unexpected hostile composite-key error: {error}"
+        );
+    }
+
+    #[test]
+    fn salvage_guard_rejects_dynamic_type_in_nominal_integer_field() {
+        let conn = DbConn::open_memory().expect("open hostile fixed-field fixture");
+        conn.execute_raw(
+            "CREATE TABLE agents (
+                id INTEGER NOT NULL,
+                project_id BLOB NOT NULL,
+                name TEXT NOT NULL
+            )",
+        )
+        .expect("create hostile agents table");
+        conn.execute_raw("INSERT INTO agents (id, project_id, name) VALUES (1, X'01', 'Agent')")
+            .expect("insert dynamic fixed-field payload");
+        let projection =
+            guarded_salvage_projection(&conn, "agents", &["id", "project_id", "name"], &[]);
+        let visits = std::cell::Cell::new(0_usize);
+
+        let error =
+            for_each_salvage_row_keyset(&conn, "agents", &projection, &["id"], &|| false, |_| {
+                visits.set(visits.get() + 1);
+                Ok(())
+            })
+            .expect_err("BLOB in nominal INTEGER field must fail closed");
+
+        assert_eq!(
+            visits.get(),
+            0,
+            "hostile field reached the full-row visitor"
+        );
+        assert!(
+            matches!(error, DbError::Sqlite(ref detail)
+                if detail.contains("agents.project_id")
+                    && detail.contains("positive INTEGER")),
+            "unexpected hostile fixed-field error: {error}"
+        );
+    }
+
+    #[test]
+    fn salvage_guard_rejects_out_of_range_fixed_integer_before_full_fetch() {
+        let conn = DbConn::open_memory().expect("open hostile integer-range fixture");
+        conn.execute_raw(
+            "CREATE TABLE agents (
+                id INTEGER NOT NULL,
+                project_id INTEGER NOT NULL,
+                name TEXT NOT NULL
+            )",
+        )
+        .expect("create hostile integer-range table");
+        conn.execute_raw("INSERT INTO agents (id, project_id, name) VALUES (1, 0, 'Agent')")
+            .expect("insert out-of-range fixed integer");
+        let projection =
+            guarded_salvage_projection(&conn, "agents", &["id", "project_id", "name"], &[]);
+        let visits = std::cell::Cell::new(0_usize);
+
+        let error =
+            for_each_salvage_row_keyset(&conn, "agents", &projection, &["id"], &|| false, |_| {
+                visits.set(visits.get() + 1);
+                Ok(())
+            })
+            .expect_err("out-of-range nominal INTEGER must fail closed");
+
+        assert_eq!(
+            visits.get(),
+            0,
+            "invalid range reached the full-row visitor"
+        );
+        assert!(
+            matches!(error, DbError::Sqlite(ref detail)
+                if detail.contains("agents.project_id")
+                    && detail.contains("positive INTEGER")),
+            "unexpected hostile integer-range error: {error}"
+        );
+    }
+
+    #[test]
+    fn salvage_guard_bounds_total_projected_bytes_before_full_page_fetch() {
+        let conn = DbConn::open_memory().expect("open page-byte-bound fixture");
+        conn.execute_raw(
+            "CREATE TABLE projects (
+                id INTEGER NOT NULL,
+                slug TEXT NOT NULL,
+                human_key TEXT
+            )",
+        )
+        .expect("create page-byte-bound projects table");
+        conn.execute_raw(
+            "INSERT INTO projects (id, slug, human_key) VALUES (1, '123456', 'abcdef')",
+        )
+        .expect("insert page-byte-bound row");
+        let projection =
+            guarded_salvage_projection(&conn, "projects", &["id", "slug"], &["human_key"]);
+        let visits = std::cell::Cell::new(0_usize);
+        begin_salvage_page_test_observation();
+        set_salvage_test_page_value_byte_limit(10);
+
+        let error =
+            for_each_salvage_row_keyset(&conn, "projects", &projection, &["id"], &|| false, |_| {
+                visits.set(visits.get() + 1);
+                Ok(())
+            })
+            .expect_err("aggregate projected page bytes must fail closed");
+        finish_salvage_page_test_observation();
+
+        assert_eq!(
+            visits.get(),
+            0,
+            "over-cap page reached the full-row visitor"
+        );
+        assert!(
+            matches!(error, DbError::Sqlite(ref detail)
+                if detail.contains("projects page projects 12 bytes")
+                    && detail.contains("10-byte page cap")),
+            "unexpected projected-page-bound error: {error}"
+        );
+    }
+
+    #[test]
+    fn salvage_id_maps_fail_closed_at_their_hard_cardinality_cap() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let storage_root = temp.path().join("archive");
+        std::fs::create_dir_all(storage_root.join("projects")).expect("create empty archive");
+        let salvage_path = temp.path().join("map-cap-salvage.sqlite3");
+        let salvage = DbConn::open_file(salvage_path.to_string_lossy().as_ref())
+            .expect("open map-cap salvage fixture");
+        salvage
+            .execute_raw(&crate::schema::init_schema_sql_base())
+            .expect("initialize map-cap salvage schema");
+        salvage
+            .query_sync(
+                "INSERT INTO projects (id, slug, human_key, created_at)
+                 VALUES (100, 'map-cap-project', '/map-cap-project', 1)",
+                &[],
+            )
+            .expect("insert map-cap salvage project");
+        for agent_id in 1..=70 {
+            salvage
+                .query_sync(
+                    "INSERT INTO agents
+                     (id, project_id, name, program, model, task_description, inception_ts,
+                      last_active_ts, attachments_policy, contact_policy)
+                     VALUES (?, 100, ?, 'test', 'test', '', 1, 1, 'auto', 'auto')",
+                    &[
+                        Value::BigInt(agent_id),
+                        Value::Text(format!("MapAgent{agent_id:04}")),
+                    ],
+                )
+                .expect("insert map-cap salvage agent");
+        }
+        drop(salvage);
+
+        begin_salvage_page_test_observation();
+        set_salvage_test_id_map_limit(64);
+        let candidate = temp.path().join("map-cap-candidate.sqlite3");
+        let error = reconstruct_from_archive_with_salvage_cancellable(
+            &candidate,
+            &storage_root,
+            Some(&salvage_path),
+            &|| false,
+        )
+        .expect_err("over-cap identity map must fail closed");
+        let (agent_pages, agent_rows, max_page_rows) = finish_salvage_page_test_observation();
+        assert!(
+            matches!(error, DbError::Sqlite(ref detail)
+                if detail.contains("agent_id_map exceeded its hard cap of 64")),
+            "unexpected map-cap error: {error}"
+        );
+        assert_eq!(agent_rows, 64);
+        assert_eq!(agent_pages, 5);
+        assert!(max_page_rows <= usize::try_from(SALVAGE_QUERY_PAGE_ROWS).unwrap_or(usize::MAX));
+        let conn = DbConn::open_file(candidate.to_string_lossy().as_ref())
+            .expect("open map-cap rejected candidate");
+        let agent_count = conn
+            .query_sync("SELECT COUNT(*) AS count FROM agents", &[])
+            .expect("count map-cap rejected agents")[0]
+            .get_named::<i64>("count")
+            .expect("map-cap rejected agent count");
+        let project_count = conn
+            .query_sync("SELECT COUNT(*) AS count FROM projects", &[])
+            .expect("count map-cap rejected projects")[0]
+            .get_named::<i64>("count")
+            .expect("map-cap rejected project count");
+        assert_eq!(project_count, 0, "map-cap salvage leaked a project row");
+        assert_eq!(agent_count, 0, "map-cap salvage leaked agent rows");
+    }
+
+    #[test]
+    fn salvage_recipient_keyset_preserves_legacy_kind_discriminator() {
+        let conn = DbConn::open_memory().expect("open legacy recipient fixture");
+        conn.execute_raw(
+            "CREATE TABLE message_recipients (
+                message_id INTEGER NOT NULL,
+                agent_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                PRIMARY KEY (message_id, agent_id, kind)
+            )",
+        )
+        .expect("create legacy recipient table");
+        for index in 0..40 {
+            conn.query_sync(
+                "INSERT INTO message_recipients (message_id, agent_id, kind) VALUES (1, 2, ?)",
+                &[Value::Text(format!("kind-{index:02}"))],
+            )
+            .expect("insert legacy recipient");
+        }
+
+        let columns =
+            table_columns(&conn, "message_recipients").expect("inspect legacy recipient columns");
+        let mut stats = ReconstructStats::default();
+        let projection = build_salvage_select(
+            "message_recipients",
+            &columns,
+            &["message_id", "agent_id", "kind"],
+            &[],
+            &mut stats,
+            Path::new(":memory:"),
+        )
+        .expect("build guarded recipient projection");
+        let mut kinds = Vec::new();
+        for_each_salvage_row_keyset(
+            &conn,
+            "message_recipients",
+            &projection,
+            &["message_id", "agent_id", "kind"],
+            &|| false,
+            |row| {
+                kinds.push(row.get_named::<String>("kind").map_err(|error| {
+                    DbError::Sqlite(format!("decode legacy recipient kind: {error}"))
+                })?);
+                Ok(())
+            },
+        )
+        .expect("page every legacy recipient discriminator");
+
+        assert_eq!(kinds.len(), 40);
+        assert_eq!(kinds.first().map(String::as_str), Some("kind-00"));
+        assert_eq!(kinds.last().map(String::as_str), Some("kind-39"));
     }
 
     #[test]
@@ -5956,6 +7426,106 @@ body
                 &MailboxProjectIdentity::from_parts(Some("beta".to_string()), None, None,)
                     .expect("beta identity")
             )
+        );
+    }
+
+    #[test]
+    fn archive_inventory_scan_honors_cancellation_between_artifacts() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let messages = tmp.path().join("storage/projects/alpha/messages/2026/07");
+        std::fs::create_dir_all(&messages).expect("create messages directory");
+        for id in 1..=128 {
+            std::fs::write(
+                messages.join(format!("2026-07-19T00-00-{id:03}Z__message__{id}.md")),
+                format!("---json\n{{\"id\":{id}}}\n---\nbody\n"),
+            )
+            .expect("write inventory artifact");
+        }
+        let checks = AtomicUsize::new(0);
+        let error =
+            scan_archive_message_inventory_cancellable(&tmp.path().join("storage"), &|| {
+                checks.fetch_add(1, Ordering::SeqCst) >= 32
+            })
+            .expect_err("inventory scan must stop after cancellation");
+        assert!(matches!(
+            error,
+            DbError::ResourceBusy(ref detail) if detail == RECONSTRUCTION_CANCELLED_DETAIL
+        ));
+        assert!(checks.load(Ordering::SeqCst) > 32);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn archive_inventory_scan_propagates_hostile_traversal_io() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let hostile_root = PathBuf::from(OsString::from_vec(
+            b"/tmp/agent-mail-inventory-hostile\0path".to_vec(),
+        ));
+        let error = scan_archive_message_inventory_cancellable(&hostile_root, &|| false)
+            .expect_err("invalid traversal metadata must fail the cancellable inventory scan");
+        assert!(
+            error
+                .to_string()
+                .contains("archive inventory: inspect directory"),
+            "unexpected metadata traversal error: {error}"
+        );
+
+        let error = inventory_read_dir(&hostile_root)
+            .expect_err("invalid read_dir path must be surfaced to snapshot callers");
+        assert!(
+            error
+                .to_string()
+                .contains("archive inventory: read directory"),
+            "unexpected read_dir traversal error: {error}"
+        );
+
+        let error = inventory_dir_entry(
+            Err(std::io::Error::other("hostile DirEntry failure")),
+            Path::new("/archive/projects"),
+        )
+        .expect_err("a failed DirEntry must not be flattened away");
+        assert!(
+            error
+                .to_string()
+                .contains("archive inventory: read directory entry under"),
+            "unexpected DirEntry traversal error: {error}"
+        );
+
+        let error = inventory_file_type_result(
+            Err(std::io::Error::other("hostile file_type failure")),
+            Path::new("/archive/projects/project"),
+        )
+        .expect_err("a failed file_type lookup must not be skipped");
+        assert!(
+            error
+                .to_string()
+                .contains("archive inventory: inspect directory entry"),
+            "unexpected file_type traversal error: {error}"
+        );
+    }
+
+    #[test]
+    fn archive_inventory_preserves_absent_and_non_directory_semantics() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let storage_root = tmp.path().join("storage");
+
+        assert_eq!(
+            scan_archive_message_inventory_cancellable(&storage_root, &|| false)
+                .expect("an absent projects directory is an empty archive"),
+            ArchiveMessageInventory::default()
+        );
+
+        std::fs::create_dir_all(&storage_root).expect("create storage root");
+        std::fs::write(storage_root.join("projects"), "not a directory")
+            .expect("write non-directory projects path");
+        assert_eq!(
+            scan_archive_message_inventory_cancellable(&storage_root, &|| false)
+                .expect("a non-directory projects path remains an empty archive"),
+            ArchiveMessageInventory::default()
         );
     }
 

--- a/crates/mcp-agent-mail-storage/src/boot_check.rs
+++ b/crates/mcp-agent-mail-storage/src/boot_check.rs
@@ -535,6 +535,8 @@ fn auto_repair_missing_refs(
         });
     }
 
+    let _application = crate::ArchiveApplicationGuard::start();
+
     let canonical = canonicalize_repo(&candidate.path)
         .ok_or_else(|| format!("canonicalize repo {}", candidate.path.display()))?;
     let _flock = RepoFlock::acquire(&canonical)

--- a/crates/mcp-agent-mail-storage/src/lib.rs
+++ b/crates/mcp-agent-mail-storage/src/lib.rs
@@ -460,6 +460,92 @@ const WBQ_ENQUEUE_MAX_BACKOFF_MS: u64 = 8;
 
 static WBQ: OnceLock<WriteBehindQueue> = OnceLock::new();
 
+// Snapshot builders live in `mcp-agent-mail-tools`, but every archive mutation
+// funnels through this crate.  A process-wide admission epoch keeps that layer
+// from publishing a reconstruction across either a direct write or a WBQ drain
+// without introducing a storage -> tools dependency cycle.  The scope is
+// deliberately conservative: an unrelated mailbox write may restart a build,
+// but no build can miss the actual filesystem application window.
+static ARCHIVE_APPLICATION_EPOCH: AtomicU64 = AtomicU64::new(0);
+static ARCHIVE_APPLICATIONS_ACTIVE: AtomicUsize = AtomicUsize::new(0);
+static ARCHIVE_APPLICATION_BARRIER: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+thread_local! {
+    static ARCHIVE_APPLICATION_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+pub(crate) struct ArchiveApplicationGuard {
+    barrier: Option<std::sync::MutexGuard<'static, ()>>,
+}
+
+impl ArchiveApplicationGuard {
+    pub(crate) fn start() -> Self {
+        let nested = ARCHIVE_APPLICATION_DEPTH.with(|depth| {
+            let current = depth.get();
+            depth.set(current.saturating_add(1));
+            current > 0
+        });
+        let barrier = if nested {
+            None
+        } else {
+            Some(
+                ARCHIVE_APPLICATION_BARRIER
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner),
+            )
+        };
+        ARCHIVE_APPLICATIONS_ACTIVE.fetch_add(1, Ordering::AcqRel);
+        ARCHIVE_APPLICATION_EPOCH.fetch_add(1, Ordering::AcqRel);
+        Self { barrier }
+    }
+}
+
+impl Drop for ArchiveApplicationGuard {
+    fn drop(&mut self) {
+        ARCHIVE_APPLICATION_EPOCH.fetch_add(1, Ordering::AcqRel);
+        ARCHIVE_APPLICATIONS_ACTIVE.fetch_sub(1, Ordering::AcqRel);
+        ARCHIVE_APPLICATION_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+        drop(self.barrier.take());
+    }
+}
+
+/// Serialize a snapshot publication check with every archive mutation.
+///
+/// The callback must stay non-blocking and must not initiate archive writes.
+pub fn with_archive_publication_barrier<T>(publish: impl FnOnce() -> T) -> T {
+    let _barrier = ARCHIVE_APPLICATION_BARRIER
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    publish()
+}
+
+fn archive_fs_write(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
+    let _application = ArchiveApplicationGuard::start();
+    fs::write(path, contents)
+}
+
+fn archive_fs_remove_file(path: &Path) -> std::io::Result<()> {
+    let _application = ArchiveApplicationGuard::start();
+    fs::remove_file(path)
+}
+
+fn archive_fs_rename(from: &Path, to: &Path) -> std::io::Result<()> {
+    let _application = ArchiveApplicationGuard::start();
+    fs::rename(from, to)
+}
+
+/// Process-wide archive application epoch used by immutable read snapshots.
+#[must_use]
+pub fn archive_application_epoch() -> u64 {
+    ARCHIVE_APPLICATION_EPOCH.load(Ordering::Acquire)
+}
+
+/// Number of archive writes currently applying filesystem changes.
+#[must_use]
+pub fn archive_applications_active() -> usize {
+    ARCHIVE_APPLICATIONS_ACTIVE.load(Ordering::Acquire)
+}
+
 fn new_write_behind_queue() -> WriteBehindQueue {
     let op_depth = Arc::new(AtomicU64::new(0));
     let channel_capacity = Config::get().wbq_channel_capacity;
@@ -1442,6 +1528,7 @@ fn wbq_message_bundle_batch_end(batch: &[WbqOpEnvelope], start: usize) -> usize 
 }
 
 fn wbq_execute_message_bundle_batch(envelopes: &[WbqOpEnvelope]) -> Result<()> {
+    let _application = ArchiveApplicationGuard::start();
     debug_assert!(!envelopes.is_empty());
 
     let mut attempts = 0;
@@ -1507,6 +1594,7 @@ fn wbq_execute_message_bundle_batch_inner(envelopes: &[WbqOpEnvelope]) -> Result
 }
 
 fn wbq_execute_op(op: &WriteOp) -> Result<()> {
+    let _application = ArchiveApplicationGuard::start();
     let mut attempts = 0;
     loop {
         match wbq_execute_op_inner(op) {
@@ -1763,7 +1851,7 @@ fn quarantine_startup_artifact_if_exists(
     }
 
     let quarantine = next_startup_quarantine_path(path, fallback_name);
-    match fs::rename(path, &quarantine) {
+    match archive_fs_rename(path, &quarantine) {
         Ok(()) => Some(quarantine),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
         Err(error) => {
@@ -1871,11 +1959,14 @@ impl FileLock {
             }
 
             // Try to create and exclusively lock the file
-            let file = fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(false)
-                .open(&self.path)?;
+            let file = {
+                let _application = ArchiveApplicationGuard::start();
+                fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(false)
+                    .open(&self.path)?
+            };
 
             match file.try_lock_exclusive() {
                 Ok(()) => {
@@ -1938,8 +2029,8 @@ impl FileLock {
 
         // Remove files BEFORE releasing flock to prevent race where another
         // process acquires the lock between flock release and file removal.
-        let _ = fs::remove_file(&self.metadata_path);
-        let _ = fs::remove_file(&self.path);
+        let _ = archive_fs_remove_file(&self.metadata_path);
+        let _ = archive_fs_remove_file(&self.path);
         // Now drop the file handle to release the OS-level flock
         self.lock_file = None;
         Ok(())
@@ -2051,13 +2142,13 @@ impl FileLock {
 
         // Try quarantining while lock is held (best race safety).
         let quarantine = next_startup_quarantine_path(&self.path, "archive-lock-artifact");
-        let quarantined = match fs::rename(&self.path, &quarantine) {
+        let quarantined = match archive_fs_rename(&self.path, &quarantine) {
             Ok(()) => true,
             Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
                 // Windows can require closing/unlocking first before renaming.
                 let _ = file.unlock();
                 drop(file);
-                fs::rename(&self.path, &quarantine).is_ok()
+                archive_fs_rename(&self.path, &quarantine).is_ok()
             }
             Err(_) => false,
         };
@@ -4587,7 +4678,7 @@ fn write_lock_owner(repo_root: &Path) {
         .as_secs();
     let start_ticks = process_start_ticks(pid).unwrap_or(0);
     let content = format!("{pid}\n{ts}\n{start_ticks}\n");
-    let _ = fs::write(&owner_path, content);
+    let _ = archive_fs_write(&owner_path, content);
 }
 
 /// Remove the `.git/index.lock.owner` file after a successful commit.
@@ -4595,7 +4686,7 @@ fn remove_lock_owner(repo_root: &Path) {
     let Some((_lock_path, owner_path)) = git_index_lock_paths_checked(repo_root) else {
         return;
     };
-    let _ = fs::remove_file(&owner_path);
+    let _ = archive_fs_remove_file(&owner_path);
 }
 
 /// Run a commit attempt while ensuring the owner sidecar is cleaned up.
@@ -4661,6 +4752,12 @@ pub fn clean_stale_git_index_lock(repo_root: &Path, max_age_seconds: f64) -> boo
     try_clean_stale_git_lock(repo_root, max_age_seconds)
 }
 
+fn remove_git_lock_pair(owner_path: &Path, lock_path: &Path) {
+    let _application = ArchiveApplicationGuard::start();
+    let _ = fs::remove_file(owner_path);
+    let _ = fs::remove_file(lock_path);
+}
+
 /// Try to clean up a stale `.git/index.lock` file with PID-aware safety.
 ///
 /// See [`clean_stale_git_index_lock`] for the supported cleanup semantics.
@@ -4695,8 +4792,7 @@ fn try_clean_stale_git_lock(repo_root: &Path, max_age_seconds: f64) -> bool {
                     tracing::info!(
                         "[git-lock] index.lock owner PID {pid} reused (start ticks mismatch), removing stale lock"
                     );
-                    let _ = fs::remove_file(&owner_path);
-                    let _ = fs::remove_file(&lock_path);
+                    remove_git_lock_pair(&owner_path, &lock_path);
                     return true;
                 }
 
@@ -4714,8 +4810,7 @@ fn try_clean_stale_git_lock(repo_root: &Path, max_age_seconds: f64) -> bool {
                             "[git-lock] index.lock held by alive PID {pid} but start ticks unavailable, force clean (age > {:.1}s)",
                             max_age_seconds * 2.0
                         );
-                        let _ = fs::remove_file(&owner_path);
-                        let _ = fs::remove_file(&lock_path);
+                        remove_git_lock_pair(&owner_path, &lock_path);
                         return true;
                     }
 
@@ -4731,8 +4826,7 @@ fn try_clean_stale_git_lock(repo_root: &Path, max_age_seconds: f64) -> bool {
                     tracing::info!(
                         "[git-lock] legacy owner format with alive PID {pid} and stale age, removing lock"
                     );
-                    let _ = fs::remove_file(&owner_path);
-                    let _ = fs::remove_file(&lock_path);
+                    remove_git_lock_pair(&owner_path, &lock_path);
                     return true;
                 }
 
@@ -4743,8 +4837,7 @@ fn try_clean_stale_git_lock(repo_root: &Path, max_age_seconds: f64) -> bool {
             // Remove owner before lock so a racing cleaner cannot pair
             // stale owner metadata with a freshly acquired lock.
             tracing::info!("[git-lock] index.lock held by dead PID {pid}, removing stale lock");
-            let _ = fs::remove_file(&owner_path);
-            let _ = fs::remove_file(&lock_path);
+            remove_git_lock_pair(&owner_path, &lock_path);
             return true;
         }
     }
@@ -4756,8 +4849,7 @@ fn try_clean_stale_git_lock(repo_root: &Path, max_age_seconds: f64) -> bool {
         && age > max_age_seconds
     {
         tracing::info!("[git-lock] removing stale index.lock (age={age:.1}s > {max_age_seconds}s)");
-        let _ = fs::remove_file(&owner_path);
-        let _ = fs::remove_file(&lock_path);
+        remove_git_lock_pair(&owner_path, &lock_path);
         return true;
     }
     false
@@ -4785,6 +4877,7 @@ fn commit_paths_lockfree(
     if rel_paths.is_empty() {
         return Ok(());
     }
+    let _application = ArchiveApplicationGuard::start();
 
     let workdir = repo.workdir().ok_or(StorageError::NotInitialized)?;
     let sig = Signature::now(&config.git_author_name, &config.git_author_email)?;
@@ -5078,13 +5171,13 @@ pub fn heal_archive_locks(config: &Config) -> Result<HealResult> {
             if f.try_lock_exclusive().is_ok() {
                 let quarantine = next_startup_quarantine_path(path, "archive-lock-artifact");
                 let mut quarantined = false;
-                match fs::rename(path, &quarantine) {
+                match archive_fs_rename(path, &quarantine) {
                     Ok(()) => quarantined = true,
                     Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
                         // Windows can require closing/unlocking first before renaming.
                         let _ = f.unlock();
                         drop(f);
-                        quarantined = fs::rename(path, &quarantine).is_ok();
+                        quarantined = archive_fs_rename(path, &quarantine).is_ok();
                     }
                     Err(_) => {}
                 }
@@ -5332,6 +5425,7 @@ fn ensure_dir(dir: &Path) -> std::io::Result<()> {
             ),
         ));
     }
+    let _application = ArchiveApplicationGuard::start();
     fs::create_dir_all(dir)?;
     {
         let mut cache = DIR_CACHE.lock().unwrap_or_else(|e| e.into_inner());
@@ -5569,6 +5663,7 @@ fn ensure_repo(root: &Path, config: &Config) -> Result<bool> {
     if repo_cache_contains(root) {
         return Ok(false);
     }
+    let _application = ArchiveApplicationGuard::start();
 
     let git_dir = root.join(".git");
     if git_dir.exists() {
@@ -6843,6 +6938,7 @@ fn update_thread_digest(
     // respect to other appenders. Even for larger payloads, combining
     // header + entry into one write avoids interleaving from concurrent
     // writers between the two calls.
+    let _application = ArchiveApplicationGuard::start();
     let (mut file, is_new) = match create_new_archive_append_file(&digest_path) {
         Ok(f) => (f, true),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
@@ -7205,6 +7301,7 @@ pub fn store_attachment(
         "bytes_original": original_bytes.len(),
         "ext": original_ext,
     });
+    let _application = ArchiveApplicationGuard::start();
     let mut audit_file = open_or_create_archive_append_file(&audit_path)?;
     audit_file.write_all(audit_entry.to_string().as_bytes())?;
     audit_file.write_all(b"\n")?;
@@ -7858,6 +7955,7 @@ pub fn clear_notification_signal(
         return SignalClearOutcome::Missing;
     }
 
+    let _application = ArchiveApplicationGuard::start();
     match fs::remove_file(&signal_path) {
         Ok(()) => {
             signal_debounce().lock().remove(&signal_key);
@@ -9530,6 +9628,7 @@ fn commit_paths(
     if rel_paths.is_empty() {
         return Ok(());
     }
+    let _application = ArchiveApplicationGuard::start();
 
     let sig = Signature::now(&config.git_author_name, &config.git_author_email)?;
     let _workdir = repo.workdir().ok_or(StorageError::NotInitialized)?;
@@ -9597,6 +9696,7 @@ fn commit_paths(
 /// Only used as an overload escape hatch for the async commit coalescer when the
 /// spill path set grows too large to track precisely.
 fn commit_all(repo: &Repository, config: &Config, message: &str) -> Result<()> {
+    let _application = ArchiveApplicationGuard::start();
     // Ensure this is a non-bare repo with a workdir.
     let _workdir = repo.workdir().ok_or(StorageError::NotInitialized)?;
 
@@ -9883,6 +9983,7 @@ fn atomic_write_bytes(path: &Path, data: &[u8], sync: bool) -> Result<()> {
 
     #[cfg(test)]
     let _test_guard = atomic_write_test_guard();
+    let _application = ArchiveApplicationGuard::start();
 
     // Refuse to write through symlinks (prevents symlink escape attacks)
     if let Ok(meta) = fs::symlink_metadata(path) {
@@ -15079,6 +15180,22 @@ mod tests {
             project_slug: project_slug.to_string(),
             agent_name: "WbqTestAgent".to_string(),
         }
+    }
+
+    #[test]
+    fn archive_application_guard_brackets_active_count_and_epoch() {
+        let epoch_before = archive_application_epoch();
+        {
+            let _guard = ArchiveApplicationGuard::start();
+            assert!(archive_applications_active() >= 1);
+            assert!(archive_application_epoch() > epoch_before);
+            {
+                let _nested = ArchiveApplicationGuard::start();
+                assert!(archive_applications_active() >= 2);
+            }
+            assert!(archive_applications_active() >= 1);
+        }
+        assert!(archive_application_epoch() >= epoch_before + 4);
     }
 
     #[test]

--- a/crates/mcp-agent-mail-tools/src/contacts.rs
+++ b/crates/mcp-agent-mail-tools/src/contacts.rs
@@ -581,7 +581,7 @@ pub async fn list_contacts(
     let agent_name =
         mcp_agent_mail_core::models::normalize_agent_name(&agent_name).unwrap_or(agent_name);
 
-    let pool = get_read_db_pool()?;
+    let pool = get_read_db_pool(ctx.cx()).await?;
     let project = resolve_project(ctx, &pool, &project_key).await?;
     let project_id = project.id.unwrap_or(0);
 

--- a/crates/mcp-agent-mail-tools/src/identity.rs
+++ b/crates/mcp-agent-mail-tools/src/identity.rs
@@ -18,8 +18,8 @@ use std::path::{Path, PathBuf};
 
 use crate::messaging::try_dispatch_archive_write;
 use crate::tool_util::{
-    db_error_to_mcp_error, db_outcome_to_mcp_result, get_db_pool, get_read_db_pool,
-    legacy_tool_error, resolve_project,
+    db_error_to_mcp_error, db_outcome_to_mcp_result, get_authoritative_live_db_pool, get_db_pool,
+    get_read_db_pool, legacy_tool_error, resolve_project,
 };
 
 /// Classify a [`mcp_agent_mail_db::DbError`] as retryable at the tool layer
@@ -1129,7 +1129,7 @@ pub fn health_check(_ctx: &McpContext) -> McpResult<String> {
     let pool = if semantic_readiness.status == "fail" {
         None
     } else {
-        match get_db_pool() {
+        match get_authoritative_live_db_pool() {
             Ok(pool) => {
                 pool.sample_pool_stats_now();
                 Some(pool)
@@ -2027,7 +2027,7 @@ pub async fn whois(
     let agent_name =
         mcp_agent_mail_core::models::normalize_agent_name(&agent_name).unwrap_or(agent_name);
 
-    let pool = get_read_db_pool()?;
+    let pool = get_read_db_pool(ctx.cx()).await?;
 
     let include_commits = include_recent_commits.unwrap_or(true);
     let limit_raw = commit_limit.unwrap_or(5);
@@ -2160,7 +2160,7 @@ pub async fn resolve_pane_identity(
 
     let mut project_keys = vec![project_key.clone()];
     if !Path::new(&project_key).is_absolute()
-        && let Ok(pool) = get_read_db_pool()
+        && let Ok(pool) = get_read_db_pool(ctx.cx()).await
         && let Ok(project) = resolve_project(ctx, &pool, &project_key).await
         && project.human_key != project_key
     {
@@ -2263,7 +2263,7 @@ pub async fn list_agents(
     limit: Option<u32>,
     active_within_days: Option<u32>,
 ) -> McpResult<String> {
-    let pool = get_read_db_pool()?;
+    let pool = get_read_db_pool(ctx.cx()).await?;
     let project = resolve_project(ctx, &pool, &project_key).await?;
     let project_id = project.id.unwrap_or(0);
 
@@ -3499,6 +3499,51 @@ body
     }
 
     #[test]
+    fn hot_health_check_does_not_advance_read_snapshot_writer_epoch() {
+        let _snapshot_guard = crate::tool_util::READ_SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _health_guard = HEALTH_CHECK_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let storage_root = temp.path().join("storage");
+        std::fs::create_dir_all(&storage_root).expect("create storage root");
+        let db_path = temp.path().join("hot-health-check.sqlite3");
+        let conn = DbConn::open_file(db_path.to_string_lossy().as_ref()).expect("open db");
+        conn.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+            .expect("init schema");
+        drop(conn);
+
+        with_process_env_overrides_for_test(
+            &[
+                ("DATABASE_URL", &format!("sqlite:///{}", db_path.display())),
+                ("STORAGE_ROOT", &storage_root.display().to_string()),
+            ],
+            || {
+                Config::reset_cached();
+                let _primed_pool = get_authoritative_live_db_pool()
+                    .expect("prime authoritative pool before measuring hot-path epoch");
+                let epoch_before = crate::tool_util::read_snapshot_db_write_epoch_for_test();
+
+                let ctx = McpContext::new(Cx::for_testing(), 1);
+                let response = health_check(&ctx).expect("health_check should serialize");
+                let value: serde_json::Value =
+                    serde_json::from_str(&response).expect("parse health_check json");
+                assert_eq!(value["semantic_readiness"]["status"], "ok");
+                assert_eq!(
+                    crate::tool_util::read_snapshot_db_write_epoch_for_test(),
+                    epoch_before,
+                    "a hot authoritative health read must not enter the durable writer epoch"
+                );
+                Config::reset_cached();
+            },
+        );
+    }
+
+    #[test]
     fn health_check_direct_sqlite_probe_uses_mailbox_runtime_engine() {
         let temp = tempfile::tempdir().expect("tempdir");
         let db_path = temp.path().join("health-check-engine.sqlite3");
@@ -3540,6 +3585,8 @@ body
         conn.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
             .expect("init schema");
         drop(conn);
+        mcp_agent_mail_db::pool::wal_checkpoint_truncate_path(&db_path)
+            .expect("stabilize stale live database fixture");
 
         with_process_env_overrides_for_test(
             &[

--- a/crates/mcp-agent-mail-tools/src/lib.rs
+++ b/crates/mcp-agent-mail-tools/src/lib.rs
@@ -60,11 +60,14 @@ pub mod tool_util {
     use fastmcp::McpErrorCode;
     use fastmcp::prelude::*;
     use mcp_agent_mail_core::Config;
-    use mcp_agent_mail_db::{DbError, DbPool, DbPoolConfig, create_pool, get_or_create_pool};
+    use mcp_agent_mail_db::{DbError, DbPool, DbPoolConfig, get_cached_pool, get_or_create_pool};
     use serde_json::{Map, Value, json};
+    use sha2::{Digest, Sha256};
     use std::collections::{BTreeSet, VecDeque};
+    use std::io::Read as _;
     use std::path::{Path, PathBuf};
-    use std::sync::{LazyLock, Mutex};
+    use std::sync::{Arc, LazyLock, Mutex};
+    use std::time::{Duration, Instant, UNIX_EPOCH};
 
     pub(crate) const MALFORMED_ATTACHMENTS_SENTINEL: &str = "[malformed-attachments-json]";
     pub(crate) const MALFORMED_RECIPIENTS_SENTINEL: &str = "[malformed-recipients-json]";
@@ -685,9 +688,131 @@ pub mod tool_util {
         }
     }
 
-    pub fn get_db_pool() -> McpResult<DbPool> {
+    pub(crate) fn get_live_db_pool() -> McpResult<DbPool> {
+        let mut cfg = DbPoolConfig::from_env();
+        if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&cfg.database_url) {
+            return get_or_create_pool(&cfg).map_err(|e| McpError::internal_error(e.to_string()));
+        }
+        cfg.run_migrations = false;
+        cfg.warmup_connections = 0;
+        mcp_agent_mail_db::create_query_only_pool(&cfg)
+            .map_err(|e| McpError::internal_error(e.to_string()))
+    }
+
+    struct ReadSnapshotWriteGuard {
+        slot: Option<Arc<ReadSnapshotScopeSlot>>,
+        active: bool,
+    }
+
+    impl ReadSnapshotWriteGuard {
+        fn begin(storage_root: &Path, sqlite_path: Option<&Path>) -> Self {
+            let Some(sqlite_path) = sqlite_path else {
+                return Self {
+                    slot: None,
+                    active: false,
+                };
+            };
+            Self {
+                slot: begin_read_snapshot_write(storage_root, sqlite_path),
+                active: true,
+            }
+        }
+    }
+
+    impl Drop for ReadSnapshotWriteGuard {
+        fn drop(&mut self) {
+            if self.active {
+                end_read_snapshot_write(self.slot.as_deref());
+            }
+        }
+    }
+
+    /// A live pool lease for mutation paths. Dropping the lease advances the
+    /// mailbox read-snapshot epoch after the operation has finished, so an
+    /// in-flight reconstruction cannot publish across a durable write window.
+    pub struct WriteDbPool {
+        pool: DbPool,
+        _write_guard: ReadSnapshotWriteGuard,
+    }
+
+    impl std::ops::Deref for WriteDbPool {
+        type Target = DbPool;
+
+        fn deref(&self) -> &Self::Target {
+            &self.pool
+        }
+    }
+
+    pub fn get_db_pool() -> McpResult<WriteDbPool> {
         let cfg = DbPoolConfig::from_env();
-        get_or_create_pool(&cfg).map_err(|e| McpError::internal_error(e.to_string()))
+        let sqlite_path =
+            if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&cfg.database_url) {
+                None
+            } else {
+                let resolved =
+                    mcp_agent_mail_db::pool::resolve_mailbox_sqlite_path(&cfg.database_url)
+                        .map_err(|error| {
+                            McpError::internal_error(format!(
+                                "resolve live SQLite writer path before pool bootstrap: {error}"
+                            ))
+                        })?;
+                Some(PathBuf::from(resolved.canonical_path))
+            };
+        let storage_root = cfg
+            .storage_root
+            .clone()
+            .unwrap_or_else(|| Config::from_env().storage_root);
+        // Enter the writer epoch before even constructing a cold pool: pool
+        // bootstrap can recover, migrate, checkpoint, or create the live DB.
+        // The guard closes the epoch on every early-return/error path.
+        let write_guard = ReadSnapshotWriteGuard::begin(&storage_root, sqlite_path.as_deref());
+        let pool = get_or_create_pool(&cfg).map_err(|e| McpError::internal_error(e.to_string()))?;
+        Ok(WriteDbPool {
+            pool,
+            _write_guard: write_guard,
+        })
+    }
+
+    /// Return the authoritative live pool for a read-only transaction.
+    ///
+    /// Hot reads reuse the existing live pool without entering a writer epoch.
+    /// A cold pool bootstrap may recover, migrate, checkpoint, or create the
+    /// mailbox, so only that bootstrap window is bracketed as a write before the
+    /// plain pool is returned to the caller.
+    pub(crate) fn get_authoritative_live_db_pool() -> McpResult<DbPool> {
+        let cfg = DbPoolConfig::from_env();
+        if let Some(pool) = get_cached_pool(&cfg) {
+            return Ok(pool);
+        }
+
+        let sqlite_path =
+            if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&cfg.database_url) {
+                None
+            } else {
+                let resolved =
+                    mcp_agent_mail_db::pool::resolve_mailbox_sqlite_path(&cfg.database_url)
+                        .map_err(|error| {
+                            McpError::internal_error(format!(
+                                "resolve authoritative SQLite path before pool bootstrap: {error}"
+                            ))
+                        })?;
+                Some(PathBuf::from(resolved.canonical_path))
+            };
+        let storage_root = cfg
+            .storage_root
+            .clone()
+            .unwrap_or_else(|| Config::from_env().storage_root);
+        let bootstrap_guard = ReadSnapshotWriteGuard::begin(&storage_root, sqlite_path.as_deref());
+        let pool = get_or_create_pool(&cfg).map_err(|error| {
+            McpError::internal_error(format!("open authoritative live database pool: {error}"))
+        })?;
+        drop(bootstrap_guard);
+        Ok(pool)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn read_snapshot_db_write_epoch_for_test() -> u64 {
+        READ_SNAPSHOT_DB_WRITE_EPOCH.load(std::sync::atomic::Ordering::Acquire)
     }
 
     fn read_pool_setup_error_to_mcp_error(message: String) -> McpError {
@@ -785,6 +910,16 @@ pub mod tool_util {
         mcp_agent_mail_db::scan_archive_message_inventory(storage_root)
     }
 
+    fn scan_read_archive_inventory_cancellable(
+        storage_root: &Path,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<mcp_agent_mail_db::ArchiveMessageInventory, ReadSnapshotAcquireError> {
+        #[cfg(test)]
+        READ_ARCHIVE_INVENTORY_SCAN_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        mcp_agent_mail_db::scan_archive_message_inventory_cancellable(storage_root, cancelled)
+            .map_err(ReadSnapshotAcquireError::failed)
+    }
+
     fn cached_read_archive_inventory(
         signature: &ReadArchiveSignature,
     ) -> Option<mcp_agent_mail_db::ArchiveMessageInventory> {
@@ -840,8 +975,32 @@ pub mod tool_util {
         inventory
     }
 
+    fn read_archive_inventory_cancellable(
+        storage_root: &Path,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<mcp_agent_mail_db::ArchiveMessageInventory, ReadSnapshotAcquireError> {
+        if cancelled() {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        let Some(signature_before) = clean_read_archive_signature(storage_root) else {
+            return scan_read_archive_inventory_cancellable(storage_root, cancelled);
+        };
+        if let Some(inventory) = cached_read_archive_inventory(&signature_before) {
+            return Ok(inventory);
+        }
+
+        let inventory = scan_read_archive_inventory_cancellable(storage_root, cancelled)?;
+        if cancelled() {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        if clean_read_archive_signature(storage_root).as_ref() == Some(&signature_before) {
+            cache_read_archive_inventory(signature_before, &inventory);
+        }
+        Ok(inventory)
+    }
+
     #[cfg(test)]
-    fn reset_read_archive_inventory_cache() {
+    pub(crate) fn reset_read_archive_inventory_cache() {
         READ_ARCHIVE_INVENTORY_CACHE
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -850,7 +1009,7 @@ pub mod tool_util {
     }
 
     #[cfg(test)]
-    fn read_archive_inventory_scan_count() -> usize {
+    pub(crate) fn read_archive_inventory_scan_count() -> usize {
         READ_ARCHIVE_INVENTORY_SCAN_COUNT.load(std::sync::atomic::Ordering::Relaxed)
     }
 
@@ -860,6 +1019,1848 @@ pub mod tool_util {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .len()
+    }
+
+    const READ_SNAPSHOT_SCOPE_CAPACITY: usize = 8;
+    const READ_SNAPSHOT_WORKER_LIMIT: usize = 4;
+    // Internal writes explicitly invalidate their mailbox epoch. The TTL is a
+    // fallback for external writers; an expired decision is served stale while
+    // one background worker validates cheap metadata/epochs. A separately
+    // configurable audit interval forces the exact content key periodically.
+    const READ_SNAPSHOT_VALIDATION_TTL_DEFAULT: Duration = Duration::from_secs(1);
+    const READ_SNAPSHOT_EXACT_AUDIT_INTERVAL_DEFAULT: Duration = Duration::from_secs(30);
+    const READ_SNAPSHOT_WAIT_SLICE: Duration = Duration::from_millis(50);
+    const READ_SNAPSHOT_BUILD_TIMEOUT: Duration = Duration::from_secs(120);
+    const READ_SNAPSHOT_GENERATION_RETRIES: usize = 3;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ReadSnapshotScope {
+        storage_root: PathBuf,
+        sqlite_path: PathBuf,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ReadSnapshotKey {
+        archive_digest: [u8; 32],
+        live_db_digest: [u8; 32],
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ReadSnapshotCheapKey {
+        archive_metadata_digest: [u8; 32],
+        live_db_metadata_digest: [u8; 32],
+        live_data_version: Option<i64>,
+        db_write_epoch: u64,
+        archive_application_epoch: u64,
+    }
+
+    pub(crate) struct SharedArchiveReadSnapshot {
+        pool: mcp_agent_mail_db::DbPool,
+        _snapshot_dir: mcp_agent_mail_db::pool::CanonicalSnapshotTempDir,
+    }
+
+    impl SharedArchiveReadSnapshot {
+        pub(crate) fn pool(&self) -> mcp_agent_mail_db::DbPool {
+            self.pool.clone()
+        }
+    }
+
+    #[derive(Clone)]
+    enum ArchiveReadDecision {
+        Live,
+        Snapshot(Arc<SharedArchiveReadSnapshot>),
+    }
+
+    impl ArchiveReadDecision {
+        fn immutable_snapshot(&self) -> Option<Arc<SharedArchiveReadSnapshot>> {
+            match self {
+                Self::Live => None,
+                Self::Snapshot(snapshot) => Some(Arc::clone(snapshot)),
+            }
+        }
+    }
+
+    struct ReadSnapshotCacheEntry {
+        key: ReadSnapshotKey,
+        cheap_key: ReadSnapshotCheapKey,
+        decision: ArchiveReadDecision,
+        validated_at: Instant,
+        strong_validated_at: Instant,
+        invalidation_epoch: u64,
+    }
+
+    struct ReadSnapshotBuildOutput {
+        key: ReadSnapshotKey,
+        cheap_key: ReadSnapshotCheapKey,
+        decision: ArchiveReadDecision,
+        strong_validated_at: Instant,
+    }
+
+    #[derive(Debug)]
+    struct ReadSnapshotBuildCompletion {
+        result: Mutex<Option<Result<(), ReadSnapshotAcquireError>>>,
+    }
+
+    impl ReadSnapshotBuildCompletion {
+        fn pending() -> Self {
+            Self {
+                result: Mutex::new(None),
+            }
+        }
+
+        fn complete(&self, result: Result<(), ReadSnapshotAcquireError>) {
+            let mut completion = self
+                .result
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if completion.is_none() {
+                *completion = Some(result);
+            }
+        }
+
+        fn result(&self) -> Option<Result<(), ReadSnapshotAcquireError>> {
+            self.result
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct ReadSnapshotBuild {
+        token: u64,
+        invalidation_epoch: u64,
+        db_write_epoch: u64,
+        archive_application_epoch: u64,
+        deadline: Instant,
+        completion: Arc<ReadSnapshotBuildCompletion>,
+    }
+
+    #[derive(Default)]
+    struct ReadSnapshotScopeState {
+        ready: Option<ReadSnapshotCacheEntry>,
+        building: Option<ReadSnapshotBuild>,
+        next_token: u64,
+        active_writers: usize,
+    }
+
+    struct ReadSnapshotScopeSlot {
+        scope: ReadSnapshotScope,
+        state: Mutex<ReadSnapshotScopeState>,
+        invalidation_epoch: std::sync::atomic::AtomicU64,
+        data_version_observer: Mutex<Option<mcp_agent_mail_db::DbConn>>,
+        notify: asupersync::sync::Notify,
+    }
+
+    impl ReadSnapshotScopeSlot {
+        fn new(scope: ReadSnapshotScope) -> Self {
+            Self {
+                scope,
+                state: Mutex::new(ReadSnapshotScopeState::default()),
+                invalidation_epoch: std::sync::atomic::AtomicU64::new(0),
+                data_version_observer: Mutex::new(None),
+                notify: asupersync::sync::Notify::new(),
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct ReadSnapshotRegistry {
+        slots: VecDeque<Arc<ReadSnapshotScopeSlot>>,
+    }
+
+    static READ_SNAPSHOT_REGISTRY: LazyLock<Mutex<ReadSnapshotRegistry>> =
+        LazyLock::new(|| Mutex::new(ReadSnapshotRegistry::default()));
+    static READ_SNAPSHOT_BLOCKING_POOL: LazyLock<asupersync::runtime::BlockingPool> =
+        LazyLock::new(|| asupersync::runtime::BlockingPool::new(0, READ_SNAPSHOT_WORKER_LIMIT));
+    const READ_SNAPSHOT_PENDING_BUILD_LIMIT: usize = READ_SNAPSHOT_SCOPE_CAPACITY;
+    static READ_SNAPSHOT_PENDING_BUILDS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    static READ_SNAPSHOT_DB_WRITES_ACTIVE: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    static READ_SNAPSHOT_DB_WRITE_EPOCH: std::sync::atomic::AtomicU64 =
+        std::sync::atomic::AtomicU64::new(0);
+
+    #[cfg(test)]
+    pub(crate) static READ_SNAPSHOT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[cfg(test)]
+    static READ_SNAPSHOT_RECONSTRUCTION_COUNT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    #[cfg(test)]
+    static READ_SNAPSHOT_RECONSTRUCTIONS_INFLIGHT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    #[cfg(test)]
+    static READ_SNAPSHOT_RECONSTRUCTIONS_MAX_INFLIGHT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    #[cfg(test)]
+    static READ_SNAPSHOT_GENERATION_SCAN_COUNT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    #[cfg(test)]
+    static READ_SNAPSHOT_GENERATION_SCANS_INFLIGHT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    #[cfg(test)]
+    static READ_SNAPSHOT_GENERATION_SCANS_MAX_INFLIGHT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    #[cfg(test)]
+    static READ_SNAPSHOT_TEST_DELAY_MILLIS: std::sync::atomic::AtomicU64 =
+        std::sync::atomic::AtomicU64::new(0);
+
+    #[cfg(test)]
+    type ReadSnapshotPreReconstructionTestHook = Box<dyn FnOnce() + Send + 'static>;
+
+    #[cfg(test)]
+    static READ_SNAPSHOT_PRE_RECONSTRUCTION_TEST_HOOK: LazyLock<
+        Mutex<Option<ReadSnapshotPreReconstructionTestHook>>,
+    > = LazyLock::new(|| Mutex::new(None));
+
+    #[cfg(test)]
+    #[derive(Default)]
+    struct ReadSnapshotPostValidationTestState {
+        armed: bool,
+        reached: bool,
+        release: bool,
+    }
+
+    #[cfg(test)]
+    static READ_SNAPSHOT_POST_VALIDATION_TEST_HOOK: LazyLock<(
+        Mutex<ReadSnapshotPostValidationTestState>,
+        std::sync::Condvar,
+    )> = LazyLock::new(|| {
+        (
+            Mutex::new(ReadSnapshotPostValidationTestState::default()),
+            std::sync::Condvar::new(),
+        )
+    });
+
+    #[cfg(test)]
+    fn read_snapshot_test_delay() {
+        let millis = READ_SNAPSHOT_TEST_DELAY_MILLIS.load(std::sync::atomic::Ordering::Acquire);
+        if millis > 0 {
+            std::thread::sleep(Duration::from_millis(millis));
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_read_snapshot_test_delay(delay: Duration) {
+        READ_SNAPSHOT_TEST_DELAY_MILLIS.store(
+            u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+            std::sync::atomic::Ordering::Release,
+        );
+    }
+
+    #[cfg(test)]
+    fn set_read_snapshot_pre_reconstruction_test_hook(hook: impl FnOnce() + Send + 'static) {
+        *READ_SNAPSHOT_PRE_RECONSTRUCTION_TEST_HOOK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Box::new(hook));
+    }
+
+    #[cfg(test)]
+    fn run_read_snapshot_pre_reconstruction_test_hook() {
+        let hook = READ_SNAPSHOT_PRE_RECONSTRUCTION_TEST_HOOK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
+    #[cfg(test)]
+    fn reset_read_snapshot_pre_reconstruction_test_hook() {
+        *READ_SNAPSHOT_PRE_RECONSTRUCTION_TEST_HOOK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+    }
+
+    #[cfg(test)]
+    fn arm_read_snapshot_post_validation_test_hook() {
+        let (state, _) = &*READ_SNAPSHOT_POST_VALIDATION_TEST_HOOK;
+        *state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            ReadSnapshotPostValidationTestState {
+                armed: true,
+                reached: false,
+                release: false,
+            };
+    }
+
+    #[cfg(test)]
+    fn wait_for_read_snapshot_post_validation_test_hook(timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let (state, notify) = &*READ_SNAPSHOT_POST_VALIDATION_TEST_HOOK;
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while !state.reached {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return false;
+            };
+            let (next, timed_out) = notify
+                .wait_timeout(state, remaining)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state = next;
+            if timed_out.timed_out() && !state.reached {
+                return false;
+            }
+        }
+        true
+    }
+
+    #[cfg(test)]
+    fn release_read_snapshot_post_validation_test_hook() {
+        let (state, notify) = &*READ_SNAPSHOT_POST_VALIDATION_TEST_HOOK;
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.release = true;
+        notify.notify_all();
+    }
+
+    #[cfg(test)]
+    fn reset_read_snapshot_post_validation_test_hook() {
+        let (state, notify) = &*READ_SNAPSHOT_POST_VALIDATION_TEST_HOOK;
+        *state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            ReadSnapshotPostValidationTestState::default();
+        notify.notify_all();
+    }
+
+    fn read_snapshot_test_pause_after_final_validation() {
+        #[cfg(test)]
+        {
+            let (state, notify) = &*READ_SNAPSHOT_POST_VALIDATION_TEST_HOOK;
+            let mut state = state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if !state.armed {
+                return;
+            }
+            state.reached = true;
+            notify.notify_all();
+            while !state.release {
+                state = notify
+                    .wait(state)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            }
+            *state = ReadSnapshotPostValidationTestState::default();
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) enum ReadSnapshotAcquireError {
+        Cancelled,
+        Busy(String),
+        TimedOut(String),
+        Failed(String),
+    }
+
+    impl ReadSnapshotAcquireError {
+        pub(crate) fn failed(error: impl std::fmt::Display) -> Self {
+            Self::Failed(error.to_string())
+        }
+    }
+
+    fn read_snapshot_duration_from_env(name: &str, default: Duration) -> Duration {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(Duration::from_millis)
+            .unwrap_or(default)
+    }
+
+    fn read_snapshot_validation_ttl() -> Duration {
+        read_snapshot_duration_from_env(
+            "MCP_AGENT_MAIL_READ_SNAPSHOT_VALIDATION_TTL_MS",
+            READ_SNAPSHOT_VALIDATION_TTL_DEFAULT,
+        )
+    }
+
+    fn read_snapshot_exact_audit_interval() -> Duration {
+        read_snapshot_duration_from_env(
+            "MCP_AGENT_MAIL_READ_SNAPSHOT_EXACT_AUDIT_INTERVAL_MS",
+            READ_SNAPSHOT_EXACT_AUDIT_INTERVAL_DEFAULT,
+        )
+    }
+
+    struct ReadSnapshotBuildPermit;
+
+    impl ReadSnapshotBuildPermit {
+        fn try_acquire() -> Option<Self> {
+            let mut pending =
+                READ_SNAPSHOT_PENDING_BUILDS.load(std::sync::atomic::Ordering::Acquire);
+            loop {
+                if pending >= READ_SNAPSHOT_PENDING_BUILD_LIMIT {
+                    return None;
+                }
+                match READ_SNAPSHOT_PENDING_BUILDS.compare_exchange_weak(
+                    pending,
+                    pending + 1,
+                    std::sync::atomic::Ordering::AcqRel,
+                    std::sync::atomic::Ordering::Acquire,
+                ) {
+                    Ok(_) => return Some(Self),
+                    Err(observed) => pending = observed,
+                }
+            }
+        }
+    }
+
+    impl Drop for ReadSnapshotBuildPermit {
+        fn drop(&mut self) {
+            READ_SNAPSHOT_PENDING_BUILDS.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+        }
+    }
+
+    struct ReadSnapshotBuildGuard {
+        slot: Arc<ReadSnapshotScopeSlot>,
+        token: u64,
+        active: bool,
+    }
+
+    impl ReadSnapshotBuildGuard {
+        fn new(slot: Arc<ReadSnapshotScopeSlot>, token: u64) -> Self {
+            Self {
+                slot,
+                token,
+                active: true,
+            }
+        }
+
+        fn publish(
+            &mut self,
+            build: &ReadSnapshotBuild,
+            result: Result<ReadSnapshotBuildOutput, ReadSnapshotAcquireError>,
+        ) {
+            let mut retired = None;
+            mcp_agent_mail_storage::with_archive_publication_barrier(|| {
+                let mut state = self
+                    .slot
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if state
+                    .building
+                    .as_ref()
+                    .is_some_and(|build| build.token == self.token)
+                {
+                    let completion = match result {
+                        Ok(output)
+                            if self
+                                .slot
+                                .invalidation_epoch
+                                .load(std::sync::atomic::Ordering::Acquire)
+                                == build.invalidation_epoch
+                                && state.active_writers == 0
+                                && READ_SNAPSHOT_DB_WRITES_ACTIVE
+                                    .load(std::sync::atomic::Ordering::Acquire)
+                                    == 0
+                                && READ_SNAPSHOT_DB_WRITE_EPOCH
+                                    .load(std::sync::atomic::Ordering::Acquire)
+                                    == build.db_write_epoch
+                                && mcp_agent_mail_storage::archive_applications_active() == 0
+                                && mcp_agent_mail_storage::archive_application_epoch()
+                                    == build.archive_application_epoch =>
+                        {
+                            retired = state.ready.replace(ReadSnapshotCacheEntry {
+                                key: output.key,
+                                cheap_key: output.cheap_key,
+                                decision: output.decision,
+                                validated_at: Instant::now(),
+                                strong_validated_at: output.strong_validated_at,
+                                invalidation_epoch: build.invalidation_epoch,
+                            });
+                            Ok(())
+                        }
+                        Ok(_) => Err(ReadSnapshotAcquireError::Busy(
+                            "archive read snapshot build was superseded by a durable write"
+                                .to_string(),
+                        )),
+                        Err(error) => Err(error),
+                    };
+                    build.completion.complete(completion);
+                    state.building = None;
+                }
+            });
+            self.active = false;
+            // A retired entry owns a pool and temporary directory. Drop it
+            // outside the state mutex so cleanup cannot block admission.
+            drop(retired);
+        }
+    }
+
+    impl Drop for ReadSnapshotBuildGuard {
+        fn drop(&mut self) {
+            if !self.active {
+                return;
+            }
+            let mut state = self
+                .slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if state
+                .building
+                .as_ref()
+                .is_some_and(|build| build.token == self.token)
+            {
+                let completion = Arc::clone(
+                    &state
+                        .building
+                        .as_ref()
+                        .expect("matching snapshot build must remain present")
+                        .completion,
+                );
+                state.building = None;
+                completion.complete(Err(ReadSnapshotAcquireError::Failed(
+                    "archive read snapshot blocking worker terminated without publishing"
+                        .to_string(),
+                )));
+            }
+            drop(state);
+            self.slot.notify.notify_waiters();
+        }
+    }
+
+    #[cfg(test)]
+    struct ReadSnapshotReconstructionGuard;
+
+    #[cfg(test)]
+    struct ReadSnapshotGenerationScanGuard;
+
+    #[cfg(test)]
+    impl ReadSnapshotReconstructionGuard {
+        fn start() -> Self {
+            use std::sync::atomic::Ordering;
+
+            READ_SNAPSHOT_RECONSTRUCTION_COUNT.fetch_add(1, Ordering::Relaxed);
+            let current = READ_SNAPSHOT_RECONSTRUCTIONS_INFLIGHT.fetch_add(1, Ordering::SeqCst) + 1;
+            READ_SNAPSHOT_RECONSTRUCTIONS_MAX_INFLIGHT.fetch_max(current, Ordering::SeqCst);
+            Self
+        }
+    }
+
+    #[cfg(test)]
+    impl Drop for ReadSnapshotReconstructionGuard {
+        fn drop(&mut self) {
+            READ_SNAPSHOT_RECONSTRUCTIONS_INFLIGHT
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[cfg(test)]
+    impl ReadSnapshotGenerationScanGuard {
+        fn start() -> Self {
+            use std::sync::atomic::Ordering;
+
+            READ_SNAPSHOT_GENERATION_SCAN_COUNT.fetch_add(1, Ordering::Relaxed);
+            let current =
+                READ_SNAPSHOT_GENERATION_SCANS_INFLIGHT.fetch_add(1, Ordering::SeqCst) + 1;
+            READ_SNAPSHOT_GENERATION_SCANS_MAX_INFLIGHT.fetch_max(current, Ordering::SeqCst);
+            Self
+        }
+    }
+
+    #[cfg(test)]
+    impl Drop for ReadSnapshotGenerationScanGuard {
+        fn drop(&mut self) {
+            READ_SNAPSHOT_GENERATION_SCANS_INFLIGHT
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    fn update_path_metadata_digest(
+        hasher: &mut Sha256,
+        path: &Path,
+    ) -> Result<(), ReadSnapshotAcquireError> {
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                hasher.update([1]);
+                hasher.update(metadata.len().to_le_bytes());
+                let file_type = metadata.file_type();
+                hasher.update([
+                    u8::from(file_type.is_file()),
+                    u8::from(file_type.is_dir()),
+                    u8::from(file_type.is_symlink()),
+                ]);
+                let modified = metadata
+                    .modified()
+                    .unwrap_or(UNIX_EPOCH)
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default();
+                hasher.update(modified.as_secs().to_le_bytes());
+                hasher.update(modified.subsec_nanos().to_le_bytes());
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                hasher.update([0]);
+            }
+            Err(error) => return Err(ReadSnapshotAcquireError::failed(error)),
+        }
+        Ok(())
+    }
+
+    fn update_path_shape_digest(
+        hasher: &mut Sha256,
+        path: &Path,
+    ) -> Result<(), ReadSnapshotAcquireError> {
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                hasher.update([1]);
+                hasher.update(metadata.len().to_le_bytes());
+                let file_type = metadata.file_type();
+                hasher.update([
+                    u8::from(file_type.is_file()),
+                    u8::from(file_type.is_dir()),
+                    u8::from(file_type.is_symlink()),
+                ]);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                hasher.update([0]);
+            }
+            Err(error) => return Err(ReadSnapshotAcquireError::failed(error)),
+        }
+        Ok(())
+    }
+
+    fn update_file_contents_digest(
+        hasher: &mut Sha256,
+        path: &Path,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<(), ReadSnapshotAcquireError> {
+        if cancelled() {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        let metadata = std::fs::symlink_metadata(path).map_err(ReadSnapshotAcquireError::failed)?;
+        if metadata.file_type().is_symlink() {
+            let target = std::fs::read_link(path).map_err(ReadSnapshotAcquireError::failed)?;
+            hasher.update(target.to_string_lossy().as_bytes());
+            return Ok(());
+        }
+        if !metadata.is_file() {
+            return Ok(());
+        }
+
+        let mut file = std::fs::File::open(path).map_err(ReadSnapshotAcquireError::failed)?;
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            if cancelled() {
+                return Err(ReadSnapshotAcquireError::Cancelled);
+            }
+            let read = file
+                .read(&mut buffer)
+                .map_err(ReadSnapshotAcquireError::failed)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        Ok(())
+    }
+
+    fn collect_archive_tree_paths(
+        directory: &Path,
+        paths: &mut Vec<PathBuf>,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<(), ReadSnapshotAcquireError> {
+        if cancelled() {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        let entries = match std::fs::read_dir(directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(ReadSnapshotAcquireError::failed(error)),
+        };
+        for entry in entries {
+            if cancelled() {
+                return Err(ReadSnapshotAcquireError::Cancelled);
+            }
+            let entry = entry.map_err(ReadSnapshotAcquireError::failed)?;
+            let path = entry.path();
+            let metadata =
+                std::fs::symlink_metadata(&path).map_err(ReadSnapshotAcquireError::failed)?;
+            paths.push(path.clone());
+            if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                collect_archive_tree_paths(&path, paths, cancelled)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_archive_generation(
+        storage_root: &Path,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<(PathBuf, [u8; 32]), ReadSnapshotAcquireError> {
+        if cancelled() {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        let canonical_root = storage_root
+            .canonicalize()
+            .map_err(ReadSnapshotAcquireError::failed)?;
+        let mut hasher = Sha256::new();
+        hasher.update(b"agent-mail-read-snapshot-archive-v1");
+        hasher.update(canonical_root.to_string_lossy().as_bytes());
+
+        if let Ok(repo) = git2::Repository::open(&canonical_root)
+            && repo
+                .workdir()
+                .and_then(|workdir| workdir.canonicalize().ok())
+                .as_ref()
+                == Some(&canonical_root)
+        {
+            let head_before = read_archive_head(&repo);
+            hasher.update(b"git");
+            if let Some(head) = head_before {
+                hasher.update(head.as_bytes());
+            }
+
+            let mut status_options = git2::StatusOptions::new();
+            status_options
+                .show(git2::StatusShow::IndexAndWorkdir)
+                .include_untracked(true)
+                .recurse_untracked_dirs(true)
+                .include_ignored(true)
+                .recurse_ignored_dirs(true)
+                .include_unmodified(false)
+                .exclude_submodules(false)
+                .pathspec("projects");
+            let statuses = repo
+                .statuses(Some(&mut status_options))
+                .map_err(ReadSnapshotAcquireError::failed)?;
+            if cancelled() {
+                return Err(ReadSnapshotAcquireError::Cancelled);
+            }
+            let mut dirty_paths = Vec::new();
+            for entry in statuses.iter() {
+                let path = entry.path().map_err(|error| {
+                    ReadSnapshotAcquireError::Failed(format!(
+                        "archive Git status path is unavailable or non-UTF-8; refusing an inexact read-snapshot generation: {error}"
+                    ))
+                })?;
+                dirty_paths.push((path.to_string(), entry.status().bits()));
+            }
+            dirty_paths.sort();
+            let mut content_paths = BTreeSet::new();
+            for (relative, status) in &dirty_paths {
+                if cancelled() {
+                    return Err(ReadSnapshotAcquireError::Cancelled);
+                }
+                hasher.update(relative.as_bytes());
+                hasher.update(status.to_le_bytes());
+                let path = canonical_root.join(relative);
+                let newly_discovered = content_paths.insert(path.clone());
+                if newly_discovered && path.exists() {
+                    let metadata = std::fs::symlink_metadata(&path)
+                        .map_err(ReadSnapshotAcquireError::failed)?;
+                    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                        let mut descendants = Vec::new();
+                        collect_archive_tree_paths(&path, &mut descendants, cancelled)?;
+                        content_paths.extend(descendants);
+                    }
+                }
+            }
+            for path in content_paths {
+                if cancelled() {
+                    return Err(ReadSnapshotAcquireError::Cancelled);
+                }
+                let relative = path.strip_prefix(&canonical_root).unwrap_or(path.as_path());
+                hasher.update(relative.to_string_lossy().as_bytes());
+                update_path_metadata_digest(&mut hasher, &path)?;
+                if path.exists() {
+                    update_file_contents_digest(&mut hasher, &path, cancelled)?;
+                }
+            }
+
+            if read_archive_head(&repo) != head_before {
+                return Err(ReadSnapshotAcquireError::Failed(
+                    "archive HEAD changed while computing the read-snapshot generation".to_string(),
+                ));
+            }
+            return Ok((canonical_root, hasher.finalize().into()));
+        }
+
+        hasher.update(b"tree");
+        let projects = canonical_root.join("projects");
+        let mut paths = Vec::new();
+        collect_archive_tree_paths(&projects, &mut paths, cancelled)?;
+        paths.sort();
+        for path in paths {
+            if cancelled() {
+                return Err(ReadSnapshotAcquireError::Cancelled);
+            }
+            let relative = path.strip_prefix(&canonical_root).unwrap_or(path.as_path());
+            hasher.update(relative.to_string_lossy().as_bytes());
+            update_path_metadata_digest(&mut hasher, &path)?;
+            update_file_contents_digest(&mut hasher, &path, cancelled)?;
+        }
+        Ok((canonical_root, hasher.finalize().into()))
+    }
+
+    fn read_live_db_generation(
+        sqlite_path: &Path,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<[u8; 32], ReadSnapshotAcquireError> {
+        let mut hasher = Sha256::new();
+        hasher.update(b"agent-mail-read-snapshot-live-db-v3-content");
+        // The main database plus rollback/WAL journals are durable content.
+        // Do not hash `-shm`: read-lock bookkeeping changes there without a
+        // durable mailbox write and would make generation validation livelock.
+        for path in
+            std::iter::once(sqlite_path.to_path_buf()).chain(["-journal", "-wal"].into_iter().map(
+                |suffix| mcp_agent_mail_db::pool::sqlite_path_with_suffix(sqlite_path, suffix),
+            ))
+        {
+            if cancelled() {
+                return Err(ReadSnapshotAcquireError::Cancelled);
+            }
+            hasher.update(path.to_string_lossy().as_bytes());
+            // Read-only FrankenSQLite probes can advance the main file's mtime
+            // without changing durable bytes. The exact generation is content
+            // addressed, so include path shape but exclude incidental mtimes.
+            update_path_shape_digest(&mut hasher, &path)?;
+            if path.exists() {
+                update_file_contents_digest(&mut hasher, &path, cancelled)?;
+            }
+        }
+        Ok(hasher.finalize().into())
+    }
+
+    fn read_snapshot_scope(
+        storage_root: &Path,
+        sqlite_path: &Path,
+    ) -> Result<ReadSnapshotScope, ReadSnapshotAcquireError> {
+        let storage_root = storage_root
+            .canonicalize()
+            .map_err(ReadSnapshotAcquireError::failed)?;
+        let sqlite_path = sqlite_path
+            .canonicalize()
+            .unwrap_or_else(|_| sqlite_path.to_path_buf());
+        Ok(ReadSnapshotScope {
+            storage_root,
+            sqlite_path,
+        })
+    }
+
+    fn read_snapshot_key(
+        scope: &ReadSnapshotScope,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<ReadSnapshotKey, ReadSnapshotAcquireError> {
+        #[cfg(test)]
+        let _generation_scan_guard = ReadSnapshotGenerationScanGuard::start();
+
+        let (_, archive_digest) = read_archive_generation(&scope.storage_root, cancelled)?;
+        if cancelled() {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        let live_db_digest = read_live_db_generation(&scope.sqlite_path, cancelled)?;
+        Ok(ReadSnapshotKey {
+            archive_digest,
+            live_db_digest,
+        })
+    }
+
+    fn open_read_only_snapshot_probe(
+        sqlite_path: &Path,
+        phase: &str,
+    ) -> Result<mcp_agent_mail_db::DbConn, String> {
+        let conn =
+            mcp_agent_mail_db::DbConn::open_file_read_only(sqlite_path.to_string_lossy().as_ref())
+                .map_err(|error| {
+                    format!(
+                        "{phase}: open {} read-only without create: {error}",
+                        sqlite_path.display()
+                    )
+                })?;
+        conn.execute_raw("PRAGMA query_only = ON;")
+            .map_err(|error| format!("{phase}: enforce query-only connection: {error}"))?;
+        Ok(conn)
+    }
+
+    fn read_snapshot_live_data_version(slot: &ReadSnapshotScopeSlot) -> Option<i64> {
+        let mut observer = slot
+            .data_version_observer
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if observer.is_none() {
+            let conn = open_read_only_snapshot_probe(
+                &slot.scope.sqlite_path,
+                "read-snapshot data_version observer",
+            )
+            .ok()?;
+            *observer = Some(conn);
+        }
+        let value = observer
+            .as_ref()
+            .and_then(|conn| mcp_agent_mail_db::pool::sqlite_data_version(conn).ok());
+        if value.is_none() {
+            // Re-open on the next validation after an observer failure. The
+            // metadata and exact-audit paths remain conservative meanwhile.
+            *observer = None;
+        }
+        value
+    }
+
+    fn read_snapshot_cheap_key(
+        slot: &ReadSnapshotScopeSlot,
+    ) -> Result<ReadSnapshotCheapKey, ReadSnapshotAcquireError> {
+        // Establish the long-lived observer before capturing file metadata:
+        // opening a read-only FrankenSQLite connection may create sidecars or
+        // advance the main file's mtime even though durable content is stable.
+        let live_data_version = read_snapshot_live_data_version(slot);
+
+        let mut archive = Sha256::new();
+        archive.update(b"agent-mail-read-snapshot-archive-metadata-v2");
+        archive.update(slot.scope.storage_root.to_string_lossy().as_bytes());
+        // Pool setup can create and remove transient root-level bookkeeping;
+        // only the projects tree and Git metadata define archive generations.
+        update_path_shape_digest(&mut archive, &slot.scope.storage_root)?;
+        update_path_metadata_digest(&mut archive, &slot.scope.storage_root.join("projects"))?;
+        update_path_metadata_digest(&mut archive, &slot.scope.storage_root.join(".git/HEAD"))?;
+        update_path_metadata_digest(&mut archive, &slot.scope.storage_root.join(".git/index"))?;
+        if let Ok(repo) = git2::Repository::open(&slot.scope.storage_root)
+            && let Some(head) = read_archive_head(&repo)
+        {
+            archive.update(head.as_bytes());
+        }
+
+        let mut live = Sha256::new();
+        live.update(b"agent-mail-read-snapshot-live-db-metadata-v2");
+        live.update(slot.scope.sqlite_path.to_string_lossy().as_bytes());
+        update_path_shape_digest(&mut live, &slot.scope.sqlite_path)?;
+        for path in ["-journal", "-wal"].into_iter().map(|suffix| {
+            mcp_agent_mail_db::pool::sqlite_path_with_suffix(&slot.scope.sqlite_path, suffix)
+        }) {
+            live.update(path.to_string_lossy().as_bytes());
+            update_path_metadata_digest(&mut live, &path)?;
+        }
+
+        Ok(ReadSnapshotCheapKey {
+            archive_metadata_digest: archive.finalize().into(),
+            live_db_metadata_digest: live.finalize().into(),
+            live_data_version,
+            db_write_epoch: READ_SNAPSHOT_DB_WRITE_EPOCH.load(std::sync::atomic::Ordering::Acquire),
+            archive_application_epoch: mcp_agent_mail_storage::archive_application_epoch(),
+        })
+    }
+
+    pub(crate) fn read_snapshot_cancelled(cx: Option<&asupersync::Cx>) -> bool {
+        cx.is_some_and(asupersync::Cx::is_cancel_requested)
+    }
+
+    fn read_snapshot_key_with_budget(
+        scope: &ReadSnapshotScope,
+        cancelled: &dyn Fn() -> bool,
+        cx: Option<&asupersync::Cx>,
+        build_deadline: Instant,
+    ) -> Result<ReadSnapshotKey, ReadSnapshotAcquireError> {
+        let key = match read_snapshot_key(scope, cancelled) {
+            Ok(key) => key,
+            Err(_) if read_snapshot_cancelled(cx) => {
+                return Err(ReadSnapshotAcquireError::Cancelled);
+            }
+            Err(_) if Instant::now() >= build_deadline => {
+                return Err(ReadSnapshotAcquireError::TimedOut(format!(
+                    "archive read snapshot generation scan exceeded its {}s work budget",
+                    READ_SNAPSHOT_BUILD_TIMEOUT.as_secs()
+                )));
+            }
+            Err(error) => return Err(error),
+        };
+        if read_snapshot_cancelled(cx) {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        if Instant::now() >= build_deadline {
+            return Err(ReadSnapshotAcquireError::TimedOut(format!(
+                "archive read snapshot generation scan exceeded its {}s work budget",
+                READ_SNAPSHOT_BUILD_TIMEOUT.as_secs()
+            )));
+        }
+        Ok(key)
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ReadSnapshotMode {
+        Canonical,
+        ForceSnapshot,
+    }
+
+    #[derive(Clone)]
+    struct ReadSnapshotBuildRequest {
+        database_url: String,
+        mode: ReadSnapshotMode,
+    }
+
+    fn read_snapshot_slot(
+        scope: ReadSnapshotScope,
+    ) -> Result<Arc<ReadSnapshotScopeSlot>, ReadSnapshotAcquireError> {
+        let mut registry = READ_SNAPSHOT_REGISTRY
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(index) = registry.slots.iter().position(|slot| slot.scope == scope) {
+            let slot = registry
+                .slots
+                .remove(index)
+                .expect("read snapshot slot index must remain valid");
+            registry.slots.push_back(Arc::clone(&slot));
+            return Ok(slot);
+        }
+
+        let retired = if registry.slots.len() >= READ_SNAPSHOT_SCOPE_CAPACITY {
+            let Some(index) = registry.slots.iter().position(|candidate| {
+                Arc::strong_count(candidate) == 1 && {
+                    let state = candidate
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    state.building.is_none() && state.active_writers == 0
+                }
+            }) else {
+                return Err(ReadSnapshotAcquireError::Busy(format!(
+                    "archive read snapshot scope registry is at its hard capacity of {READ_SNAPSHOT_SCOPE_CAPACITY} active mailboxes"
+                )));
+            };
+            registry.slots.remove(index)
+        } else {
+            None
+        };
+        let slot = Arc::new(ReadSnapshotScopeSlot::new(scope));
+        registry.slots.push_back(Arc::clone(&slot));
+        drop(registry);
+        // A retired entry can own a pool and temporary directory. Never run
+        // that cleanup while holding the global registry lock.
+        drop(retired);
+        Ok(slot)
+    }
+
+    fn begin_read_snapshot_write(
+        storage_root: &Path,
+        sqlite_path: &Path,
+    ) -> Option<Arc<ReadSnapshotScopeSlot>> {
+        READ_SNAPSHOT_DB_WRITES_ACTIVE.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        READ_SNAPSHOT_DB_WRITE_EPOCH.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+
+        let slot = read_snapshot_scope(storage_root, sqlite_path)
+            .ok()
+            .and_then(|scope| read_snapshot_slot(scope).ok());
+        if let Some(slot) = &slot {
+            let mut state = slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.active_writers = state.active_writers.saturating_add(1);
+            slot.invalidation_epoch
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            drop(state);
+            slot.notify.notify_waiters();
+        }
+        slot
+    }
+
+    fn end_read_snapshot_write(slot: Option<&ReadSnapshotScopeSlot>) {
+        if let Some(slot) = slot {
+            let mut state = slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.active_writers = state.active_writers.saturating_sub(1);
+            slot.invalidation_epoch
+                .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+            drop(state);
+        }
+        READ_SNAPSHOT_DB_WRITE_EPOCH.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        READ_SNAPSHOT_DB_WRITES_ACTIVE.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+        if let Some(slot) = slot {
+            slot.notify.notify_waiters();
+        }
+    }
+
+    fn invalidate_read_snapshot_slot(slot: &ReadSnapshotScopeSlot) {
+        slot.invalidation_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        slot.notify.notify_waiters();
+    }
+
+    pub(crate) fn invalidate_read_snapshots_for_archive(storage_root: &Path) {
+        let canonical = storage_root
+            .canonicalize()
+            .unwrap_or_else(|_| storage_root.to_path_buf());
+        let slots = READ_SNAPSHOT_REGISTRY
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .slots
+            .iter()
+            .filter(|slot| slot.scope.storage_root == canonical)
+            .cloned()
+            .collect::<Vec<_>>();
+        for slot in slots {
+            invalidate_read_snapshot_slot(&slot);
+        }
+    }
+
+    fn build_read_snapshot(
+        scope: &ReadSnapshotScope,
+        inventory: &mcp_agent_mail_db::ArchiveMessageInventory,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Arc<SharedArchiveReadSnapshot>, ReadSnapshotAcquireError> {
+        #[cfg(test)]
+        let _reconstruction_guard = ReadSnapshotReconstructionGuard::start();
+
+        let snapshot_dir =
+            mcp_agent_mail_db::pool::CanonicalSnapshotTempDir::new("agent-mail-read-snapshot-")
+                .map_err(ReadSnapshotAcquireError::failed)?;
+        let snapshot_db = snapshot_dir.path().join("mailbox.sqlite3");
+        let stats = if scope.sqlite_path.exists() {
+            mcp_agent_mail_db::reconstruct_from_archive_with_salvage_cancellable(
+                &snapshot_db,
+                &scope.storage_root,
+                Some(scope.sqlite_path.as_path()),
+                cancelled,
+            )
+            .map_err(ReadSnapshotAcquireError::failed)?
+        } else {
+            mcp_agent_mail_db::reconstruct_from_archive_cancellable(
+                &snapshot_db,
+                &scope.storage_root,
+                cancelled,
+            )
+            .map_err(ReadSnapshotAcquireError::failed)?
+        };
+        if cancelled() {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        validate_read_snapshot_completeness(inventory, &stats)?;
+        let pool = mcp_agent_mail_db::create_query_only_pool(&mcp_agent_mail_db::DbPoolConfig {
+            database_url: mcp_agent_mail_core::disk::sqlite_url_from_path(&snapshot_db),
+            storage_root: Some(scope.storage_root.clone()),
+            ..Default::default()
+        })
+        .map_err(ReadSnapshotAcquireError::failed)?;
+        Ok(Arc::new(SharedArchiveReadSnapshot {
+            pool,
+            _snapshot_dir: snapshot_dir,
+        }))
+    }
+
+    fn validate_read_snapshot_inventory(
+        inventory: &mcp_agent_mail_db::ArchiveMessageInventory,
+    ) -> Result<(), ReadSnapshotAcquireError> {
+        if inventory.parse_errors > 0 {
+            return Err(ReadSnapshotAcquireError::Failed(format!(
+                "archive read snapshot inventory found {} canonical message file(s) that could not be parsed; refusing an incomplete read decision",
+                inventory.parse_errors
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_read_snapshot_completeness(
+        inventory: &mcp_agent_mail_db::ArchiveMessageInventory,
+        stats: &mcp_agent_mail_db::ReconstructStats,
+    ) -> Result<(), ReadSnapshotAcquireError> {
+        validate_read_snapshot_inventory(inventory)?;
+        if stats.parse_errors > 0 {
+            return Err(ReadSnapshotAcquireError::Failed(format!(
+                "archive read snapshot reconstruction skipped {} malformed or unreadable archive artifact(s); refusing partial publication",
+                stats.parse_errors
+            )));
+        }
+
+        let reconstructed_message_files = stats
+            .messages
+            .checked_add(stats.duplicate_canonical_message_files)
+            .ok_or_else(|| {
+                ReadSnapshotAcquireError::Failed(
+                    "archive read snapshot message completeness count overflowed".to_string(),
+                )
+            })?;
+        if stats.projects != inventory.projects
+            || stats.agents != inventory.agents
+            || reconstructed_message_files != inventory.canonical_message_files
+        {
+            return Err(ReadSnapshotAcquireError::Failed(format!(
+                "archive read snapshot reconstruction was incomplete: inventory projects={} agents={} canonical_message_files={}; reconstructed projects={} agents={} messages={} duplicate_canonical_message_files={} (salvaged projects={} agents={} messages={})",
+                inventory.projects,
+                inventory.agents,
+                inventory.canonical_message_files,
+                stats.projects,
+                stats.agents,
+                stats.messages,
+                stats.duplicate_canonical_message_files,
+                stats.salvaged_projects,
+                stats.salvaged_agents,
+                stats.salvaged_messages,
+            )));
+        }
+        Ok(())
+    }
+
+    fn read_snapshot_stop_error(
+        slot: &ReadSnapshotScopeSlot,
+        build: &ReadSnapshotBuild,
+        cx: &asupersync::Cx,
+        deadline: Instant,
+        phase: &str,
+    ) -> Option<ReadSnapshotAcquireError> {
+        if cx.is_cancel_requested() {
+            return Some(ReadSnapshotAcquireError::Cancelled);
+        }
+        if Instant::now() >= deadline {
+            return Some(ReadSnapshotAcquireError::TimedOut(format!(
+                "archive read snapshot {phase} exceeded its {}s cold-bootstrap budget",
+                READ_SNAPSHOT_BUILD_TIMEOUT.as_secs()
+            )));
+        }
+        if slot
+            .invalidation_epoch
+            .load(std::sync::atomic::Ordering::Acquire)
+            != build.invalidation_epoch
+            || slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .active_writers
+                > 0
+            || READ_SNAPSHOT_DB_WRITES_ACTIVE.load(std::sync::atomic::Ordering::Acquire) > 0
+            || READ_SNAPSHOT_DB_WRITE_EPOCH.load(std::sync::atomic::Ordering::Acquire)
+                != build.db_write_epoch
+            || mcp_agent_mail_storage::archive_applications_active() > 0
+            || mcp_agent_mail_storage::archive_application_epoch()
+                != build.archive_application_epoch
+        {
+            return Some(ReadSnapshotAcquireError::Busy(
+                "archive read snapshot build was superseded by a durable write".to_string(),
+            ));
+        }
+        None
+    }
+
+    fn normalize_read_snapshot_build_error(
+        error: ReadSnapshotAcquireError,
+        slot: &ReadSnapshotScopeSlot,
+        build: &ReadSnapshotBuild,
+        cx: &asupersync::Cx,
+        deadline: Instant,
+        phase: &str,
+    ) -> ReadSnapshotAcquireError {
+        read_snapshot_stop_error(slot, build, cx, deadline, phase).unwrap_or(error)
+    }
+
+    fn run_read_snapshot_build(
+        slot: &ReadSnapshotScopeSlot,
+        request: &ReadSnapshotBuildRequest,
+        build: &ReadSnapshotBuild,
+        cx: &asupersync::Cx,
+    ) -> Result<ReadSnapshotBuildOutput, ReadSnapshotAcquireError> {
+        #[cfg(test)]
+        read_snapshot_test_delay();
+
+        let cancelled = || {
+            read_snapshot_stop_error(
+                slot,
+                build,
+                cx,
+                build.deadline,
+                "generation or reconstruction",
+            )
+            .is_some()
+        };
+        let mut archive_inventory = None;
+        for _ in 0..READ_SNAPSHOT_GENERATION_RETRIES {
+            if let Some(error) =
+                read_snapshot_stop_error(slot, build, cx, build.deadline, "generation")
+            {
+                return Err(error);
+            }
+            let cheap_key = read_snapshot_cheap_key(slot)?;
+            let cheap_cached = slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .ready
+                .as_ref()
+                .filter(|entry| {
+                    entry.invalidation_epoch == build.invalidation_epoch
+                        && entry.cheap_key == cheap_key
+                        && Instant::now().duration_since(entry.strong_validated_at)
+                            < read_snapshot_exact_audit_interval()
+                })
+                .map(|entry| {
+                    (
+                        entry.key.clone(),
+                        entry.decision.clone(),
+                        entry.strong_validated_at,
+                    )
+                });
+            if let Some((key, decision, strong_validated_at)) = cheap_cached {
+                return Ok(ReadSnapshotBuildOutput {
+                    key,
+                    cheap_key,
+                    decision,
+                    strong_validated_at,
+                });
+            }
+
+            let key =
+                read_snapshot_key_with_budget(&slot.scope, &cancelled, Some(cx), build.deadline)
+                    .map_err(|error| {
+                        normalize_read_snapshot_build_error(
+                            error,
+                            slot,
+                            &build,
+                            cx,
+                            build.deadline,
+                            "generation",
+                        )
+                    })?;
+
+            let cached_decision = slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .ready
+                .as_ref()
+                .filter(|entry| {
+                    entry.invalidation_epoch == build.invalidation_epoch && entry.key == key
+                })
+                .map(|entry| entry.decision.clone());
+            if let Some(decision) = cached_decision {
+                let cheap_after = read_snapshot_cheap_key(slot)?;
+                if cheap_after == cheap_key {
+                    read_snapshot_test_pause_after_final_validation();
+                    return Ok(ReadSnapshotBuildOutput {
+                        key,
+                        cheap_key: cheap_after,
+                        decision,
+                        strong_validated_at: Instant::now(),
+                    });
+                }
+                continue;
+            }
+
+            if archive_inventory
+                .as_ref()
+                .is_none_or(|(digest, _)| *digest != key.archive_digest)
+            {
+                archive_inventory = Some((
+                    key.archive_digest,
+                    read_archive_inventory_cancellable(&slot.scope.storage_root, &cancelled)
+                        .map_err(|error| {
+                            normalize_read_snapshot_build_error(
+                                error,
+                                slot,
+                                &build,
+                                cx,
+                                build.deadline,
+                                "archive inventory",
+                            )
+                        })?,
+                ));
+            }
+            let inventory = &archive_inventory
+                .as_ref()
+                .expect("archive inventory generation must be initialized")
+                .1;
+            validate_read_snapshot_inventory(inventory)?;
+            let snapshot_required = if request.mode == ReadSnapshotMode::ForceSnapshot {
+                true
+            } else {
+                let archive_has_state = read_archive_inventory_has_state(inventory);
+                match open_read_only_snapshot_probe(
+                    &slot.scope.sqlite_path,
+                    "read-snapshot archive-ahead probe",
+                ) {
+                    Ok(conn) => {
+                        if archive_has_state
+                            && live_db_is_suspect(
+                                &request.database_url,
+                                &slot.scope.storage_root,
+                                &slot.scope.sqlite_path,
+                            )
+                        {
+                            true
+                        } else {
+                            let conn = mcp_agent_mail_db::guard_db_conn(
+                                conn,
+                                "tool_util::run_read_snapshot_build archive-ahead probe",
+                            );
+                            let ahead = read_archive_is_ahead(
+                                &slot.scope.storage_root,
+                                &slot.scope.sqlite_path,
+                                &conn,
+                                inventory,
+                            );
+                            drop(conn);
+                            match ahead {
+                                Ok(ahead) => ahead,
+                                Err(error) if archive_has_state => {
+                                    tracing::warn!(
+                                        source = %slot.scope.sqlite_path.display(),
+                                        storage_root = %slot.scope.storage_root.display(),
+                                        error = %error,
+                                        "using archive snapshot because the live sqlite inventory probe failed"
+                                    );
+                                    true
+                                }
+                                Err(_) => false,
+                            }
+                        }
+                    }
+                    Err(error) if archive_has_state => {
+                        tracing::warn!(
+                            source = %slot.scope.sqlite_path.display(),
+                            storage_root = %slot.scope.storage_root.display(),
+                            error = %error,
+                            "using archive snapshot because the live sqlite source could not be opened"
+                        );
+                        true
+                    }
+                    Err(_) => false,
+                }
+            };
+
+            let decision = if snapshot_required {
+                #[cfg(test)]
+                run_read_snapshot_pre_reconstruction_test_hook();
+                ArchiveReadDecision::Snapshot(
+                    build_read_snapshot(&slot.scope, inventory, &cancelled).map_err(|error| {
+                        normalize_read_snapshot_build_error(
+                            error,
+                            slot,
+                            &build,
+                            cx,
+                            build.deadline,
+                            "reconstruction",
+                        )
+                    })?,
+                )
+            } else {
+                ArchiveReadDecision::Live
+            };
+
+            let after =
+                read_snapshot_key_with_budget(&slot.scope, &cancelled, Some(cx), build.deadline)
+                    .map_err(|error| {
+                        normalize_read_snapshot_build_error(
+                            error,
+                            slot,
+                            &build,
+                            cx,
+                            build.deadline,
+                            "post-build validation",
+                        )
+                    })?;
+            let cheap_after = read_snapshot_cheap_key(slot)?;
+            if after == key && cheap_after == cheap_key {
+                read_snapshot_test_pause_after_final_validation();
+                return Ok(ReadSnapshotBuildOutput {
+                    key,
+                    cheap_key: cheap_after,
+                    decision,
+                    strong_validated_at: Instant::now(),
+                });
+            }
+        }
+
+        Err(ReadSnapshotAcquireError::Busy(
+            "archive or live SQLite content changed repeatedly during read-snapshot reconstruction"
+                .to_string(),
+        ))
+    }
+
+    fn try_claim_read_snapshot_build(
+        slot: &ReadSnapshotScopeSlot,
+        deadline: Instant,
+    ) -> Result<Option<ReadSnapshotBuild>, ReadSnapshotAcquireError> {
+        let mut state = slot
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.active_writers > 0
+            || READ_SNAPSHOT_DB_WRITES_ACTIVE.load(std::sync::atomic::Ordering::Acquire) > 0
+            || mcp_agent_mail_storage::archive_applications_active() > 0
+        {
+            return Err(ReadSnapshotAcquireError::Busy(
+                "archive read snapshot build is blocked while a durable writer is active"
+                    .to_string(),
+            ));
+        }
+        if state.building.is_some() {
+            return Ok(None);
+        }
+        state.next_token = state.next_token.wrapping_add(1).max(1);
+        let build = ReadSnapshotBuild {
+            token: state.next_token,
+            invalidation_epoch: slot
+                .invalidation_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            db_write_epoch: READ_SNAPSHOT_DB_WRITE_EPOCH.load(std::sync::atomic::Ordering::Acquire),
+            archive_application_epoch: mcp_agent_mail_storage::archive_application_epoch(),
+            deadline,
+            completion: Arc::new(ReadSnapshotBuildCompletion::pending()),
+        };
+        state.building = Some(build.clone());
+        Ok(Some(build))
+    }
+
+    fn fail_scheduled_read_snapshot_build(
+        slot: &ReadSnapshotScopeSlot,
+        build: &ReadSnapshotBuild,
+        error: ReadSnapshotAcquireError,
+    ) {
+        let mut state = slot
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state
+            .building
+            .as_ref()
+            .is_some_and(|active| active.token == build.token)
+        {
+            state.building = None;
+            build.completion.complete(Err(error));
+        }
+        drop(state);
+        slot.notify.notify_waiters();
+    }
+
+    fn schedule_read_snapshot_build(
+        slot: Arc<ReadSnapshotScopeSlot>,
+        request: ReadSnapshotBuildRequest,
+        build: &ReadSnapshotBuild,
+        cx: asupersync::Cx,
+    ) -> Result<(), ReadSnapshotAcquireError> {
+        let Some(pending_permit) = ReadSnapshotBuildPermit::try_acquire() else {
+            let error = ReadSnapshotAcquireError::Busy(format!(
+                "archive read snapshot build queue is at its hard pending limit of {READ_SNAPSHOT_PENDING_BUILD_LIMIT}"
+            ));
+            fail_scheduled_read_snapshot_build(&slot, build, error.clone());
+            return Err(error);
+        };
+        let worker_slot = Arc::clone(&slot);
+        let worker_build = build.clone();
+        let handle = READ_SNAPSHOT_BLOCKING_POOL.spawn(move || {
+            let mut guard =
+                ReadSnapshotBuildGuard::new(Arc::clone(&worker_slot), worker_build.token);
+            let result = run_read_snapshot_build(&worker_slot, &request, &worker_build, &cx);
+            guard.publish(&worker_build, result);
+            drop(pending_permit);
+            worker_slot.notify.notify_waiters();
+        });
+        if handle.is_cancelled() {
+            let error = ReadSnapshotAcquireError::Busy(
+                "archive read snapshot blocking pool is unavailable".to_string(),
+            );
+            fail_scheduled_read_snapshot_build(&slot, build, error.clone());
+            return Err(error);
+        }
+        drop(handle);
+        Ok(())
+    }
+
+    async fn wait_for_read_snapshot_build(
+        slot: &ReadSnapshotScopeSlot,
+        build: ReadSnapshotBuild,
+        cx: &asupersync::Cx,
+        caller_deadline: Instant,
+    ) -> Result<(), ReadSnapshotAcquireError> {
+        loop {
+            if cx.is_cancel_requested() {
+                return Err(ReadSnapshotAcquireError::Cancelled);
+            }
+            if let Some(completion) = build.completion.result() {
+                return match completion {
+                    Ok(()) => Ok(()),
+                    Err(ReadSnapshotAcquireError::Cancelled) => Ok(()),
+                    Err(ReadSnapshotAcquireError::Busy(message))
+                        if message.contains("superseded by a durable write") =>
+                    {
+                        Ok(())
+                    }
+                    Err(error) => Err(error),
+                };
+            }
+
+            let now = Instant::now();
+            let deadline = build.deadline.min(caller_deadline);
+            if now >= deadline {
+                return Err(ReadSnapshotAcquireError::TimedOut(format!(
+                    "archive read snapshot cold bootstrap exceeded its {}s budget",
+                    READ_SNAPSHOT_BUILD_TIMEOUT.as_secs()
+                )));
+            }
+            let wait_for = READ_SNAPSHOT_WAIT_SLICE.min(deadline - now);
+            let notified = Box::pin(slot.notify.notified());
+            let _ =
+                asupersync::time::timeout(asupersync::time::wall_now(), wait_for, notified).await;
+        }
+    }
+
+    async fn get_archive_read_decision(
+        storage_root: &Path,
+        sqlite_path: &Path,
+        database_url: &str,
+        cx: &asupersync::Cx,
+        mode: ReadSnapshotMode,
+    ) -> Result<ArchiveReadDecision, ReadSnapshotAcquireError> {
+        if cx.is_cancel_requested() {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
+        let slot = read_snapshot_slot(read_snapshot_scope(storage_root, sqlite_path)?)?;
+        let request = ReadSnapshotBuildRequest {
+            database_url: database_url.to_string(),
+            mode,
+        };
+        let cold_deadline = Instant::now() + READ_SNAPSHOT_BUILD_TIMEOUT;
+
+        loop {
+            if cx.is_cancel_requested() {
+                return Err(ReadSnapshotAcquireError::Cancelled);
+            }
+            let epoch = slot
+                .invalidation_epoch
+                .load(std::sync::atomic::Ordering::Acquire);
+            let (ready, active_build) = {
+                let state = slot
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let ready = state.ready.as_ref().and_then(|entry| {
+                    (entry.invalidation_epoch == epoch
+                        && state.active_writers == 0
+                        && READ_SNAPSHOT_DB_WRITES_ACTIVE
+                            .load(std::sync::atomic::Ordering::Acquire)
+                            == 0
+                        && entry.cheap_key.db_write_epoch
+                            == READ_SNAPSHOT_DB_WRITE_EPOCH
+                                .load(std::sync::atomic::Ordering::Acquire)
+                        && mcp_agent_mail_storage::archive_applications_active() == 0
+                        && entry.cheap_key.archive_application_epoch
+                            == mcp_agent_mail_storage::archive_application_epoch())
+                    .then(|| {
+                        (
+                            entry.decision.clone(),
+                            Instant::now().duration_since(entry.validated_at)
+                                < read_snapshot_validation_ttl(),
+                        )
+                    })
+                });
+                (ready, state.building.clone())
+            };
+
+            if let Some((decision, true)) = ready {
+                return Ok(decision);
+            }
+            if let Some((decision, false)) = ready {
+                if active_build.is_none() {
+                    match try_claim_read_snapshot_build(&slot, cold_deadline) {
+                        Ok(Some(build)) => {
+                            if let Err(error) = schedule_read_snapshot_build(
+                                Arc::clone(&slot),
+                                request.clone(),
+                                &build,
+                                cx.clone(),
+                            ) {
+                                tracing::warn!(error = ?error, "snapshot stale-while-revalidate scheduling failed");
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(error) => tracing::debug!(
+                            error = ?error,
+                            "snapshot stale-while-revalidate deferred while admission is busy"
+                        ),
+                    }
+                }
+                return Ok(decision);
+            }
+
+            let build = match active_build {
+                Some(build) => build,
+                None => {
+                    let Some(build) = try_claim_read_snapshot_build(&slot, cold_deadline)? else {
+                        continue;
+                    };
+                    schedule_read_snapshot_build(
+                        Arc::clone(&slot),
+                        request.clone(),
+                        &build,
+                        cx.clone(),
+                    )?;
+                    build
+                }
+            };
+            wait_for_read_snapshot_build(&slot, build, cx, cold_deadline).await?;
+        }
+    }
+
+    pub(crate) async fn get_archive_read_snapshot_if(
+        storage_root: &Path,
+        sqlite_path: &Path,
+        database_url: &str,
+        cx: &asupersync::Cx,
+    ) -> Result<Option<Arc<SharedArchiveReadSnapshot>>, ReadSnapshotAcquireError> {
+        get_archive_read_decision(
+            storage_root,
+            sqlite_path,
+            database_url,
+            cx,
+            ReadSnapshotMode::Canonical,
+        )
+        .await
+        .map(|decision| decision.immutable_snapshot())
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn get_or_build_archive_read_snapshot(
+        storage_root: &Path,
+        sqlite_path: &Path,
+        cx: &asupersync::Cx,
+    ) -> Result<Arc<SharedArchiveReadSnapshot>, ReadSnapshotAcquireError> {
+        get_archive_read_decision(
+            storage_root,
+            sqlite_path,
+            &mcp_agent_mail_core::disk::sqlite_url_from_path(sqlite_path),
+            cx,
+            ReadSnapshotMode::ForceSnapshot,
+        )
+        .await?
+        .immutable_snapshot()
+        .ok_or_else(|| {
+            ReadSnapshotAcquireError::Failed(
+                "archive snapshot was unexpectedly bypassed by an unconditional build".to_string(),
+            )
+        })
+    }
+
+    pub(crate) fn read_snapshot_acquire_error_to_mcp_error(
+        error: ReadSnapshotAcquireError,
+    ) -> McpError {
+        match error {
+            ReadSnapshotAcquireError::Cancelled => McpError::request_cancelled(),
+            ReadSnapshotAcquireError::Busy(message) => {
+                db_error_to_mcp_error(DbError::ResourceBusy(message))
+            }
+            ReadSnapshotAcquireError::TimedOut(message) => legacy_tool_error(
+                "SNAPSHOT_TIMEOUT",
+                message,
+                true,
+                json!({"timeout_seconds": READ_SNAPSHOT_BUILD_TIMEOUT.as_secs()}),
+            ),
+            ReadSnapshotAcquireError::Failed(message) => {
+                read_pool_setup_error_to_mcp_error(message)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reset_read_snapshot_cache() {
+        use std::sync::atomic::Ordering;
+
+        let mut registry = READ_SNAPSHOT_REGISTRY
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            registry.slots.iter().all(|slot| slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .building
+                .is_none()),
+            "cannot reset the read snapshot cache while a reconstruction is active"
+        );
+        assert_eq!(
+            READ_SNAPSHOT_DB_WRITES_ACTIVE.load(Ordering::SeqCst),
+            0,
+            "cannot reset the read snapshot cache while a write lease is active"
+        );
+        registry.slots.clear();
+        drop(registry);
+        READ_SNAPSHOT_RECONSTRUCTION_COUNT.store(0, Ordering::SeqCst);
+        READ_SNAPSHOT_RECONSTRUCTIONS_INFLIGHT.store(0, Ordering::SeqCst);
+        READ_SNAPSHOT_RECONSTRUCTIONS_MAX_INFLIGHT.store(0, Ordering::SeqCst);
+        READ_SNAPSHOT_GENERATION_SCAN_COUNT.store(0, Ordering::SeqCst);
+        READ_SNAPSHOT_GENERATION_SCANS_INFLIGHT.store(0, Ordering::SeqCst);
+        READ_SNAPSHOT_GENERATION_SCANS_MAX_INFLIGHT.store(0, Ordering::SeqCst);
+        READ_SNAPSHOT_TEST_DELAY_MILLIS.store(0, Ordering::Release);
+        reset_read_snapshot_pre_reconstruction_test_hook();
+        reset_read_snapshot_post_validation_test_hook();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn read_snapshot_cache_stats() -> (usize, bool, usize, usize, usize) {
+        use std::sync::atomic::Ordering;
+
+        let registry = READ_SNAPSHOT_REGISTRY
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut ready = 0;
+        let mut building = false;
+        for slot in &registry.slots {
+            let state = slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            ready += usize::from(state.ready.is_some());
+            building |= state.building.is_some();
+        }
+        (
+            ready,
+            building,
+            READ_SNAPSHOT_RECONSTRUCTION_COUNT.load(Ordering::SeqCst),
+            READ_SNAPSHOT_RECONSTRUCTIONS_INFLIGHT.load(Ordering::SeqCst),
+            READ_SNAPSHOT_RECONSTRUCTIONS_MAX_INFLIGHT.load(Ordering::SeqCst),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn read_snapshot_generation_scan_stats() -> (usize, usize, usize) {
+        use std::sync::atomic::Ordering;
+
+        (
+            READ_SNAPSHOT_GENERATION_SCAN_COUNT.load(Ordering::SeqCst),
+            READ_SNAPSHOT_GENERATION_SCANS_INFLIGHT.load(Ordering::SeqCst),
+            READ_SNAPSHOT_GENERATION_SCANS_MAX_INFLIGHT.load(Ordering::SeqCst),
+        )
+    }
+
+    #[cfg(test)]
+    fn expire_read_snapshot_validation() {
+        let registry = READ_SNAPSHOT_REGISTRY
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let expired_at = Instant::now() - read_snapshot_validation_ttl();
+        for slot in &registry.slots {
+            if let Some(entry) = slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .ready
+                .as_mut()
+            {
+                entry.validated_at = expired_at;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn expire_read_snapshot_exact_audit() {
+        let registry = READ_SNAPSHOT_REGISTRY
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let expired_at = Instant::now() - read_snapshot_exact_audit_interval();
+        for slot in &registry.slots {
+            if let Some(entry) = slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .ready
+                .as_mut()
+            {
+                entry.validated_at = Instant::now() - read_snapshot_validation_ttl();
+                entry.strong_validated_at = expired_at;
+            }
+        }
     }
 
     fn query_read_db_inventory(
@@ -933,8 +2934,9 @@ pub mod tool_util {
         })
     }
 
-    fn read_archive_inventory_has_state(storage_root: &Path) -> bool {
-        let archive = read_archive_inventory(storage_root);
+    fn read_archive_inventory_has_state(
+        archive: &mcp_agent_mail_db::ArchiveMessageInventory,
+    ) -> bool {
         archive.projects > 0 || archive.agents > 0 || archive.unique_message_ids > 0
     }
 
@@ -950,12 +2952,12 @@ pub mod tool_util {
         storage_root: &Path,
         sqlite_path: &Path,
         conn: &mcp_agent_mail_db::DbConn,
+        archive: &mcp_agent_mail_db::ArchiveMessageInventory,
     ) -> Result<bool, String> {
         if !archive_storage_root_is_authoritative_for_sqlite_path(storage_root, sqlite_path) {
             return Ok(false);
         }
 
-        let archive = read_archive_inventory(storage_root);
         if archive.projects == 0 && archive.agents == 0 && archive.unique_message_ids == 0 {
             return Ok(false);
         }
@@ -964,7 +2966,7 @@ pub mod tool_util {
         let archive_message_count = archive.unique_message_ids;
         let archive_max_id = archive.latest_message_id.unwrap_or(0);
         let missing_archive_projects = mcp_agent_mail_db::archive_missing_project_identities(
-            &archive,
+            archive,
             &db_inventory.project_identities,
         );
 
@@ -988,14 +2990,21 @@ pub mod tool_util {
 
     pub struct ToolReadPool {
         pool: mcp_agent_mail_db::DbPool,
-        _snapshot_dir: Option<mcp_agent_mail_db::pool::CanonicalSnapshotTempDir>,
+        _snapshot: Option<Arc<SharedArchiveReadSnapshot>>,
     }
 
     impl ToolReadPool {
         const fn live(pool: mcp_agent_mail_db::DbPool) -> Self {
             Self {
                 pool,
-                _snapshot_dir: None,
+                _snapshot: None,
+            }
+        }
+
+        fn snapshot(snapshot: Arc<SharedArchiveReadSnapshot>) -> Self {
+            Self {
+                pool: snapshot.pool(),
+                _snapshot: Some(snapshot),
             }
         }
     }
@@ -1050,7 +3059,12 @@ pub mod tool_util {
         }
     }
 
-    fn open_read_db_pool() -> Result<Option<ToolReadPool>, String> {
+    async fn open_read_db_pool_with_cx(
+        cx: &asupersync::Cx,
+    ) -> Result<Option<ToolReadPool>, ReadSnapshotAcquireError> {
+        if read_snapshot_cancelled(Some(cx)) {
+            return Err(ReadSnapshotAcquireError::Cancelled);
+        }
         let config = Config::from_env();
         if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&config.database_url) {
             return Ok(None);
@@ -1058,99 +3072,53 @@ pub mod tool_util {
 
         let sqlite_path =
             mcp_agent_mail_db::pool::resolve_mailbox_sqlite_path(&config.database_url)
-                .map_err(|err| err.to_string())?
+                .map_err(ReadSnapshotAcquireError::failed)?
                 .canonical_path;
         if sqlite_path == ":memory:" {
             return Ok(None);
         }
 
         let resolved_path = PathBuf::from(&sqlite_path);
-        let archive_has_state = archive_storage_root_is_authoritative_for_sqlite_path(
+        if !archive_storage_root_is_authoritative_for_sqlite_path(
             &config.storage_root,
             &resolved_path,
-        ) && read_archive_inventory_has_state(&config.storage_root);
-
-        // When the durability verdict says the live DB is suspect or worse,
-        // force archive-snapshot reads even if the archive isn't strictly
-        // "ahead" of the DB by row count.
-        let durability_forces_snapshot = archive_has_state
-            && live_db_is_suspect(&config.database_url, &config.storage_root, &resolved_path);
-
-        let use_archive_snapshot = if durability_forces_snapshot {
-            true
-        } else {
-            match mcp_agent_mail_db::DbConn::open_file(&sqlite_path) {
-                Ok(conn) => {
-                    let conn = mcp_agent_mail_db::guard_db_conn(
-                        conn,
-                        "tool_util::open_read_db_pool archive-ahead probe",
-                    );
-                    let archive_ahead =
-                        read_archive_is_ahead(&config.storage_root, &resolved_path, &conn);
-                    drop(conn);
-                    match archive_ahead {
-                        Ok(true) => true,
-                        Err(error) if archive_has_state => {
-                            tracing::warn!(
-                                source = %resolved_path.display(),
-                                storage_root = %config.storage_root.display(),
-                                error = %error,
-                                "using archive-backed tool snapshot because the live sqlite inventory probe failed"
-                            );
-                            true
-                        }
-                        Ok(false) | Err(_) => false,
-                    }
-                }
-                Err(error) if archive_has_state => {
-                    tracing::warn!(
-                        source = %resolved_path.display(),
-                        storage_root = %config.storage_root.display(),
-                        error = %error,
-                        "using archive-backed tool snapshot because the live sqlite source could not be opened"
-                    );
-                    true
-                }
-                Err(_) => false,
-            }
-        };
-
-        if !use_archive_snapshot {
+        ) {
             return Ok(None);
         }
 
-        let snapshot_dir =
-            mcp_agent_mail_db::pool::CanonicalSnapshotTempDir::new("agent-mail-tool-snapshot-")
-                .map_err(|err| err.to_string())?;
-        let snapshot_db = snapshot_dir.path().join("mailbox.sqlite3");
-        if resolved_path.exists() {
-            mcp_agent_mail_db::reconstruct_from_archive_with_salvage(
-                &snapshot_db,
-                &config.storage_root,
-                Some(resolved_path.as_path()),
-            )
-            .map_err(|err| err.to_string())?;
-        } else {
-            mcp_agent_mail_db::reconstruct_from_archive(&snapshot_db, &config.storage_root)
-                .map_err(|err| err.to_string())?;
-        }
-        let pool = create_pool(&mcp_agent_mail_db::DbPoolConfig {
-            database_url: mcp_agent_mail_core::disk::sqlite_url_from_path(&snapshot_db),
-            storage_root: Some(config.storage_root),
-            ..Default::default()
-        })
-        .map_err(|err| err.to_string())?;
-        Ok(Some(ToolReadPool {
-            pool,
-            _snapshot_dir: Some(snapshot_dir),
-        }))
+        get_archive_read_snapshot_if(
+            &config.storage_root,
+            &resolved_path,
+            &config.database_url,
+            cx,
+        )
+        .await
+        .map(|snapshot| snapshot.map(ToolReadPool::snapshot))
     }
 
-    pub fn get_read_db_pool() -> McpResult<ToolReadPool> {
-        match open_read_db_pool() {
+    #[cfg(test)]
+    async fn open_read_db_pool() -> Result<Option<ToolReadPool>, ReadSnapshotAcquireError> {
+        open_read_db_pool_with_cx(&asupersync::Cx::for_testing()).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn open_tool_read_snapshot_pointer(
+        cx: &asupersync::Cx,
+    ) -> Result<Option<usize>, ReadSnapshotAcquireError> {
+        open_read_db_pool_with_cx(cx).await.map(|pool| {
+            pool.and_then(|pool| {
+                pool._snapshot
+                    .as_ref()
+                    .map(|snapshot| Arc::as_ptr(snapshot) as usize)
+            })
+        })
+    }
+
+    pub async fn get_read_db_pool(cx: &asupersync::Cx) -> McpResult<ToolReadPool> {
+        match open_read_db_pool_with_cx(cx).await {
             Ok(Some(pool)) => Ok(pool),
-            Ok(None) => get_db_pool().map(ToolReadPool::live),
-            Err(error) => Err(read_pool_setup_error_to_mcp_error(error)),
+            Ok(None) => get_live_db_pool().map(ToolReadPool::live),
+            Err(error) => Err(read_snapshot_acquire_error_to_mcp_error(error)),
         }
     }
 
@@ -1278,13 +3246,10 @@ pub mod tool_util {
             }
         }
 
-        // Check read cache first (slug lookups only; ensure_project always hits DB)
+        // Project lookup caching is owned by the query layer so the cache key is
+        // scoped to this pool's SQLite identity.  A process can serve live and
+        // reconstructed snapshot databases with the same project slug.
         let is_absolute = std::path::Path::new(raw_identifier).is_absolute();
-        if !is_absolute
-            && let Some(cached) = mcp_agent_mail_db::read_cache().get_project(raw_identifier)
-        {
-            return Ok(cached);
-        }
         let out = if is_absolute {
             mcp_agent_mail_db::queries::ensure_project(ctx.cx(), pool, raw_identifier).await
         } else {
@@ -1292,11 +3257,7 @@ pub mod tool_util {
         };
 
         match db_outcome_to_mcp_result(out) {
-            Ok(project) => {
-                // Populate cache on miss
-                mcp_agent_mail_db::read_cache().put_project(&project);
-                Ok(project)
-            }
+            Ok(project) => Ok(project),
             Err(e) => {
                 // Only enhance NOT_FOUND errors with fuzzy suggestions
                 let is_not_found = e
@@ -1584,9 +3545,39 @@ pub mod tool_util {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use std::sync::{Mutex, OnceLock};
+        use std::sync::Mutex;
 
-        static READ_POOL_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        fn run_async<F: std::future::Future>(future: F) -> F::Output {
+            let runtime = asupersync::runtime::RuntimeBuilder::current_thread()
+                .build()
+                .expect("build test runtime");
+            runtime.block_on(future)
+        }
+
+        fn wait_for_snapshot_pointer_change(
+            storage_root: &Path,
+            sqlite_path: &Path,
+            old_pointer: usize,
+        ) -> Arc<SharedArchiveReadSnapshot> {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                let cx = asupersync::Cx::for_testing();
+                let snapshot = run_async(get_or_build_archive_read_snapshot(
+                    storage_root,
+                    sqlite_path,
+                    &cx,
+                ))
+                .expect("refreshed archive snapshot");
+                if Arc::as_ptr(&snapshot) as usize != old_pointer {
+                    return snapshot;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "background snapshot refresh did not publish a replacement"
+                );
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
 
         #[test]
         fn process_env_overrides_bypass_stale_dependency_config_cache() {
@@ -1607,6 +3598,187 @@ pub mod tool_util {
             );
 
             Config::reset_cached();
+        }
+
+        #[test]
+        fn resolve_project_scopes_cache_to_each_database_generation() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let live_path = temp.path().join("live.sqlite3");
+            let snapshot_path = temp.path().join("snapshot.sqlite3");
+            for (path, id, human_key) in [
+                (&live_path, 17_i64, "/live-generation"),
+                (&snapshot_path, 42_i64, "/snapshot-generation"),
+            ] {
+                let conn = mcp_agent_mail_db::DbConn::open_file(path.to_string_lossy().as_ref())
+                    .expect("open split-brain fixture");
+                conn.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                    .expect("initialize split-brain fixture");
+                conn.query_sync(
+                    "INSERT INTO projects (id, slug, human_key, created_at) VALUES (?, 'same-project', ?, 0)",
+                    &[
+                        mcp_agent_mail_db::sqlmodel::Value::BigInt(id),
+                        mcp_agent_mail_db::sqlmodel::Value::Text(human_key.to_string()),
+                    ],
+                )
+                .expect("seed split-brain project");
+            }
+            let make_pool = |path: &Path| {
+                mcp_agent_mail_db::create_query_only_pool(&mcp_agent_mail_db::DbPoolConfig {
+                    database_url: mcp_agent_mail_core::disk::sqlite_url_from_path(path),
+                    storage_root: Some(temp.path().join("archive")),
+                    min_connections: 0,
+                    max_connections: 1,
+                    run_migrations: false,
+                    warmup_connections: 0,
+                    ..Default::default()
+                })
+                .expect("create split-brain query pool")
+            };
+            let live_pool = make_pool(&live_path);
+            let snapshot_pool = make_pool(&snapshot_path);
+            let cx = asupersync::Cx::for_testing();
+            let ctx = McpContext::new(cx, 1);
+
+            let (live, snapshot, live_again) = run_async(async {
+                let live = resolve_project(&ctx, &live_pool, "same-project")
+                    .await
+                    .expect("resolve live generation");
+                let snapshot = resolve_project(&ctx, &snapshot_pool, "same-project")
+                    .await
+                    .expect("resolve snapshot generation");
+                let live_again = resolve_project(&ctx, &live_pool, "same-project")
+                    .await
+                    .expect("resolve live generation again");
+                (live, snapshot, live_again)
+            });
+
+            assert_eq!(
+                (live.id, live.human_key.as_str()),
+                (Some(17), "/live-generation")
+            );
+            assert_eq!(
+                (snapshot.id, snapshot.human_key.as_str()),
+                (Some(42), "/snapshot-generation")
+            );
+            assert_eq!(
+                (live_again.id, live_again.human_key.as_str()),
+                (Some(17), "/live-generation"),
+                "snapshot cache population must not replace the live pool identity"
+            );
+        }
+
+        #[test]
+        fn snapshot_probes_are_read_only_from_the_first_open() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let absent = temp.path().join("absent.sqlite3");
+            assert!(
+                open_read_only_snapshot_probe(&absent, "absent probe").is_err(),
+                "absent probe must fail closed"
+            );
+            assert!(!absent.exists(), "absent probe must not create a database");
+
+            let valid = temp.path().join("valid.sqlite3");
+            let seed = mcp_agent_mail_db::DbConn::open_file(valid.to_string_lossy().as_ref())
+                .expect("open valid probe fixture");
+            seed.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                .expect("initialize valid probe fixture");
+            drop(seed);
+            let probe = open_read_only_snapshot_probe(&valid, "valid probe")
+                .expect("open valid probe read-only");
+            let query_only = probe
+                .query_sync("PRAGMA query_only", &[])
+                .expect("read query-only pragma")[0]
+                .get_as::<i64>(0)
+                .expect("decode query-only pragma");
+            assert_eq!(query_only, 1);
+            assert!(
+                probe
+                    .query_sync(
+                        "INSERT INTO projects (slug, human_key, created_at) VALUES ('forbidden', '/forbidden', 0)",
+                        &[],
+                    )
+                    .is_err(),
+                "snapshot probe must reject writes"
+            );
+            drop(probe);
+
+            let raced = temp.path().join("raced-away.sqlite3");
+            let seed = mcp_agent_mail_db::DbConn::open_file(raced.to_string_lossy().as_ref())
+                .expect("open raced probe fixture");
+            seed.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                .expect("initialize raced probe fixture");
+            drop(seed);
+            assert!(raced.is_file(), "race fixture must exist before unlink");
+            std::fs::remove_file(&raced).expect("unlink race fixture");
+            assert!(
+                open_read_only_snapshot_probe(&raced, "raced probe").is_err(),
+                "probe must fail if the source vanishes before its first open"
+            );
+            assert!(!raced.exists(), "raced probe must not recreate the source");
+        }
+
+        #[test]
+        fn file_read_fallback_is_query_only_and_never_bootstraps() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            std::fs::create_dir_all(&storage_root).expect("create read fallback archive");
+            let db_path = temp.path().join("read-fallback.sqlite3");
+            let database_url = mcp_agent_mail_core::disk::sqlite_url_from_path(&db_path);
+            let storage_root_text = storage_root.display().to_string();
+            mcp_agent_mail_core::config::with_process_env_overrides_for_test(
+                &[
+                    ("DATABASE_URL", database_url.as_str()),
+                    ("STORAGE_ROOT", storage_root_text.as_str()),
+                ],
+                || {
+                    Config::reset_cached();
+                    let pool = get_live_db_pool().expect("construct absent read fallback");
+                    let cx = asupersync::Cx::for_testing();
+                    assert!(
+                        !matches!(run_async(pool.acquire(&cx)), Outcome::Ok(_)),
+                        "absent file read fallback must fail closed"
+                    );
+                    Config::reset_cached();
+                },
+            );
+            assert!(
+                !db_path.exists(),
+                "read fallback must not create the live DB"
+            );
+
+            let seed = mcp_agent_mail_db::DbConn::open_file(db_path.to_string_lossy().as_ref())
+                .expect("open read fallback fixture");
+            seed.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                .expect("initialize read fallback fixture");
+            drop(seed);
+            mcp_agent_mail_core::config::with_process_env_overrides_for_test(
+                &[
+                    ("DATABASE_URL", database_url.as_str()),
+                    ("STORAGE_ROOT", storage_root_text.as_str()),
+                ],
+                || {
+                    Config::reset_cached();
+                    let pool = get_live_db_pool().expect("construct valid read fallback");
+                    let cx = asupersync::Cx::for_testing();
+                    let conn = match run_async(pool.acquire(&cx)) {
+                        Outcome::Ok(conn) => conn,
+                        Outcome::Err(err) => panic!("valid read fallback acquire failed: {err}"),
+                        Outcome::Cancelled(_) => panic!("valid read fallback acquire cancelled"),
+                        Outcome::Panicked(panic) => {
+                            panic!("valid read fallback acquire panicked: {}", panic.message())
+                        }
+                    };
+                    assert!(
+                        conn.query_sync(
+                            "INSERT INTO projects (slug, human_key, created_at) VALUES ('forbidden', '/forbidden', 0)",
+                            &[],
+                        )
+                        .is_err(),
+                        "file read fallback must reject writes"
+                    );
+                    Config::reset_cached();
+                },
+            );
         }
 
         fn write_inventory_message(storage_root: &Path, file_id: i64, message_id: i64) {
@@ -1663,9 +3835,493 @@ body
         }
 
         #[test]
+        fn snapshot_completeness_rejects_reconstruction_traversal_loss() {
+            let inventory = mcp_agent_mail_db::ArchiveMessageInventory {
+                projects: 1,
+                agents: 1,
+                canonical_message_files: 1,
+                ..mcp_agent_mail_db::ArchiveMessageInventory::default()
+            };
+            let mut stats = mcp_agent_mail_db::ReconstructStats::default();
+            stats.projects = 1;
+
+            let error = validate_read_snapshot_completeness(&inventory, &stats)
+                .expect_err("a best-effort reconstruction traversal loss must fail publication");
+            assert!(
+                matches!(
+                    error,
+                    ReadSnapshotAcquireError::Failed(ref detail)
+                        if detail.contains("reconstruction was incomplete")
+                            && detail.contains("inventory projects=1 agents=1 canonical_message_files=1")
+                            && detail.contains("reconstructed projects=1 agents=0 messages=0")
+                ),
+                "unexpected reconstruction completeness error: {error:?}"
+            );
+        }
+
+        #[test]
+        fn snapshot_completeness_counts_duplicate_files_but_not_salvage_rows() {
+            let inventory = mcp_agent_mail_db::ArchiveMessageInventory {
+                projects: 1,
+                agents: 1,
+                canonical_message_files: 2,
+                ..mcp_agent_mail_db::ArchiveMessageInventory::default()
+            };
+            let mut stats = mcp_agent_mail_db::ReconstructStats::default();
+            stats.projects = 1;
+            stats.agents = 1;
+            stats.messages = 1;
+            stats.duplicate_canonical_message_files = 1;
+            stats.salvaged_projects = 9;
+            stats.salvaged_agents = 9;
+            stats.salvaged_messages = 9;
+
+            validate_read_snapshot_completeness(&inventory, &stats).expect(
+                "archive completeness is reconstructed messages plus duplicate canonical files; salvage is separate",
+            );
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn hostile_reconstruction_traversal_never_publishes_ready_snapshot() {
+            use std::os::unix::fs::PermissionsExt;
+
+            struct PermissionRestore {
+                path: PathBuf,
+                permissions: std::fs::Permissions,
+            }
+
+            impl Drop for PermissionRestore {
+                fn drop(&mut self) {
+                    let _ = std::fs::set_permissions(&self.path, self.permissions.clone());
+                }
+            }
+
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+            reset_read_archive_inventory_cache();
+
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            let repo = git2::Repository::init(&storage_root).expect("init archive repo");
+            let project_dir = storage_root.join("projects").join("stable-project");
+            let agents_dir = project_dir.join("agents");
+            let agent_dir = agents_dir.join("StableAgent");
+            std::fs::create_dir_all(&agent_dir).expect("create stable agent directory");
+            std::fs::write(
+                project_dir.join("project.json"),
+                r#"{"slug":"stable-project","human_key":"/stable-project"}"#,
+            )
+            .expect("write stable project metadata");
+            std::fs::write(agent_dir.join("profile.json"), "{}").expect("write stable profile");
+            commit_archive_tree(&repo, "commit stable traversal fixture");
+
+            let permission_restore = PermissionRestore {
+                path: agents_dir.clone(),
+                permissions: std::fs::metadata(&agents_dir)
+                    .expect("inspect agent directory permissions")
+                    .permissions(),
+            };
+            set_read_snapshot_pre_reconstruction_test_hook({
+                let agents_dir = agents_dir.clone();
+                move || {
+                    std::fs::set_permissions(&agents_dir, std::fs::Permissions::from_mode(0))
+                        .expect("make reconstruction traversal hostile");
+                }
+            });
+
+            let sqlite_path = temp.path().join("missing-live.sqlite3");
+            let cx = asupersync::Cx::for_testing();
+            let error = match run_async(get_or_build_archive_read_snapshot(
+                &storage_root,
+                &sqlite_path,
+                &cx,
+            )) {
+                Err(error) => error,
+                Ok(_) => panic!("a reconstruction traversal loss must fail the snapshot build"),
+            };
+            assert!(
+                matches!(
+                    error,
+                    ReadSnapshotAcquireError::Failed(ref detail)
+                        if detail.contains("reconstruction was incomplete")
+                            && detail.contains("inventory projects=1 agents=1")
+                            && detail.contains("reconstructed projects=1 agents=0")
+                ),
+                "unexpected hostile reconstruction error: {error:?}"
+            );
+            let (ready, building, reconstructions, inflight, _) = read_snapshot_cache_stats();
+            assert_eq!(ready, 0, "traversal loss must not publish ready state");
+            assert!(!building, "failed traversal must release its build slot");
+            assert_eq!(reconstructions, 1);
+            assert_eq!(inflight, 0);
+
+            drop(permission_restore);
+            reset_read_snapshot_cache();
+            reset_read_archive_inventory_cache();
+        }
+
+        #[test]
+        fn malformed_stable_agent_profile_never_publishes_ready_snapshot() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+            reset_read_archive_inventory_cache();
+
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            let repo = git2::Repository::init(&storage_root).expect("init archive repo");
+            let project_dir = storage_root.join("projects").join("stable-project");
+            let agent_dir = project_dir.join("agents").join("BrokenAgent");
+            std::fs::create_dir_all(&agent_dir).expect("create malformed agent directory");
+            std::fs::write(
+                project_dir.join("project.json"),
+                r#"{"slug":"stable-project","human_key":"/stable-project"}"#,
+            )
+            .expect("write stable project metadata");
+            std::fs::write(agent_dir.join("profile.json"), "{not-json")
+                .expect("write malformed stable profile");
+            commit_archive_tree(&repo, "commit malformed stable agent profile");
+
+            let sqlite_path = temp.path().join("missing-live.sqlite3");
+            let cx = asupersync::Cx::for_testing();
+            let error = match run_async(get_or_build_archive_read_snapshot(
+                &storage_root,
+                &sqlite_path,
+                &cx,
+            )) {
+                Err(error) => error,
+                Ok(_) => panic!("malformed stable profile must fail the cold snapshot build"),
+            };
+            assert!(
+                matches!(
+                    error,
+                    ReadSnapshotAcquireError::Failed(ref detail)
+                        if detail.contains("reconstruction skipped 1 malformed or unreadable archive artifact")
+                ),
+                "unexpected malformed-profile snapshot error: {error:?}"
+            );
+            let (ready, building, reconstructions, inflight, _) = read_snapshot_cache_stats();
+            assert_eq!(
+                ready, 0,
+                "a failed reconstruction must not publish ready state"
+            );
+            assert!(
+                !building,
+                "failed reconstruction must release its build slot"
+            );
+            assert_eq!(reconstructions, 1);
+            assert_eq!(inflight, 0);
+
+            reset_read_snapshot_cache();
+            reset_read_archive_inventory_cache();
+        }
+
+        #[derive(Debug, Clone, Copy)]
+        enum ArchivePublicationRaceMutation {
+            ProjectMetadata,
+            AgentProfile,
+            RawAttachment,
+            NotificationSignal,
+            AsyncCommit,
+            ColdPoolBootstrap,
+        }
+
+        impl ArchivePublicationRaceMutation {
+            fn label(self) -> &'static str {
+                match self {
+                    Self::ProjectMetadata => "project metadata",
+                    Self::AgentProfile => "agent profile",
+                    Self::RawAttachment => "raw attachment",
+                    Self::NotificationSignal => "notification signal",
+                    Self::AsyncCommit => "async commit",
+                    Self::ColdPoolBootstrap => "cold live-pool bootstrap",
+                }
+            }
+        }
+
+        struct PostValidationHookReleaseGuard {
+            active: bool,
+        }
+
+        impl PostValidationHookReleaseGuard {
+            fn new() -> Self {
+                Self { active: true }
+            }
+
+            fn release(&mut self) {
+                if self.active {
+                    release_read_snapshot_post_validation_test_hook();
+                    self.active = false;
+                }
+            }
+        }
+
+        impl Drop for PostValidationHookReleaseGuard {
+            fn drop(&mut self) {
+                self.release();
+            }
+        }
+
+        fn wait_for_read_snapshot_build_completion(label: &str) {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while read_snapshot_cache_stats().1 && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                !read_snapshot_cache_stats().1,
+                "{label} snapshot builder did not finish after the race hook was released"
+            );
+        }
+
+        fn run_archive_publication_race_case(mutation: ArchivePublicationRaceMutation) {
+            reset_read_snapshot_cache();
+            reset_read_archive_inventory_cache();
+            mcp_agent_mail_storage::flush_async_commits();
+
+            let temp = tempfile::tempdir().expect("race tempdir");
+            let storage_root = temp.path().join("archive");
+            let mut config = Config {
+                storage_root: storage_root.clone(),
+                ..Config::default()
+            };
+            config.notifications_enabled = true;
+            config.notifications_debounce_ms = 0;
+            config.notifications_signals_dir = temp.path().join("signals");
+
+            let archive = mcp_agent_mail_storage::ensure_archive(&config, "cache-project")
+                .expect("ensure race archive");
+            write_inventory_message(&storage_root, 1, 1);
+            let repo = git2::Repository::open(&storage_root).expect("open race archive repo");
+            commit_archive_tree(&repo, "seed publication race archive");
+
+            let async_path = archive.root.join("async-only.txt");
+            if matches!(mutation, ArchivePublicationRaceMutation::AsyncCommit) {
+                std::fs::write(&async_path, b"commit me after final validation\n")
+                    .expect("write async commit fixture");
+            }
+
+            let sqlite_path = temp.path().join("missing-live.sqlite3");
+            let cx = asupersync::Cx::for_testing();
+            let initial = run_async(get_or_build_archive_read_snapshot(
+                &storage_root,
+                &sqlite_path,
+                &cx,
+            ))
+            .expect("initial race snapshot");
+            let initial_pointer = Arc::as_ptr(&initial) as usize;
+
+            expire_read_snapshot_exact_audit();
+            arm_read_snapshot_post_validation_test_hook();
+            let mut release_guard = PostValidationHookReleaseGuard::new();
+            let stale = run_async(get_or_build_archive_read_snapshot(
+                &storage_root,
+                &sqlite_path,
+                &cx,
+            ))
+            .expect("serve stale snapshot while exact audit runs");
+            assert_eq!(
+                Arc::as_ptr(&stale) as usize,
+                initial_pointer,
+                "{} case must initially serve the existing snapshot",
+                mutation.label()
+            );
+            assert!(
+                wait_for_read_snapshot_post_validation_test_hook(Duration::from_secs(5)),
+                "{} exact audit did not pause after final validation",
+                mutation.label()
+            );
+            let build_completion = {
+                let scope =
+                    read_snapshot_scope(&storage_root, &sqlite_path).expect("paused race scope");
+                let slot = read_snapshot_slot(scope).expect("paused race slot");
+                let state = slot
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                Arc::clone(
+                    &state
+                        .building
+                        .as_ref()
+                        .expect("paused exact audit must retain its build")
+                        .completion,
+                )
+            };
+
+            let archive_epoch_before = mcp_agent_mail_storage::archive_application_epoch();
+            let db_epoch_before =
+                READ_SNAPSHOT_DB_WRITE_EPOCH.load(std::sync::atomic::Ordering::Acquire);
+            let mut cold_pool = None;
+            match mutation {
+                ArchivePublicationRaceMutation::ProjectMetadata => {
+                    mcp_agent_mail_storage::write_project_metadata_with_config(
+                        &archive,
+                        &config,
+                        "/publication-race-metadata",
+                    )
+                    .expect("write project metadata during publication race");
+                }
+                ArchivePublicationRaceMutation::AgentProfile => {
+                    mcp_agent_mail_storage::write_agent_profile_with_config(
+                        &archive,
+                        &config,
+                        &json!({"name": "PublicationRaceAgent", "program": "test"}),
+                    )
+                    .expect("write agent profile during publication race");
+                }
+                ArchivePublicationRaceMutation::RawAttachment => {
+                    let source = temp.path().join("publication-race.bin");
+                    std::fs::write(&source, b"publication race attachment")
+                        .expect("write attachment source fixture");
+                    mcp_agent_mail_storage::store_raw_attachment(&archive, &source, 1024)
+                        .expect("store raw attachment during publication race");
+                }
+                ArchivePublicationRaceMutation::NotificationSignal => {
+                    assert_eq!(
+                        mcp_agent_mail_storage::emit_notification_signal(
+                            &config,
+                            "cache-project",
+                            "PublicationRaceAgent",
+                            None,
+                        ),
+                        mcp_agent_mail_storage::SignalEmitOutcome::Emitted,
+                        "emit signal during publication race"
+                    );
+                }
+                ArchivePublicationRaceMutation::AsyncCommit => {
+                    let head_before = repo
+                        .head()
+                        .expect("race HEAD before async commit")
+                        .target()
+                        .expect("race HEAD target before async commit");
+                    mcp_agent_mail_storage::enqueue_async_commit(
+                        &storage_root,
+                        &config,
+                        "test: async publication race",
+                        &["projects/cache-project/async-only.txt".to_string()],
+                    );
+                    mcp_agent_mail_storage::flush_async_commits();
+                    let head_after = repo
+                        .head()
+                        .expect("race HEAD after async commit")
+                        .target()
+                        .expect("race HEAD target after async commit");
+                    assert_ne!(
+                        head_before, head_after,
+                        "async coalescer must apply a real Git mutation during the pause"
+                    );
+                }
+                ArchivePublicationRaceMutation::ColdPoolBootstrap => {
+                    let database_url =
+                        mcp_agent_mail_core::disk::sqlite_url_from_path(&sqlite_path);
+                    let storage_root_text = storage_root.display().to_string();
+                    let pool = mcp_agent_mail_core::config::with_process_env_overrides_for_test(
+                        &[
+                            ("DATABASE_URL", database_url.as_str()),
+                            ("STORAGE_ROOT", storage_root_text.as_str()),
+                        ],
+                        || {
+                            Config::reset_cached();
+                            let pool = get_db_pool().expect("enter cold-pool writer epoch");
+                            let conn = match run_async(pool.acquire(&cx)) {
+                                Outcome::Ok(conn) => conn,
+                                Outcome::Err(err) => {
+                                    panic!("cold live-pool bootstrap failed: {err}")
+                                }
+                                Outcome::Cancelled(_) => {
+                                    panic!("cold live-pool bootstrap cancelled")
+                                }
+                                Outcome::Panicked(panic) => {
+                                    panic!("cold live-pool bootstrap panicked: {}", panic.message())
+                                }
+                            };
+                            drop(conn);
+                            Config::reset_cached();
+                            pool
+                        },
+                    );
+                    assert!(
+                        sqlite_path.is_file(),
+                        "cold pool must bootstrap the live DB"
+                    );
+                    cold_pool = Some(pool);
+                }
+            }
+            if matches!(mutation, ArchivePublicationRaceMutation::ColdPoolBootstrap) {
+                assert_ne!(
+                    db_epoch_before,
+                    READ_SNAPSHOT_DB_WRITE_EPOCH.load(std::sync::atomic::Ordering::Acquire),
+                    "cold bootstrap must enter the writer epoch before pool construction"
+                );
+            } else {
+                assert_ne!(
+                    archive_epoch_before,
+                    mcp_agent_mail_storage::archive_application_epoch(),
+                    "{} must cross the guarded archive mutation boundary",
+                    mutation.label()
+                );
+            }
+
+            release_guard.release();
+            wait_for_read_snapshot_build_completion(mutation.label());
+
+            let scope = read_snapshot_scope(&storage_root, &sqlite_path).expect("race scope");
+            let slot = read_snapshot_slot(scope).expect("race slot");
+            let state = slot
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let ready = state
+                .ready
+                .as_ref()
+                .and_then(|entry| entry.decision.immutable_snapshot())
+                .expect("existing snapshot remains ready after rejected publication");
+            assert_eq!(
+                Arc::as_ptr(&ready) as usize,
+                initial_pointer,
+                "{} mutation must prevent the validated candidate from replacing the ready snapshot",
+                mutation.label()
+            );
+            assert!(matches!(
+                build_completion.result(),
+                Some(Err(ReadSnapshotAcquireError::Busy(message)))
+                    if message.contains("superseded by a durable write")
+            ));
+            drop(state);
+            drop(ready);
+            drop(slot);
+            drop(cold_pool);
+
+            mcp_agent_mail_storage::flush_async_commits();
+            drop(stale);
+            drop(initial);
+            reset_read_snapshot_cache();
+            reset_read_archive_inventory_cache();
+        }
+
+        #[test]
+        fn post_validation_archive_mutations_reject_snapshot_publication() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for mutation in [
+                ArchivePublicationRaceMutation::ProjectMetadata,
+                ArchivePublicationRaceMutation::AgentProfile,
+                ArchivePublicationRaceMutation::RawAttachment,
+                ArchivePublicationRaceMutation::NotificationSignal,
+                ArchivePublicationRaceMutation::AsyncCommit,
+                ArchivePublicationRaceMutation::ColdPoolBootstrap,
+            ] {
+                run_archive_publication_race_case(mutation);
+            }
+        }
+
+        #[test]
         fn read_archive_inventory_cache_never_hides_uncommitted_archive_state() {
-            let _guard = READ_POOL_TEST_LOCK
-                .get_or_init(|| Mutex::new(()))
+            let _guard = READ_SNAPSHOT_TEST_LOCK
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             reset_read_archive_inventory_cache();
@@ -1724,8 +4380,7 @@ body
 
         #[test]
         fn read_archive_inventory_cache_is_bounded_and_scoped_by_canonical_root() {
-            let _guard = READ_POOL_TEST_LOCK
-                .get_or_init(|| Mutex::new(()))
+            let _guard = READ_SNAPSHOT_TEST_LOCK
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             reset_read_archive_inventory_cache();
@@ -1778,6 +4433,846 @@ body
             );
 
             reset_read_archive_inventory_cache();
+        }
+
+        #[test]
+        fn snapshot_registry_and_pending_queue_enforce_hard_admission_caps() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+
+            let held = (0..READ_SNAPSHOT_SCOPE_CAPACITY)
+                .map(|index| {
+                    read_snapshot_slot(ReadSnapshotScope {
+                        storage_root: PathBuf::from(format!("/held/archive-{index}")),
+                        sqlite_path: PathBuf::from(format!("/held/mailbox-{index}.sqlite3")),
+                    })
+                    .expect("admit slot below hard capacity")
+                })
+                .collect::<Vec<_>>();
+            assert!(matches!(
+                read_snapshot_slot(ReadSnapshotScope {
+                    storage_root: PathBuf::from("/held/archive-overflow"),
+                    sqlite_path: PathBuf::from("/held/mailbox-overflow.sqlite3"),
+                }),
+                Err(ReadSnapshotAcquireError::Busy(_))
+            ));
+            assert_eq!(
+                READ_SNAPSHOT_REGISTRY
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .slots
+                    .len(),
+                READ_SNAPSHOT_SCOPE_CAPACITY
+            );
+
+            let permits = (0..READ_SNAPSHOT_PENDING_BUILD_LIMIT)
+                .map(|_| ReadSnapshotBuildPermit::try_acquire().expect("pending permit"))
+                .collect::<Vec<_>>();
+            assert!(ReadSnapshotBuildPermit::try_acquire().is_none());
+            drop(permits);
+            drop(held);
+            reset_read_snapshot_cache();
+        }
+
+        #[test]
+        fn archive_read_snapshot_singleflight_is_bounded_and_invalidates_dirty_generation() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_archive_inventory_cache();
+            reset_read_snapshot_cache();
+
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            let repo = git2::Repository::init(&storage_root).expect("init archive repo");
+            write_inventory_message(&storage_root, 1, 1);
+            commit_archive_tree(&repo, "seed archive");
+            let sqlite_path = temp.path().join("missing-live.sqlite3");
+
+            let cancelled_cx = asupersync::Cx::for_testing();
+            cancelled_cx.set_cancel_requested(true);
+            let cancelled = match run_async(get_or_build_archive_read_snapshot(
+                &storage_root,
+                &sqlite_path,
+                &cancelled_cx,
+            )) {
+                Err(error) => error,
+                Ok(_) => panic!("a cancelled request must not start reconstruction"),
+            };
+            assert!(matches!(cancelled, ReadSnapshotAcquireError::Cancelled));
+            assert_eq!(
+                read_snapshot_cache_stats(),
+                (0, false, 0, 0, 0),
+                "cancelled admission must leave no builder or cached generation"
+            );
+            assert_eq!(read_snapshot_generation_scan_stats(), (0, 0, 0));
+
+            let worker_count = 12;
+            let barrier = Arc::new(std::sync::Barrier::new(worker_count));
+            let pointers = Arc::new(Mutex::new(Vec::new()));
+            std::thread::scope(|scope| {
+                for _ in 0..worker_count {
+                    let barrier = Arc::clone(&barrier);
+                    let pointers = Arc::clone(&pointers);
+                    let storage_root = storage_root.clone();
+                    let sqlite_path = sqlite_path.clone();
+                    scope.spawn(move || {
+                        barrier.wait();
+                        let cx = asupersync::Cx::for_testing();
+                        let snapshot = run_async(get_or_build_archive_read_snapshot(
+                            &storage_root,
+                            &sqlite_path,
+                            &cx,
+                        ))
+                        .expect("shared archive read snapshot");
+                        pointers
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .push(Arc::as_ptr(&snapshot) as usize);
+                    });
+                }
+            });
+
+            let pointers = pointers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert_eq!(pointers.len(), worker_count);
+            assert!(
+                pointers.windows(2).all(|pair| pair[0] == pair[1]),
+                "all concurrent readers must receive the same immutable snapshot"
+            );
+            let original_pointer = pointers[0];
+            drop(pointers);
+
+            let (ready, building, reconstructions, inflight, max_inflight) =
+                read_snapshot_cache_stats();
+            assert_eq!(ready, 1);
+            assert!(!building);
+            assert_eq!(reconstructions, 1);
+            assert_eq!(inflight, 0);
+            assert_eq!(
+                max_inflight, 1,
+                "single-flight must never run more than one reconstruction task"
+            );
+            assert_eq!(
+                read_snapshot_generation_scan_stats(),
+                (2, 0, 1),
+                "N concurrent cold reads require only before/after generation scans"
+            );
+
+            expire_read_snapshot_validation();
+            let validation_barrier = Arc::new(std::sync::Barrier::new(worker_count));
+            let validation_pointers = Arc::new(Mutex::new(Vec::new()));
+            std::thread::scope(|scope| {
+                for _ in 0..worker_count {
+                    let barrier = Arc::clone(&validation_barrier);
+                    let pointers = Arc::clone(&validation_pointers);
+                    let storage_root = storage_root.clone();
+                    let sqlite_path = sqlite_path.clone();
+                    scope.spawn(move || {
+                        barrier.wait();
+                        let cx = asupersync::Cx::for_testing();
+                        let snapshot = run_async(get_or_build_archive_read_snapshot(
+                            &storage_root,
+                            &sqlite_path,
+                            &cx,
+                        ))
+                        .expect("coalesced snapshot validation");
+                        pointers
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .push(Arc::as_ptr(&snapshot) as usize);
+                    });
+                }
+            });
+            let validation_pointers = validation_pointers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert_eq!(validation_pointers.len(), worker_count);
+            assert!(
+                validation_pointers
+                    .iter()
+                    .all(|pointer| *pointer == original_pointer),
+                "a coalesced validation must reuse the exact immutable snapshot"
+            );
+            drop(validation_pointers);
+            let validation_deadline = Instant::now() + Duration::from_secs(5);
+            while read_snapshot_cache_stats().1 && Instant::now() < validation_deadline {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            assert!(
+                !read_snapshot_cache_stats().1,
+                "validation worker did not finish"
+            );
+            assert_eq!(
+                read_snapshot_generation_scan_stats(),
+                (2, 0, 1),
+                "routine cache validation must use the cheap metadata and epoch signature"
+            );
+            assert_eq!(read_snapshot_cache_stats().2, 1);
+
+            write_inventory_message(&storage_root, 2, 2);
+            expire_read_snapshot_exact_audit();
+            let replacement =
+                wait_for_snapshot_pointer_change(&storage_root, &sqlite_path, original_pointer);
+            let replacement_pointer = Arc::as_ptr(&replacement) as usize;
+            assert_ne!(
+                replacement_pointer, original_pointer,
+                "a dirty archive generation must not reuse the committed snapshot"
+            );
+            let cx = asupersync::Cx::for_testing();
+            let replacement_again = run_async(get_or_build_archive_read_snapshot(
+                &storage_root,
+                &sqlite_path,
+                &cx,
+            ))
+            .expect("reuse replacement snapshot");
+            assert_eq!(
+                Arc::as_ptr(&replacement_again) as usize,
+                replacement_pointer,
+                "the unchanged dirty generation should reuse its immutable snapshot"
+            );
+
+            write_inventory_message(&storage_root, 2, 3);
+            expire_read_snapshot_exact_audit();
+            let mutated =
+                wait_for_snapshot_pointer_change(&storage_root, &sqlite_path, replacement_pointer);
+            let mutated_pointer = Arc::as_ptr(&mutated) as usize;
+            assert_ne!(
+                mutated_pointer, replacement_pointer,
+                "an in-place dirty artifact mutation must invalidate the snapshot"
+            );
+            let mutated_again = run_async(get_or_build_archive_read_snapshot(
+                &storage_root,
+                &sqlite_path,
+                &cx,
+            ))
+            .expect("reuse in-place mutation snapshot");
+            assert_eq!(
+                Arc::as_ptr(&mutated_again) as usize,
+                mutated_pointer,
+                "an unchanged in-place mutation generation should be reused"
+            );
+            drop(mutated_again);
+            drop(mutated);
+            drop(replacement_again);
+            drop(replacement);
+
+            let (ready, building, reconstructions, inflight, max_inflight) =
+                read_snapshot_cache_stats();
+            assert_eq!(ready, 1, "only the latest mailbox generation is retained");
+            assert!(!building);
+            assert_eq!(
+                reconstructions, 3,
+                "new and mutated dirty archive content must invalidate prior generations"
+            );
+            assert_eq!(inflight, 0);
+            assert_eq!(max_inflight, 1);
+            assert_eq!(
+                read_snapshot_generation_scan_stats(),
+                (6, 0, 1),
+                "cheap validation adds no strong scan and both invalidations stay single-flight"
+            );
+
+            reset_read_snapshot_cache();
+            reset_read_archive_inventory_cache();
+        }
+
+        #[test]
+        fn real_tool_read_path_coalesces_inventory_generation_and_reconstruction() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_archive_inventory_cache();
+            reset_read_snapshot_cache();
+
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            git2::Repository::init(&storage_root).expect("init dirty archive repo");
+            write_inventory_message(&storage_root, 1, 1);
+            let db_path = temp.path().join("live.sqlite3");
+            let conn = mcp_agent_mail_db::DbConn::open_file(db_path.to_string_lossy().as_ref())
+                .expect("open live db");
+            conn.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                .expect("initialize live schema");
+            drop(conn);
+
+            let database_url = mcp_agent_mail_core::disk::sqlite_url_from_path(&db_path);
+            let storage_root_text = storage_root.to_string_lossy().into_owned();
+            mcp_agent_mail_core::config::with_process_env_overrides_for_test(
+                &[
+                    ("DATABASE_URL", database_url.as_str()),
+                    ("STORAGE_ROOT", storage_root_text.as_str()),
+                ],
+                || {
+                    Config::reset_cached();
+
+                    let cancelled_cx = asupersync::Cx::for_testing();
+                    cancelled_cx.set_cancel_requested(true);
+                    let cancelled = run_async(open_read_db_pool_with_cx(&cancelled_cx));
+                    assert!(matches!(
+                        cancelled,
+                        Err(ReadSnapshotAcquireError::Cancelled)
+                    ));
+                    assert_eq!(read_archive_inventory_scan_count(), 0);
+                    assert_eq!(read_snapshot_generation_scan_stats(), (0, 0, 0));
+                    assert_eq!(read_snapshot_cache_stats(), (0, false, 0, 0, 0));
+
+                    let worker_count = 12;
+                    let barrier = Arc::new(std::sync::Barrier::new(worker_count));
+                    let pointers = Arc::new(Mutex::new(Vec::new()));
+                    std::thread::scope(|scope| {
+                        for _ in 0..worker_count {
+                            let barrier = Arc::clone(&barrier);
+                            let pointers = Arc::clone(&pointers);
+                            scope.spawn(move || {
+                                let cx = asupersync::Cx::for_testing();
+                                barrier.wait();
+                                let pool = run_async(open_read_db_pool_with_cx(&cx))
+                                    .expect("real read path")
+                                    .expect("archive snapshot pool");
+                                let snapshot = pool
+                                    ._snapshot
+                                    .as_ref()
+                                    .expect("snapshot ownership must be retained");
+                                pointers
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                    .push(Arc::as_ptr(snapshot) as usize);
+                            });
+                        }
+                    });
+
+                    let pointers = pointers
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    assert_eq!(pointers.len(), worker_count);
+                    assert!(pointers.windows(2).all(|pair| pair[0] == pair[1]));
+                    assert_eq!(
+                        read_archive_inventory_scan_count(),
+                        1,
+                        "the real tool predicate must reuse one inventory for state and drift"
+                    );
+                    assert_eq!(read_snapshot_generation_scan_stats(), (2, 0, 1));
+                    assert_eq!(read_snapshot_cache_stats(), (1, false, 1, 0, 1));
+                },
+            );
+
+            reset_read_snapshot_cache();
+            reset_read_archive_inventory_cache();
+        }
+
+        #[test]
+        fn expired_live_decision_serves_stale_while_cheap_validation_runs() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            git2::Repository::init(&storage_root).expect("init empty archive");
+            let sqlite_path = temp.path().join("mailbox.sqlite3");
+            let conn = mcp_agent_mail_db::DbConn::open_file(sqlite_path.to_string_lossy().as_ref())
+                .expect("open live mailbox");
+            conn.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                .expect("initialize live mailbox");
+            drop(conn);
+            let cx = asupersync::Cx::for_testing();
+            let database_url = mcp_agent_mail_core::disk::sqlite_url_from_path(&sqlite_path);
+            assert!(
+                run_async(get_archive_read_snapshot_if(
+                    &storage_root,
+                    &sqlite_path,
+                    &database_url,
+                    &cx,
+                ))
+                .expect("initial live decision")
+                .is_none()
+            );
+
+            expire_read_snapshot_validation();
+            set_read_snapshot_test_delay(Duration::from_millis(400));
+            let started = Instant::now();
+            assert!(
+                run_async(get_archive_read_snapshot_if(
+                    &storage_root,
+                    &sqlite_path,
+                    &database_url,
+                    &cx,
+                ))
+                .expect("stale live decision")
+                .is_none()
+            );
+            assert!(
+                started.elapsed() < Duration::from_millis(200),
+                "expired Live decisions must not wait for background validation"
+            );
+            let deadline = Instant::now() + Duration::from_secs(3);
+            while read_snapshot_cache_stats().1 && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            set_read_snapshot_test_delay(Duration::ZERO);
+            assert!(!read_snapshot_cache_stats().1);
+            assert_eq!(read_snapshot_cache_stats().2, 0);
+            assert_eq!(read_snapshot_generation_scan_stats(), (2, 0, 1));
+            reset_read_snapshot_cache();
+        }
+
+        #[test]
+        fn archive_read_snapshot_waiter_uses_leader_deadline_without_starting_second_builder() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            let repo = git2::Repository::init(&storage_root).expect("init archive repo");
+            write_inventory_message(&storage_root, 1, 1);
+            commit_archive_tree(&repo, "seed archive");
+            let sqlite_path = temp.path().join("missing-live.sqlite3");
+            let scope = read_snapshot_scope(&storage_root, &sqlite_path).expect("snapshot scope");
+
+            let slot = read_snapshot_slot(scope).expect("snapshot slot");
+            let simulated_build = ReadSnapshotBuild {
+                token: 7,
+                invalidation_epoch: 0,
+                db_write_epoch: READ_SNAPSHOT_DB_WRITE_EPOCH
+                    .load(std::sync::atomic::Ordering::Acquire),
+                archive_application_epoch: mcp_agent_mail_storage::archive_application_epoch(),
+                deadline: Instant::now(),
+                completion: Arc::new(ReadSnapshotBuildCompletion::pending()),
+            };
+            slot.state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .building = Some(simulated_build.clone());
+
+            let cx = asupersync::Cx::for_testing();
+            let error = run_async(wait_for_read_snapshot_build(
+                &slot,
+                simulated_build.clone(),
+                &cx,
+                Instant::now(),
+            ))
+            .expect_err("expired leader deadline must time out");
+            assert!(matches!(
+                error,
+                ReadSnapshotAcquireError::TimedOut(ref message)
+                    if message.contains("cold bootstrap")
+            ));
+            assert_eq!(
+                read_snapshot_cache_stats(),
+                (0, true, 0, 0, 0),
+                "a timed-out waiter must not replace or clear the leader"
+            );
+            assert_eq!(
+                read_snapshot_generation_scan_stats(),
+                (0, 0, 0),
+                "a timed-out waiter must not start generation discovery"
+            );
+            slot.state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .building = None;
+            assert_eq!(read_snapshot_cache_stats(), (0, false, 0, 0, 0));
+            reset_read_snapshot_cache();
+        }
+
+        #[test]
+        fn archive_read_snapshot_waiter_retains_its_generation_completion() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            std::fs::create_dir_all(&storage_root).expect("create archive root");
+            let scope = read_snapshot_scope(&storage_root, &temp.path().join("live.sqlite3"))
+                .expect("snapshot scope");
+            let slot = read_snapshot_slot(scope).expect("snapshot slot");
+            let deadline = Instant::now() + Duration::from_secs(1);
+
+            let first = try_claim_read_snapshot_build(&slot, deadline)
+                .expect("claim first build")
+                .expect("first build");
+            {
+                let mut state = slot
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                state.building = None;
+                first
+                    .completion
+                    .complete(Err(ReadSnapshotAcquireError::Failed(
+                        "first generation failed".to_string(),
+                    )));
+            }
+
+            let second = try_claim_read_snapshot_build(&slot, deadline)
+                .expect("claim second build")
+                .expect("second build");
+            {
+                let mut state = slot
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                state.building = None;
+                second.completion.complete(Ok(()));
+            }
+
+            let third = try_claim_read_snapshot_build(&slot, deadline)
+                .expect("claim third build")
+                .expect("third build");
+            let cx = asupersync::Cx::for_testing();
+            let error = run_async(wait_for_read_snapshot_build(&slot, first, &cx, deadline))
+                .expect_err("first waiter must observe its own failed generation");
+            assert!(matches!(
+                error,
+                ReadSnapshotAcquireError::Failed(ref message)
+                    if message == "first generation failed"
+            ));
+            assert!(matches!(second.completion.result(), Some(Ok(()))));
+            assert_eq!(
+                slot.state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .building
+                    .as_ref()
+                    .map(|build| build.token),
+                Some(third.token),
+                "waiting on generation one must not follow or disturb generation three"
+            );
+            fail_scheduled_read_snapshot_build(&slot, &third, ReadSnapshotAcquireError::Cancelled);
+            reset_read_snapshot_cache();
+        }
+
+        #[test]
+        fn query_only_snapshot_pool_rejects_mutation_and_preserves_rows() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let sqlite_path = temp.path().join("immutable.sqlite3");
+            let conn = mcp_agent_mail_db::DbConn::open_file(sqlite_path.to_string_lossy().as_ref())
+                .expect("open snapshot fixture");
+            conn.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                .expect("initialize snapshot fixture");
+            drop(conn);
+
+            let pool =
+                mcp_agent_mail_db::create_query_only_pool(&mcp_agent_mail_db::DbPoolConfig {
+                    database_url: mcp_agent_mail_core::disk::sqlite_url_from_path(&sqlite_path),
+                    storage_root: Some(temp.path().to_path_buf()),
+                    ..Default::default()
+                })
+                .expect("query-only pool");
+            let cx = asupersync::Cx::for_testing();
+            let conn = match run_async(pool.acquire(&cx)) {
+                Outcome::Ok(conn) => conn,
+                Outcome::Err(err) => panic!("query-only pool acquire failed: {err}"),
+                Outcome::Cancelled(_) => panic!("query-only pool acquire cancelled"),
+                Outcome::Panicked(panic) => {
+                    panic!("query-only pool acquire panicked: {}", panic.message())
+                }
+            };
+            let mutation = conn.query_sync(
+                "INSERT INTO projects (slug, human_key, created_at) VALUES ('leak', '/leak', 0)",
+                &[],
+            );
+            assert!(
+                mutation.is_err(),
+                "shared snapshot connections must reject every DML statement"
+            );
+            let rows = conn
+                .query_sync("SELECT COUNT(*) AS project_count FROM projects", &[])
+                .expect("snapshot remains readable");
+            assert_eq!(
+                rows.first()
+                    .and_then(|row| row.get_named::<i64>("project_count").ok()),
+                Some(0),
+                "failed mutation must not leak into later reads of the shared pool"
+            );
+        }
+
+        #[test]
+        fn slow_cold_snapshot_build_does_not_block_current_thread_executor() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            let repo = git2::Repository::init(&storage_root).expect("init archive repo");
+            write_inventory_message(&storage_root, 1, 1);
+            commit_archive_tree(&repo, "seed archive");
+            let sqlite_path = temp.path().join("missing-live.sqlite3");
+            READ_SNAPSHOT_TEST_DELAY_MILLIS.store(250, std::sync::atomic::Ordering::Release);
+
+            let cx = asupersync::Cx::for_testing();
+            let started = Instant::now();
+            let _ = run_async(asupersync::time::timeout(
+                asupersync::time::wall_now(),
+                Duration::from_millis(25),
+                Box::pin(get_or_build_archive_read_snapshot(
+                    &storage_root,
+                    &sqlite_path,
+                    &cx,
+                )),
+            ));
+            assert!(
+                started.elapsed() < Duration::from_millis(150),
+                "a slow reconstruction must run on the blocking pool so the executor timer can fire"
+            );
+            assert!(
+                read_snapshot_cache_stats().1,
+                "the detached blocking worker should still own the cold build"
+            );
+
+            let wait_deadline = Instant::now() + Duration::from_secs(3);
+            while read_snapshot_cache_stats().1 && Instant::now() < wait_deadline {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            assert!(
+                !read_snapshot_cache_stats().1,
+                "blocking worker did not finish"
+            );
+            reset_read_snapshot_cache();
+        }
+
+        #[test]
+        fn live_generation_hashes_same_size_main_and_wal_content() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let sqlite_path = temp.path().join("mailbox.sqlite3");
+            let wal_path = mcp_agent_mail_db::pool::sqlite_path_with_suffix(&sqlite_path, "-wal");
+            std::fs::write(&sqlite_path, b"AAAA").expect("write main fixture");
+            std::fs::write(&wal_path, b"1111").expect("write wal fixture");
+            let first =
+                read_live_db_generation(&sqlite_path, &|| false).expect("first live generation");
+
+            std::fs::write(&sqlite_path, b"AAAA").expect("rewrite unchanged main fixture");
+            std::fs::write(&wal_path, b"1111").expect("rewrite unchanged wal fixture");
+            let metadata_only = read_live_db_generation(&sqlite_path, &|| false)
+                .expect("metadata-only live generation");
+            assert_eq!(
+                first, metadata_only,
+                "metadata-only rewrites must not change a content-addressed generation"
+            );
+
+            std::fs::write(&wal_path, b"2222").expect("same-size wal rewrite");
+            let wal_changed =
+                read_live_db_generation(&sqlite_path, &|| false).expect("wal-changed generation");
+            assert_ne!(first, wal_changed, "same-size WAL writes must invalidate");
+
+            std::fs::write(&sqlite_path, b"BBBB").expect("same-size main rewrite");
+            std::fs::remove_file(&wal_path).expect("checkpoint removes wal");
+            let checkpointed =
+                read_live_db_generation(&sqlite_path, &|| false).expect("checkpointed generation");
+            assert_ne!(
+                wal_changed, checkpointed,
+                "same-size main updates and WAL checkpoint transitions must invalidate"
+            );
+        }
+
+        #[test]
+        fn dropping_live_write_lease_immediately_invalidates_exact_scope() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            std::fs::create_dir_all(&storage_root).expect("create archive root");
+            let sqlite_path = temp.path().join("mailbox.sqlite3");
+            let conn = mcp_agent_mail_db::DbConn::open_file(sqlite_path.to_string_lossy().as_ref())
+                .expect("open live fixture");
+            conn.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                .expect("initialize live fixture");
+            drop(conn);
+            let scope = read_snapshot_scope(&storage_root, &sqlite_path).expect("snapshot scope");
+            let slot = read_snapshot_slot(scope).expect("snapshot slot");
+            assert_eq!(
+                slot.invalidation_epoch
+                    .load(std::sync::atomic::Ordering::Acquire),
+                0
+            );
+            let pool = mcp_agent_mail_db::create_pool_without_startup_init(
+                &mcp_agent_mail_db::DbPoolConfig {
+                    database_url: mcp_agent_mail_core::disk::sqlite_url_from_path(&sqlite_path),
+                    storage_root: Some(storage_root.clone()),
+                    ..Default::default()
+                },
+            )
+            .expect("live write pool");
+            let simulated_build =
+                try_claim_read_snapshot_build(&slot, Instant::now() + Duration::from_secs(1))
+                    .expect("claim build before writer")
+                    .expect("new scope build");
+            let write_pool = WriteDbPool {
+                pool,
+                _write_guard: ReadSnapshotWriteGuard::begin(
+                    &storage_root,
+                    Some(sqlite_path.as_path()),
+                ),
+            };
+            assert_eq!(
+                slot.invalidation_epoch
+                    .load(std::sync::atomic::Ordering::Acquire),
+                1,
+                "write lease admission must invalidate before the first mutation"
+            );
+            assert_eq!(
+                slot.state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .active_writers,
+                1
+            );
+            let nested_slot = begin_read_snapshot_write(&storage_root, &sqlite_path);
+            assert_eq!(
+                slot.state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .active_writers,
+                2,
+                "nested write leases must keep the scope admitted until the final exit"
+            );
+            end_read_snapshot_write(nested_slot.as_deref());
+            assert_eq!(
+                slot.state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .active_writers,
+                1,
+                "exiting one nested lease must not reopen snapshot admission"
+            );
+            let mut simulated_guard =
+                ReadSnapshotBuildGuard::new(Arc::clone(&slot), simulated_build.token);
+            simulated_guard.publish(
+                &simulated_build,
+                Ok(ReadSnapshotBuildOutput {
+                    key: ReadSnapshotKey {
+                        archive_digest: [0; 32],
+                        live_db_digest: [0; 32],
+                    },
+                    cheap_key: read_snapshot_cheap_key(&slot).expect("cheap key"),
+                    decision: ArchiveReadDecision::Live,
+                    strong_validated_at: Instant::now(),
+                }),
+            );
+            assert!(
+                slot.state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .ready
+                    .is_none(),
+                "a build claimed before writer admission must not publish during the write epoch"
+            );
+            assert!(matches!(
+                try_claim_read_snapshot_build(&slot, Instant::now() + Duration::from_secs(1)),
+                Err(ReadSnapshotAcquireError::Busy(_))
+            ));
+            let cx = asupersync::Cx::for_testing();
+            let conn = match run_async(write_pool.acquire(&cx)) {
+                Outcome::Ok(conn) => conn,
+                Outcome::Err(err) => panic!("live write pool acquire failed: {err}"),
+                Outcome::Cancelled(_) => panic!("live write pool acquire cancelled"),
+                Outcome::Panicked(panic) => {
+                    panic!("live write pool acquire panicked: {}", panic.message())
+                }
+            };
+            conn.query_sync(
+                "INSERT INTO projects (slug, human_key, created_at) VALUES ('written', '/written', 0)",
+                &[],
+            )
+            .expect("durable live write");
+            drop(conn);
+            drop(write_pool);
+            assert_eq!(
+                slot.invalidation_epoch
+                    .load(std::sync::atomic::Ordering::Acquire),
+                4,
+                "each nested writer entry and exit must advance the exact scope epoch"
+            );
+            reset_read_snapshot_cache();
+        }
+
+        #[test]
+        fn expired_snapshot_detects_checkpointed_same_length_live_write() {
+            let _guard = READ_SNAPSHOT_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            reset_read_snapshot_cache();
+            let temp = tempfile::tempdir().expect("tempdir");
+            let storage_root = temp.path().join("archive");
+            let repo = git2::Repository::init(&storage_root).expect("init archive repo");
+            write_inventory_message(&storage_root, 1, 1);
+            commit_archive_tree(&repo, "seed archive");
+            let sqlite_path = temp.path().join("mailbox.sqlite3");
+            mcp_agent_mail_db::reconstruct_from_archive(&sqlite_path, &storage_root)
+                .expect("seed live mailbox");
+
+            let cx = asupersync::Cx::for_testing();
+            let first = run_async(get_or_build_archive_read_snapshot(
+                &storage_root,
+                &sqlite_path,
+                &cx,
+            ))
+            .expect("initial snapshot");
+            let first_pointer = Arc::as_ptr(&first) as usize;
+            let live = mcp_agent_mail_db::DbConn::open_file(sqlite_path.to_string_lossy().as_ref())
+                .expect("open live mailbox");
+            live.query_sync("UPDATE messages SET subject = 'Mutate' WHERE id = 1", &[])
+                .expect("same-length live update");
+            drop(live);
+            mcp_agent_mail_db::pool::wal_checkpoint_truncate_path(&sqlite_path)
+                .expect("checkpoint same-length write");
+
+            expire_read_snapshot_exact_audit();
+            let refreshed =
+                wait_for_snapshot_pointer_change(&storage_root, &sqlite_path, first_pointer);
+            let refreshed_pool = refreshed.pool();
+            let refreshed_conn = match run_async(refreshed_pool.acquire(&cx)) {
+                Outcome::Ok(conn) => conn,
+                Outcome::Err(err) => panic!("refreshed snapshot acquire failed: {err}"),
+                Outcome::Cancelled(_) => panic!("refreshed snapshot acquire cancelled"),
+                Outcome::Panicked(panic) => {
+                    panic!("refreshed snapshot acquire panicked: {}", panic.message())
+                }
+            };
+            let subject = refreshed_conn
+                .query_sync("SELECT subject FROM messages WHERE id = 1", &[])
+                .expect("query refreshed snapshot")[0]
+                .get_named::<String>("subject")
+                .expect("refreshed subject");
+            assert_eq!(subject, "Mutate");
+            drop(refreshed_conn);
+            drop(refreshed_pool);
+            drop(refreshed);
+            drop(first);
+            reset_read_snapshot_cache();
+        }
+
+        #[test]
+        fn snapshot_acquisition_errors_have_exact_retry_envelopes() {
+            let busy = read_snapshot_acquire_error_to_mcp_error(ReadSnapshotAcquireError::Busy(
+                "snapshot worker unavailable".to_string(),
+            ));
+            let busy_data = busy.data.expect("busy envelope");
+            assert_eq!(busy_data["error"]["type"], "RESOURCE_BUSY");
+            assert_eq!(busy_data["error"]["recoverable"], true);
+
+            let timeout = read_snapshot_acquire_error_to_mcp_error(
+                ReadSnapshotAcquireError::TimedOut("cold bootstrap timed out".to_string()),
+            );
+            let timeout_data = timeout.data.expect("timeout envelope");
+            assert_eq!(timeout_data["error"]["type"], "SNAPSHOT_TIMEOUT");
+            assert_eq!(timeout_data["error"]["recoverable"], true);
+            assert_eq!(
+                timeout_data["error"]["data"]["timeout_seconds"],
+                READ_SNAPSHOT_BUILD_TIMEOUT.as_secs()
+            );
         }
 
         #[test]
@@ -1867,8 +5362,7 @@ body
 
         #[test]
         fn open_read_db_pool_ignores_unrelated_default_archive_overlap() {
-            let _guard = READ_POOL_TEST_LOCK
-                .get_or_init(|| Mutex::new(()))
+            let _guard = READ_SNAPSHOT_TEST_LOCK
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
 
@@ -1916,7 +5410,7 @@ body
                     .expect("insert overlapping project");
                     drop(conn);
 
-                    let pool = open_read_db_pool().expect("open read db pool");
+                    let pool = run_async(open_read_db_pool()).expect("open read db pool");
                     assert!(
                         pool.is_none(),
                         "default global archive should not force shared tool read snapshots for an external custom DB"
@@ -1936,8 +5430,7 @@ body
 
         #[test]
         fn db_error_to_mcp_error_corruption_mapping_is_pure_with_live_pool() {
-            let _guard = READ_POOL_TEST_LOCK
-                .get_or_init(|| Mutex::new(()))
+            let _guard = READ_SNAPSHOT_TEST_LOCK
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
 

--- a/crates/mcp-agent-mail-tools/src/messaging.rs
+++ b/crates/mcp-agent-mail-tools/src/messaging.rs
@@ -24,8 +24,8 @@ use serde_json::{Value, json};
 
 use crate::tool_util::{
     db_error_to_mcp_error, db_outcome_to_mcp_result, get_db_pool, get_read_db_pool,
-    legacy_tool_error, parse_attachment_metadata_json, parse_recipients_lists, resolve_agent,
-    resolve_project,
+    invalidate_read_snapshots_for_archive, legacy_tool_error, parse_attachment_metadata_json,
+    parse_recipients_lists, resolve_agent, resolve_project,
 };
 use mcp_agent_mail_core::pattern_overlap::CompiledPattern;
 
@@ -42,6 +42,15 @@ fn emit_tail_latency_evidence(ledger: &TailLatencyPhaseLedger) {
 }
 
 pub(crate) fn try_dispatch_archive_write(op: mcp_agent_mail_storage::WriteOp, context: &str) {
+    let storage_root = match &op {
+        mcp_agent_mail_storage::WriteOp::MessageBundle { config, .. }
+        | mcp_agent_mail_storage::WriteOp::AgentProfile { config, .. }
+        | mcp_agent_mail_storage::WriteOp::FileReservation { config, .. }
+        | mcp_agent_mail_storage::WriteOp::NotificationSignal { config, .. }
+        | mcp_agent_mail_storage::WriteOp::ClearSignal { config, .. } => {
+            config.storage_root.clone()
+        }
+    };
     match mcp_agent_mail_storage::wbq_enqueue(op.clone()) {
         mcp_agent_mail_storage::WbqEnqueueResult::Enqueued
         | mcp_agent_mail_storage::WbqEnqueueResult::SkippedDiskCritical => {
@@ -54,6 +63,7 @@ pub(crate) fn try_dispatch_archive_write(op: mcp_agent_mail_storage::WriteOp, co
             }
         }
     }
+    invalidate_read_snapshots_for_archive(&storage_root);
 }
 
 /// Write a message bundle to the git archive (best-effort).
@@ -3154,7 +3164,7 @@ pub async fn fetch_inbox(
 
     // Use archive-aware read pool so that inbox reads fall back to archive
     // snapshots when the live SQLite is suspect (DegradedReadOnly).
-    let read_pool = get_read_db_pool()?;
+    let read_pool = get_read_db_pool(ctx.cx()).await?;
     let project = resolve_project(ctx, &read_pool, &project_key).await?;
     let project_id = project.id.unwrap_or(0);
 
@@ -3345,23 +3355,21 @@ pub async fn fetch_inbox(
     // is degraded the write will fail gracefully (already best-effort).
     if !messages.is_empty() {
         let ids: Vec<i64> = messages.iter().map(|m| m.id).collect();
-        let write_path = get_db_pool()
-            .ok()
-            .map(|live_pool| live_pool.sqlite_path().to_string());
-        if let Some(ref live_sqlite_path) = write_path {
+        if let Ok(live_pool) = get_db_pool() {
+            let live_sqlite_path = live_pool.sqlite_path().to_string();
             match mcp_agent_mail_db::sync::mark_messages_read_batch_sync(
-                live_sqlite_path,
+                &live_sqlite_path,
                 agent_id,
                 &ids,
             ) {
                 Ok(Some(batch)) => {
                     apply_auto_read_timestamp(&mut messages, &batch.message_ids, batch.read_ts);
                     mcp_agent_mail_db::read_cache()
-                        .invalidate_inbox_stats_scoped(live_sqlite_path, agent_id);
+                        .invalidate_inbox_stats_scoped(&live_sqlite_path, agent_id);
                 }
                 Ok(None) => {
                     mcp_agent_mail_db::read_cache()
-                        .invalidate_inbox_stats_scoped(live_sqlite_path, agent_id);
+                        .invalidate_inbox_stats_scoped(&live_sqlite_path, agent_id);
                 }
                 Err(e) => {
                     tracing::warn!(

--- a/crates/mcp-agent-mail-tools/src/products.rs
+++ b/crates/mcp-agent-mail-tools/src/products.rs
@@ -560,7 +560,7 @@ pub async fn search_messages_product(
         return Err(worktrees_required());
     }
 
-    let pool = get_read_db_pool()?;
+    let pool = get_read_db_pool(ctx.cx()).await?;
     let product = get_product_by_key(ctx.cx(), &pool, product_key.trim())
         .await?
         .ok_or_else(|| {
@@ -744,7 +744,7 @@ pub async fn fetch_inbox_product(
         return Err(worktrees_required());
     }
 
-    let pool = get_read_db_pool()?;
+    let pool = get_read_db_pool(ctx.cx()).await?;
     let product = get_product_by_key(ctx.cx(), &pool, product_key.trim())
         .await?
         .ok_or_else(|| {
@@ -871,7 +871,7 @@ pub async fn summarize_thread_product(
         return Err(worktrees_required());
     }
 
-    let pool = get_read_db_pool()?;
+    let pool = get_read_db_pool(ctx.cx()).await?;
     let product = get_product_by_key(ctx.cx(), &pool, product_key.trim())
         .await?
         .ok_or_else(|| {

--- a/crates/mcp-agent-mail-tools/src/reservations.rs
+++ b/crates/mcp-agent-mail-tools/src/reservations.rs
@@ -32,8 +32,8 @@ use crate::resources::{
     reservation_project_workspace_path,
 };
 use crate::tool_util::{
-    db_error_to_mcp_error, db_outcome_to_mcp_result, get_db_pool, legacy_tool_error, resolve_agent,
-    resolve_project,
+    db_error_to_mcp_error, db_outcome_to_mcp_result, get_authoritative_live_db_pool, get_db_pool,
+    legacy_tool_error, resolve_agent, resolve_project,
 };
 
 const RELEASE_INTENT_SCHEMA_VERSION: u32 = 1;
@@ -280,7 +280,16 @@ fn validate_conflict_check_paths(paths: &[String]) -> McpResult<()> {
 /// artifact (wrong holder until TTL), so active ops are dropped and healed by
 /// reconcile-on-read instead (the same convergence path as the disk-critical
 /// skip).
-fn dispatch_reservation_archive_write(op: mcp_agent_mail_storage::WriteOp, context: &str) {
+pub(crate) fn dispatch_reservation_archive_write(
+    op: mcp_agent_mail_storage::WriteOp,
+    context: &str,
+) {
+    let storage_root = match &op {
+        mcp_agent_mail_storage::WriteOp::FileReservation { config, .. } => {
+            config.storage_root.clone()
+        }
+        _ => unreachable!("reservation archive dispatcher only accepts reservation writes"),
+    };
     // GH#178: the reservation JSON artifact (`id-<id>.json`) must be durable on
     // return because the pre-commit guard reads it directly; a stale artifact
     // yields the *wrong holder* (GH#112). The previous implementation enqueued
@@ -332,6 +341,7 @@ fn dispatch_reservation_archive_write(op: mcp_agent_mail_storage::WriteOp, conte
             }
         }
     }
+    crate::tool_util::invalidate_read_snapshots_for_archive(&storage_root);
 }
 
 /// Is every record in this archive op a TERMINAL release artifact (`released_ts`
@@ -1426,7 +1436,7 @@ pub async fn check_file_reservation_conflicts(
     let caller = mcp_agent_mail_core::models::normalize_agent_name(caller)
         .unwrap_or_else(|| caller.to_string());
 
-    let pool = get_db_pool()?;
+    let pool = get_authoritative_live_db_pool()?;
     let snapshot = acquire_outcome(
         mcp_agent_mail_db::queries::get_reservation_conflict_snapshot(
             ctx.cx(),
@@ -3282,6 +3292,7 @@ mod tests {
                         Outcome::Ok(rows) => rows,
                         other => panic!("before snapshot failed: {other:?}"),
                     };
+                let write_epoch_before = crate::tool_util::read_snapshot_db_write_epoch_for_test();
                 let ctx = McpContext::new(cx.clone(), 1);
                 let response: ReservationConflictCheckResponse = serde_json::from_str(
                     &check_file_reservation_conflicts(
@@ -3304,6 +3315,12 @@ mod tests {
                     .expect("conflict check"),
                 )
                 .expect("response json");
+
+                assert_eq!(
+                    crate::tool_util::read_snapshot_db_write_epoch_for_test(),
+                    write_epoch_before,
+                    "a cached authoritative conflict read must not enter or advance the writer epoch"
+                );
 
                 assert!(!response.conflict_free);
                 assert!(response.read_only);

--- a/crates/mcp-agent-mail-tools/src/resources.rs
+++ b/crates/mcp-agent-mail-tools/src/resources.rs
@@ -18,13 +18,16 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     tool_cluster,
     tool_util::{
-        db_error_to_mcp_error, db_outcome_to_mcp_result, get_db_pool,
+        SharedArchiveReadSnapshot, db_error_to_mcp_error, db_outcome_to_mcp_result,
+        get_archive_read_snapshot_if, get_db_pool, get_live_db_pool,
         parse_attachment_metadata_json, parse_recipients_json_value,
+        read_snapshot_acquire_error_to_mcp_error, read_snapshot_cancelled,
     },
 };
 
@@ -99,6 +102,7 @@ fn is_missing_projects_table_error(message: &str) -> bool {
     lower.contains("no such table") && lower.contains("projects")
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct ResourceReconcileInventory {
     projects: usize,
@@ -108,6 +112,7 @@ struct ResourceReconcileInventory {
     project_identities: std::collections::BTreeSet<mcp_agent_mail_db::MailboxProjectIdentity>,
 }
 
+#[cfg(test)]
 fn query_resource_db_inventory(
     conn: &mcp_agent_mail_db::DbConn,
 ) -> Result<ResourceReconcileInventory, String> {
@@ -183,15 +188,12 @@ fn query_resource_db_inventory(
     })
 }
 
-fn resource_archive_inventory_has_state(storage_root: &Path) -> bool {
-    let archive = crate::tool_util::read_archive_inventory(storage_root);
-    archive.projects > 0 || archive.agents > 0 || archive.unique_message_ids > 0
-}
-
+#[cfg(test)]
 fn resource_archive_is_ahead(
     storage_root: &Path,
     sqlite_path: &Path,
     conn: &mcp_agent_mail_db::DbConn,
+    archive: &mcp_agent_mail_db::ArchiveMessageInventory,
 ) -> Result<bool, String> {
     if !crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
         storage_root,
@@ -200,7 +202,6 @@ fn resource_archive_is_ahead(
         return Ok(false);
     }
 
-    let archive = crate::tool_util::read_archive_inventory(storage_root);
     if archive.projects == 0 && archive.agents == 0 && archive.unique_message_ids == 0 {
         return Ok(false);
     }
@@ -209,7 +210,7 @@ fn resource_archive_is_ahead(
     let archive_message_count = archive.unique_message_ids;
     let archive_max_id = archive.latest_message_id.unwrap_or(0);
     let missing_archive_projects = mcp_agent_mail_db::archive_missing_project_identities(
-        &archive,
+        archive,
         &db_inventory.project_identities,
     );
 
@@ -232,15 +233,26 @@ fn resource_archive_is_ahead(
 
 struct ResourceReadPool {
     pool: mcp_agent_mail_db::DbPool,
-    _snapshot_dir: Option<mcp_agent_mail_db::pool::CanonicalSnapshotTempDir>,
+    _snapshot: Option<Arc<SharedArchiveReadSnapshot>>,
 }
 
 impl ResourceReadPool {
     const fn live(pool: mcp_agent_mail_db::DbPool) -> Self {
         Self {
             pool,
-            _snapshot_dir: None,
+            _snapshot: None,
         }
+    }
+
+    fn snapshot(snapshot: Arc<SharedArchiveReadSnapshot>) -> Self {
+        Self {
+            pool: snapshot.pool(),
+            _snapshot: Some(snapshot),
+        }
+    }
+
+    const fn is_snapshot(&self) -> bool {
+        self._snapshot.is_some()
     }
 }
 
@@ -252,145 +264,52 @@ impl std::ops::Deref for ResourceReadPool {
     }
 }
 
-/// Check whether the live `SQLite` database is suspect for resource reads.
-///
-/// Delegates to the fast mailbox verdict. When `DurabilityState` is
-/// `DegradedReadOnly` (or worse), resource reads should fall back to
-/// archive-based data instead of the potentially corrupt live file.
-fn resource_live_db_is_suspect(
-    database_url: &str,
-    storage_root: &Path,
-    sqlite_path: &Path,
-) -> bool {
-    if !crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
-        storage_root,
-        sqlite_path,
-    ) {
-        return false;
+async fn open_resource_read_pool_with_cx(
+    cx: &asupersync::Cx,
+) -> Result<Option<ResourceReadPool>, crate::tool_util::ReadSnapshotAcquireError> {
+    if read_snapshot_cancelled(Some(cx)) {
+        return Err(crate::tool_util::ReadSnapshotAcquireError::Cancelled);
     }
-
-    let verdict = mcp_agent_mail_db::compute_mailbox_verdict(
-        database_url,
-        storage_root,
-        &mcp_agent_mail_db::VerdictOptions::fast(),
-    );
-    let durability = mcp_agent_mail_db::DurabilityState::from_mailbox_state(verdict.state);
-    if mcp_agent_mail_db::verdict_prefers_archive_snapshot_reads_for_primary_read_surface(
-        &verdict,
-        sqlite_path,
-    ) {
-        tracing::info!(
-            verdict_state = %verdict.state,
-            durability_state = %durability,
-            "live SQLite is suspect; resource reads will prefer archive snapshots"
-        );
-        true
-    } else {
-        false
-    }
-}
-
-fn open_resource_read_pool() -> Result<Option<ResourceReadPool>, String> {
     let config = Config::from_env();
     if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&config.database_url) {
         return Ok(None);
     }
 
     let sqlite_path = mcp_agent_mail_db::pool::resolve_mailbox_sqlite_path(&config.database_url)
-        .map_err(|err| err.to_string())?
+        .map_err(crate::tool_util::ReadSnapshotAcquireError::failed)?
         .canonical_path;
     if sqlite_path == ":memory:" {
         return Ok(None);
     }
 
     let resolved_path = PathBuf::from(&sqlite_path);
-    let archive_has_state = crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
+    if !crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
         &config.storage_root,
         &resolved_path,
-    ) && resource_archive_inventory_has_state(&config.storage_root);
-
-    // When the durability verdict says the live DB is suspect or worse,
-    // force archive-snapshot reads even if the archive isn't strictly
-    // "ahead" of the DB by row count.
-    let durability_forces_snapshot = archive_has_state
-        && resource_live_db_is_suspect(&config.database_url, &config.storage_root, &resolved_path);
-
-    let use_archive_snapshot = if !resolved_path.exists() {
-        archive_has_state
-    } else if durability_forces_snapshot {
-        true
-    } else {
-        match mcp_agent_mail_db::DbConn::open_file(&sqlite_path) {
-            Ok(conn) => {
-                let conn = mcp_agent_mail_db::guard_db_conn(
-                    conn,
-                    "resources::open_read_db_pool archive-ahead probe",
-                );
-                let archive_ahead =
-                    resource_archive_is_ahead(&config.storage_root, &resolved_path, &conn);
-                drop(conn);
-                match archive_ahead {
-                    Ok(true) => true,
-                    Err(error) if archive_has_state => {
-                        tracing::warn!(
-                            source = %resolved_path.display(),
-                            storage_root = %config.storage_root.display(),
-                            error = %error,
-                            "using archive-backed resource snapshot because the live sqlite inventory probe failed"
-                        );
-                        true
-                    }
-                    Ok(false) | Err(_) => false,
-                }
-            }
-            Err(error) if archive_has_state => {
-                tracing::warn!(
-                    source = %resolved_path.display(),
-                    storage_root = %config.storage_root.display(),
-                    error = %error,
-                    "using archive-backed resource snapshot because the live sqlite source could not be opened"
-                );
-                true
-            }
-            Err(_) => false,
-        }
-    };
-
-    if !use_archive_snapshot {
+    ) {
         return Ok(None);
     }
 
-    let snapshot_dir =
-        mcp_agent_mail_db::pool::CanonicalSnapshotTempDir::new("agent-mail-resource-snapshot-")
-            .map_err(|err| err.to_string())?;
-    let snapshot_db = snapshot_dir.path().join("mailbox.sqlite3");
-    if resolved_path.exists() {
-        mcp_agent_mail_db::reconstruct_from_archive_with_salvage(
-            &snapshot_db,
-            &config.storage_root,
-            Some(resolved_path.as_path()),
-        )
-        .map_err(|err| err.to_string())?;
-    } else {
-        mcp_agent_mail_db::reconstruct_from_archive(&snapshot_db, &config.storage_root)
-            .map_err(|err| err.to_string())?;
-    }
-    let pool = mcp_agent_mail_db::create_pool(&mcp_agent_mail_db::DbPoolConfig {
-        database_url: mcp_agent_mail_core::disk::sqlite_url_from_path(&snapshot_db),
-        storage_root: Some(config.storage_root),
-        ..Default::default()
-    })
-    .map_err(|err| err.to_string())?;
-    Ok(Some(ResourceReadPool {
-        pool,
-        _snapshot_dir: Some(snapshot_dir),
-    }))
+    get_archive_read_snapshot_if(
+        &config.storage_root,
+        &resolved_path,
+        &config.database_url,
+        cx,
+    )
+    .await
+    .map(|snapshot| snapshot.map(ResourceReadPool::snapshot))
+}
+
+#[cfg(test)]
+async fn open_resource_read_pool()
+-> Result<Option<ResourceReadPool>, crate::tool_util::ReadSnapshotAcquireError> {
+    open_resource_read_pool_with_cx(&asupersync::Cx::for_testing()).await
 }
 
 fn open_live_resource_read_pool() -> McpResult<ResourceReadPool> {
     let config = Config::from_env();
     if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&config.database_url) {
-        return get_db_pool().map(ResourceReadPool::live);
+        return get_live_db_pool().map(ResourceReadPool::live);
     }
 
     let resolved = mcp_agent_mail_db::pool::resolve_mailbox_sqlite_path(&config.database_url)
@@ -416,12 +335,12 @@ fn open_live_resource_read_pool() -> McpResult<ResourceReadPool> {
     pool_config.run_migrations = false;
     pool_config.warmup_connections = 0;
 
-    mcp_agent_mail_db::create_pool_without_startup_init(&pool_config)
+    mcp_agent_mail_db::create_query_only_pool(&pool_config)
         .map(ResourceReadPool::live)
         .map_err(|err| resource_sync_db_error_to_mcp_error(err.to_string()))
 }
 
-fn resource_live_database_missing_without_archive_state() -> bool {
+fn resource_live_database_is_missing() -> bool {
     let config = Config::from_env();
     if mcp_agent_mail_core::disk::is_sqlite_memory_database_url(&config.database_url) {
         return false;
@@ -432,19 +351,14 @@ fn resource_live_database_missing_without_archive_state() -> bool {
         return false;
     };
     let resolved_path = PathBuf::from(&resolved.canonical_path);
-    let archive_has_authoritative_state =
-        crate::tool_util::archive_storage_root_is_authoritative_for_sqlite_path(
-            &config.storage_root,
-            &resolved_path,
-        ) && resource_archive_inventory_has_state(&config.storage_root);
-    !resolved_path.exists() && !archive_has_authoritative_state
+    !resolved_path.exists()
 }
 
-fn get_resource_db_pool() -> McpResult<ResourceReadPool> {
-    match open_resource_read_pool() {
+async fn get_resource_db_pool(cx: &asupersync::Cx) -> McpResult<ResourceReadPool> {
+    match open_resource_read_pool_with_cx(cx).await {
         Ok(Some(pool)) => Ok(pool),
         Ok(None) => open_live_resource_read_pool(),
-        Err(error) => Err(resource_sync_db_error_to_mcp_error(error)),
+        Err(error) => Err(read_snapshot_acquire_error_to_mcp_error(error)),
     }
 }
 
@@ -836,7 +750,7 @@ pub struct AgentsListResponse {
 )]
 pub async fn agents_list(ctx: &McpContext, project_key: String) -> McpResult<String> {
     let (project_key, _query) = split_param_and_query(&project_key);
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
 
     let project_id = project.id.unwrap_or(0);
@@ -2172,7 +2086,7 @@ fn apply_projects_list_query_options(
     description = "List all projects known to the server in creation order.\n\nWhen to use\n-----------\n- Discover available projects when a user provides only an agent name.\n- Build UIs that let operators switch context between projects.\n\nReturns\n-------\nlist[dict]\n    Each: { id, slug, human_key, created_at }\n\nExample\n-------\n```json\n{\"jsonrpc\":\"2.0\",\"id\":\"r2\",\"method\":\"resources/read\",\"params\":{\"uri\":\"resource://projects\"}}\n```"
 )]
 pub async fn projects_list(ctx: &McpContext) -> McpResult<String> {
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
     let rows =
         db_outcome_to_mcp_result(mcp_agent_mail_db::queries::list_projects(ctx.cx(), &pool).await)?;
 
@@ -2200,7 +2114,7 @@ pub async fn projects_list_query(ctx: &McpContext, query: String) -> McpResult<S
     let params = parse_query(&query);
     let query_opts = parse_projects_list_query_options(&params)?;
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
     let rows =
         db_outcome_to_mcp_result(mcp_agent_mail_db::queries::list_projects(ctx.cx(), &pool).await)?;
 
@@ -2250,12 +2164,18 @@ pub struct ProjectDetailResponse {
 )]
 pub async fn project_details(ctx: &McpContext, slug: String) -> McpResult<String> {
     let (slug, _query) = split_param_and_query(&slug);
-    let pool = match get_resource_db_pool() {
-        Ok(pool) => pool,
-        Err(_) if resource_live_database_missing_without_archive_state() => {
-            return Err(resource_project_not_found_error());
+    let pool = match open_resource_read_pool_with_cx(ctx.cx()).await {
+        Ok(Some(pool)) => pool,
+        Ok(None) => match open_live_resource_read_pool() {
+            Ok(pool) => pool,
+            Err(_) if resource_live_database_is_missing() => {
+                return Err(resource_project_not_found_error());
+            }
+            Err(error) => return Err(error),
+        },
+        Err(error) => {
+            return Err(read_snapshot_acquire_error_to_mcp_error(error));
         }
-        Err(err) => return Err(err),
     };
 
     let project = resolve_existing_resource_project(ctx, &pool, &slug).await?;
@@ -2329,7 +2249,7 @@ pub async fn product_details(ctx: &McpContext, key: String) -> McpResult<String>
     }
 
     let (key, _query) = split_param_and_query(&key);
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
     let product =
         match mcp_agent_mail_db::queries::get_product_by_key(ctx.cx(), &pool, key.trim()).await {
             Outcome::Ok(product) => product,
@@ -2410,7 +2330,7 @@ pub async fn message_details(ctx: &McpContext, message_id: String) -> McpResult<
         ));
     }
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
     let project_id = project.id.unwrap_or(0);
 
@@ -2525,7 +2445,7 @@ pub async fn thread_details(ctx: &McpContext, thread_id: String) -> McpResult<St
         ));
     }
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
 
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
 
@@ -2663,7 +2583,7 @@ pub async fn inbox(ctx: &McpContext, agent: String) -> McpResult<String> {
         ));
     }
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
 
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
 
@@ -3275,7 +3195,7 @@ fn mailbox_full_messages(
     description = "List recent messages in an agent's mailbox with commit metadata fields. When archive commit data is unavailable, the `commit.summary` explicitly says so.\n\nReturns\n-------\ndict\n    { project, agent, count, messages: [{ id, subject, from, created_ts, importance, ack_required, kind, commit: {hexsha, summary} | null }] }"
 )]
 pub async fn mailbox(ctx: &McpContext, agent: String) -> McpResult<String> {
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
     let request = resolve_mailbox_resource_request(ctx, &pool, &agent).await?;
     let (inbox_rows, outbox_messages) = load_mailbox_messages(ctx, &pool, &request).await?;
     let messages = mailbox_simple_messages(
@@ -3302,7 +3222,7 @@ pub async fn mailbox(ctx: &McpContext, agent: String) -> McpResult<String> {
     description = "List recent messages in an agent's mailbox with commit metadata fields, including explicit unavailable markers when no archive commit data is resolved."
 )]
 pub async fn mailbox_with_commits(ctx: &McpContext, agent: String) -> McpResult<String> {
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
     let request = resolve_mailbox_resource_request(ctx, &pool, &agent).await?;
     let (inbox_rows, outbox_messages) = load_mailbox_messages(ctx, &pool, &request).await?;
     let messages = mailbox_full_messages(
@@ -3373,7 +3293,7 @@ pub async fn outbox(ctx: &McpContext, agent: String) -> McpResult<String> {
         ));
     }
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
 
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
 
@@ -3458,7 +3378,7 @@ pub async fn views_urgent_unread(ctx: &McpContext, agent: String) -> McpResult<S
         ));
     }
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
 
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
 
@@ -3533,7 +3453,7 @@ pub async fn views_ack_required(ctx: &McpContext, agent: String) -> McpResult<St
         ));
     }
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
 
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
 
@@ -3640,7 +3560,7 @@ pub async fn views_acks_stale(ctx: &McpContext, agent: String) -> McpResult<Stri
         ));
     }
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
 
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
 
@@ -3733,7 +3653,7 @@ pub async fn views_ack_overdue(ctx: &McpContext, agent: String) -> McpResult<Str
         ));
     }
 
-    let pool = get_resource_db_pool()?;
+    let pool = get_resource_db_pool(ctx.cx()).await?;
 
     let project = resolve_existing_resource_project(ctx, &pool, &project_key).await?;
 
@@ -4501,9 +4421,20 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
     let (slug_str, query) = split_param_and_query(&slug);
     let active_only = query.get("active_only").is_none_or(|v| parse_bool_param(v));
 
-    let pool = get_resource_db_pool()?;
+    let read_pool = get_resource_db_pool(ctx.cx()).await?;
+    // Reconstructed pools are immutable and shared process-wide. Cleanup is
+    // permitted only on a separately acquired durable live write lease; a
+    // resource read must never mutate its cached snapshot.
+    let write_pool = if read_pool.is_snapshot() {
+        None
+    } else {
+        Some(get_db_pool()?)
+    };
+    let pool: &mcp_agent_mail_db::DbPool = write_pool
+        .as_ref()
+        .map_or_else(|| &*read_pool, |live| &**live);
 
-    let project = resolve_existing_resource_project(ctx, &pool, &slug_str).await?;
+    let project = resolve_existing_resource_project(ctx, pool, &slug_str).await?;
 
     let project_id = project.id.unwrap_or(0);
 
@@ -4530,7 +4461,7 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
 
     // We only need agents map + mail cache for stale evaluation.
     let agent_rows = db_outcome_to_mcp_result(
-        mcp_agent_mail_db::queries::list_agents(ctx.cx(), &pool, project_id).await,
+        mcp_agent_mail_db::queries::list_agents(ctx.cx(), pool, project_id).await,
     )?;
     let agent_by_id: HashMap<i64, mcp_agent_mail_db::AgentRow> = agent_rows
         .iter()
@@ -4544,10 +4475,18 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
 
     // Cleanup only needs unreleased rows (including expired). Released history is unbounded and
     // scanning it on every resource read can time out on long-lived projects.
-    let all_rows = db_outcome_to_mcp_result(
-        mcp_agent_mail_db::queries::list_unreleased_file_reservations(ctx.cx(), &pool, project_id)
+    let all_rows = if write_pool.is_some() {
+        db_outcome_to_mcp_result(
+            mcp_agent_mail_db::queries::list_unreleased_file_reservations(
+                ctx.cx(),
+                pool,
+                project_id,
+            )
             .await,
-    )?;
+        )?
+    } else {
+        Vec::new()
+    };
 
     // Expire TTL-elapsed reservations (released_ts=NULL AND expires_ts <= now).
     for row in all_rows.iter().filter(|r| r.expires_ts <= now_micros) {
@@ -4555,7 +4494,7 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
         let updated = db_outcome_to_mcp_result(
             mcp_agent_mail_db::queries::force_release_reservation(
                 ctx.cx(),
-                &pool,
+                pool,
                 id,
                 Some(row.expires_ts),
             )
@@ -4583,7 +4522,7 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
             let out = db_outcome_to_mcp_result(
                 mcp_agent_mail_db::queries::get_agent_last_mail_activity(
                     ctx.cx(),
-                    &pool,
+                    pool,
                     row.agent_id,
                     project_id,
                 )
@@ -4605,7 +4544,7 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
             let updated = db_outcome_to_mcp_result(
                 mcp_agent_mail_db::queries::force_release_reservation(
                     ctx.cx(),
-                    &pool,
+                    pool,
                     id,
                     Some(row.expires_ts),
                 )
@@ -4656,7 +4595,7 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
         let updated = db_outcome_to_mcp_result(
             mcp_agent_mail_db::queries::force_release_reservation(
                 ctx.cx(),
-                &pool,
+                pool,
                 id,
                 Some(row.expires_ts),
             )
@@ -4672,7 +4611,7 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
     // Best-effort archive artifact writes for any releases.
     if !released_ids.is_empty() {
         let released_rows = db_outcome_to_mcp_result(
-            mcp_agent_mail_db::queries::get_reservations_by_ids(ctx.cx(), &pool, &released_ids)
+            mcp_agent_mail_db::queries::get_reservations_by_ids(ctx.cx(), pool, &released_ids)
                 .await,
         )?;
         let mut release_payloads: Vec<serde_json::Value> = Vec::with_capacity(released_rows.len());
@@ -4715,7 +4654,7 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
                 config: config.clone(),
                 reservations: release_payloads,
             };
-            crate::messaging::try_dispatch_archive_write(
+            crate::reservations::dispatch_reservation_archive_write(
                 op,
                 &format!(
                     "reservation release artifacts archive write project={}",
@@ -4727,13 +4666,8 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
 
     // List file reservations for the resource output after cleanup.
     let mut rows = db_outcome_to_mcp_result(
-        mcp_agent_mail_db::queries::list_file_reservations(
-            ctx.cx(),
-            &pool,
-            project_id,
-            active_only,
-        )
-        .await,
+        mcp_agent_mail_db::queries::list_file_reservations(ctx.cx(), pool, project_id, active_only)
+            .await,
     )?;
     if active_only {
         // Defense in depth: enforce active-only semantics here too, so older DB
@@ -4759,7 +4693,7 @@ pub async fn file_reservations(ctx: &McpContext, slug: String) -> McpResult<Stri
             let out = db_outcome_to_mcp_result(
                 mcp_agent_mail_db::queries::get_agent_last_mail_activity(
                     ctx.cx(),
-                    &pool,
+                    pool,
                     row.agent_id,
                     project_id,
                 )
@@ -4900,6 +4834,9 @@ mod resource_shape_tests {
     where
         F: FnOnce() -> T,
     {
+        let _snapshot_lock = crate::tool_util::READ_SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _lock = RESOURCE_TEST_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -4961,6 +4898,120 @@ mod resource_shape_tests {
             .build()
             .expect("build runtime");
         rt.block_on(f(cx))
+    }
+
+    #[test]
+    fn mixed_tool_resource_cold_burst_coalesces_one_blocking_reconstruction() {
+        with_serialized_resources(|| {
+            crate::tool_util::reset_read_archive_inventory_cache();
+            crate::tool_util::reset_read_snapshot_cache();
+
+            let config = Config::from_env();
+            git2::Repository::init(&config.storage_root).expect("init dirty resource archive");
+            let project_dir = config
+                .storage_root
+                .join("projects")
+                .join("resource-cache-project");
+            let message_dir = project_dir.join("messages").join("2026").join("07");
+            std::fs::create_dir_all(&message_dir).expect("create resource message directory");
+            std::fs::write(
+                project_dir.join("project.json"),
+                r#"{"slug":"resource-cache-project","human_key":"/resource-cache-project"}"#,
+            )
+            .expect("write resource project metadata");
+            std::fs::write(
+                message_dir.join("2026-07-18T00-00-00Z__resource__1.md"),
+                "---json\n{\"id\":1,\"from\":\"RedPeak\",\"to\":[],\"subject\":\"resource\",\"created_ts\":\"2026-07-18T00:00:00Z\"}\n---\nbody\n",
+            )
+            .expect("write resource message");
+
+            let resolved =
+                mcp_agent_mail_db::pool::resolve_mailbox_sqlite_path(&config.database_url)
+                    .expect("resolve resource sqlite path");
+            let db_path = PathBuf::from(resolved.canonical_path);
+            let conn = mcp_agent_mail_db::DbConn::open_file(db_path.to_string_lossy().as_ref())
+                .expect("open resource live db");
+            conn.execute_raw(&mcp_agent_mail_db::schema::init_schema_sql_base())
+                .expect("initialize resource live schema");
+            drop(conn);
+
+            let cancelled_cx = Cx::for_testing();
+            cancelled_cx.set_cancel_requested(true);
+            let cancelled =
+                run_async(|_| async { open_resource_read_pool_with_cx(&cancelled_cx).await });
+            assert!(matches!(
+                cancelled,
+                Err(crate::tool_util::ReadSnapshotAcquireError::Cancelled)
+            ));
+            assert_eq!(crate::tool_util::read_archive_inventory_scan_count(), 0);
+            assert_eq!(
+                crate::tool_util::read_snapshot_generation_scan_stats(),
+                (0, 0, 0)
+            );
+            assert_eq!(
+                crate::tool_util::read_snapshot_cache_stats(),
+                (0, false, 0, 0, 0)
+            );
+            crate::tool_util::set_read_snapshot_test_delay(std::time::Duration::from_millis(75));
+
+            let worker_count = 12;
+            let barrier = Arc::new(std::sync::Barrier::new(worker_count));
+            let pointers = Arc::new(Mutex::new(Vec::new()));
+            std::thread::scope(|scope| {
+                for index in 0..worker_count {
+                    let barrier = Arc::clone(&barrier);
+                    let pointers = Arc::clone(&pointers);
+                    scope.spawn(move || {
+                        let cx = Cx::for_testing();
+                        barrier.wait();
+                        let pointer = if index % 2 == 0 {
+                            let pool =
+                                run_async(|_| async { open_resource_read_pool_with_cx(&cx).await })
+                                    .expect("real resource read path")
+                                    .expect("resource archive snapshot pool");
+                            let snapshot = pool
+                                ._snapshot
+                                .as_ref()
+                                .expect("resource snapshot ownership must be retained");
+                            Arc::as_ptr(snapshot) as usize
+                        } else {
+                            run_async(|_| async {
+                                crate::tool_util::open_tool_read_snapshot_pointer(&cx).await
+                            })
+                            .expect("real tool read path")
+                            .expect("tool archive snapshot pointer")
+                        };
+                        pointers
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .push(pointer);
+                    });
+                }
+            });
+
+            let pointers = pointers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert_eq!(pointers.len(), worker_count);
+            assert!(pointers.windows(2).all(|pair| pair[0] == pair[1]));
+            assert_eq!(
+                crate::tool_util::read_archive_inventory_scan_count(),
+                1,
+                "the real resource predicate must reuse one inventory for state and drift"
+            );
+            assert_eq!(
+                crate::tool_util::read_snapshot_generation_scan_stats(),
+                (2, 0, 1)
+            );
+            assert_eq!(
+                crate::tool_util::read_snapshot_cache_stats(),
+                (1, false, 1, 0, 1)
+            );
+
+            drop(pointers);
+            crate::tool_util::reset_read_snapshot_cache();
+            crate::tool_util::reset_read_archive_inventory_cache();
+        });
     }
 
     fn write_archive_ahead_files() -> (PathBuf, PathBuf) {
@@ -7336,6 +7387,71 @@ mod resource_shape_tests {
     }
 
     #[test]
+    fn file_reservation_resource_does_not_mutate_shared_archive_snapshot() {
+        with_serialized_resources(|| {
+            run_async(|cx: Cx| async move {
+                crate::tool_util::reset_read_snapshot_cache();
+                let ctx = McpContext::new(cx.clone(), 1);
+                let (storage_root, db_path) = write_archive_ahead_files();
+                let reservations_dir = storage_root
+                    .join("projects")
+                    .join("ahead-project")
+                    .join("file_reservations");
+                std::fs::create_dir_all(&reservations_dir)
+                    .expect("create reservation archive directory");
+                std::fs::write(
+                    reservations_dir.join("id-904.json"),
+                    r#"{
+                        "id": 904,
+                        "project": "/ahead-project",
+                        "agent": "Alice",
+                        "path_pattern": "src/**",
+                        "exclusive": true,
+                        "reason": "immutable snapshot regression",
+                        "created_ts": "2020-01-01T00:00:00Z",
+                        "expires_ts": "2020-01-01T00:01:00Z"
+                    }"#,
+                )
+                .expect("write expired reservation artifact");
+
+                let first = parse_json(
+                    &file_reservations(&ctx, "ahead-project?active_only=false".to_string())
+                        .await
+                        .expect("first immutable reservation read"),
+                );
+                let second = parse_json(
+                    &file_reservations(&ctx, "ahead-project?active_only=false".to_string())
+                        .await
+                        .expect("second immutable reservation read"),
+                );
+                assert_eq!(first, second, "resource reads must not mutate cached rows");
+                let entries = first.as_array().expect("reservation array");
+                let reservation = entries
+                    .iter()
+                    .find(|entry| entry["id"] == 904)
+                    .expect("archived reservation");
+                assert_eq!(reservation["released_ts"], Value::Null);
+                assert!(
+                    !db_path.exists(),
+                    "snapshot-only cleanup must not create or write a live mailbox"
+                );
+                assert_eq!(
+                    crate::tool_util::read_snapshot_cache_stats().2,
+                    1,
+                    "both resource reads must share one immutable reconstruction"
+                );
+                let wait_deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+                while crate::tool_util::read_snapshot_cache_stats().1
+                    && std::time::Instant::now() < wait_deadline
+                {
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                crate::tool_util::reset_read_snapshot_cache();
+            });
+        });
+    }
+
+    #[test]
     fn resources_keep_live_db_when_db_has_newer_messages_than_metadata_only_archive_drift() {
         with_serialized_resources(|| {
             run_async(|cx: Cx| async move {
@@ -7344,8 +7460,10 @@ mod resource_shape_tests {
 
                 let conn = mcp_agent_mail_db::DbConn::open_file(db_path.to_string_lossy().as_ref())
                     .expect("open live db");
+                let storage_root = Config::from_env().storage_root;
+                let archive_inventory = crate::tool_util::read_archive_inventory(&storage_root);
                 assert!(
-                    !resource_archive_is_ahead(&Config::from_env().storage_root, &db_path, &conn)
+                    !resource_archive_is_ahead(&storage_root, &db_path, &conn, &archive_inventory)
                         .expect("resource archive ahead probe"),
                     "newer live message evidence should suppress metadata-only archive fallback"
                 );
@@ -7390,7 +7508,9 @@ mod resource_shape_tests {
                     incremental_check.details
                 );
 
-                let pool = open_resource_read_pool().expect("open resource read pool");
+                let pool = open_resource_read_pool()
+                    .await
+                    .expect("open resource read pool");
                 assert!(
                     pool.is_none(),
                     "resource reads should stay on the live DB when only archive metadata is ahead"
@@ -7401,6 +7521,9 @@ mod resource_shape_tests {
 
     #[test]
     fn resources_ignore_unrelated_default_archive_overlap() {
+        let _snapshot_guard = crate::tool_util::READ_SNAPSHOT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _guard = RESOURCE_TEST_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -7447,7 +7570,8 @@ mod resource_shape_tests {
                 .expect("insert overlapping project");
                 drop(conn);
 
-                let pool = open_resource_read_pool().expect("open resource read pool");
+                let pool = run_async(|_| async { open_resource_read_pool().await })
+                    .expect("open resource read pool");
                 assert!(
                     pool.is_none(),
                     "default global archive should not force resource snapshots for an external custom DB"

--- a/crates/mcp-agent-mail-tools/src/search.rs
+++ b/crates/mcp-agent-mail-tools/src/search.rs
@@ -922,7 +922,7 @@ pub async fn search_messages(
         &[("date_to", date_to), ("before", before), ("until", until)],
     )?;
 
-    let pool = get_read_db_pool()?;
+    let pool = get_read_db_pool(ctx.cx()).await?;
     let project = resolve_project(ctx, &pool, &project_key).await?;
     let project_id = project.id.unwrap_or(0);
     phase.mark("scope_resolution");
@@ -1164,7 +1164,7 @@ pub async fn summarize_thread(
     let use_llm = llm_mode.unwrap_or(true);
     let msg_limit = parse_summarize_thread_limit(per_thread_limit)?;
 
-    let pool = get_read_db_pool()?;
+    let pool = get_read_db_pool(ctx.cx()).await?;
     let project = resolve_project(ctx, &pool, &project_key).await?;
     let project_id = project.id.unwrap_or(0);
 


### PR DESCRIPTION
## Problem

Archive-backed read tools can concurrently reconstruct the same state, observe mixed live/archive generations, and publish a cache entry even when inventory or reconstruction traversal was incomplete. Health reads also risked creating avoidable writer-generation churn.

## What changed

- Add generation-aware single-flight reconstruction so one builder owns a generation while waiters share its completion object.
- Use cheap and exact generation keys that cover relevant archive/live shape and content, persistent SQLite `data_version`, archive/write epochs, and same-size content changes without self-invalidating on incidental main/root mtime or SHM churn.
- Build read snapshots from query-only pools and reject publication if DB or archive generations move during construction or post-validation.
- Fail closed when inventory or reconstruction reports traversal/read/parse loss, and compare exact project, agent, message, and duplicate-canonical-file counts while keeping salvage-only rows separate.
- Keep public non-cancellable recovery behavior best-effort while making cache publication strict.
- Route hot authoritative health reads through the cached live read helper without advancing the writer epoch.
- Add bounded cancellation, deadline, write-lease, generation-conflict, partial-snapshot, same-size external-write, and stale-live-DB regression coverage.

## Concurrency model

A build is keyed to an observed generation. Waiters never steal or cancel another generation and retain their own completion object. Publication occurs only after exact post-validation under the archive barrier and is rejected if either database or archive authority moved. External and background writers remain bounded by exact content keys, persistent `data_version`, and the configured validation TTL.

## Validation

Exact candidate:

- Head: `6426e0ac8be395ee3d32be90cd0b4fc7f5dfab9b`
- Parent: `1901acb3cce7b6e299ae19b0be802a8a14d13079`
- Tree: `2cf72798bdb16259579c47662a6a74f84befb0b5`
- Patch SHA-256: `ddb2b6bfd409a9aff1c1884150a803ceb1ab00142e250359067bd5ef94de5187`
- Stable patch ID: `a2ed8bc6a56c28ed7d37c81c70e4106ad03640c0`

Isolated Linux validation on `ssh g`:

- Four-package offline `cargo check --tests`: pass for DB, storage, tools, and server crates; two pre-existing dead-code warnings only.
- Sixteen focused regressions: pass, including inventory and reconstruction traversal rejection, malformed-profile no-publication, duplicate/collision accounting, single-flight and post-validation conflicts, hot-health epoch stability, write-lease behavior, same-size live byte changes, and stale-live list reconstruction.
- Direct Rustfmt check across all 13 changed files: pass.
- `git diff --check`: pass.
- Independent exact-head review: APPROVE, P0/P1/P2 = 0/0/0.

## Risk and rollout

This is intentionally a draft because the patch changes shared read-path concurrency across 13 files. Upstream CI and maintainer review are required before merge.

No service restart, production deployment, mailbox read/write, database migration, or hub mutation was performed. Deployment should be a separate reviewed transaction after upstream acceptance.