### PR TITLE
Fix reservation read parity for conflict-focused views

### DIFF
--- a/crates/mcp-agent-mail-cli/src/lib.rs
+++ b/crates/mcp-agent-mail-cli/src/lib.rs
@@ -466,7 +466,7 @@ pub enum Commands {
         /// Show reservations for all agents, not just the selected agent.
         #[arg(long)]
         all: bool,
-        /// Show only conflicting reservations.
+        /// Add a `conflicting_active` projection; `all_active` stays authoritative.
         #[arg(long)]
         conflicts: bool,
         /// Warn about reservations expiring within N minutes.

--- a/crates/mcp-agent-mail-cli/src/robot.rs
+++ b/crates/mcp-agent-mail-cli/src/robot.rs
@@ -2621,7 +2621,7 @@ pub enum RobotSubcommand {
         /// Show reservations for all agents, not just the selected agent.
         #[arg(long)]
         all: bool,
-        /// Show only conflicting reservations.
+        /// Add a `conflicting_active` projection; `all_active` stays authoritative.
         #[arg(long)]
         conflicts: bool,
         /// Warn about reservations expiring within N minutes.
@@ -7506,6 +7506,10 @@ struct ReservationsData {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     my_reservations: Vec<ReservationEntry>,
     all_active: Vec<ReservationEntry>,
+    /// Conflict-only projection. `all_active` always remains the authoritative
+    /// active snapshot, including when `--conflicts` is selected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    conflicting_active: Option<Vec<ReservationEntry>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     conflicts: Vec<ReservationConflict>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -7899,13 +7903,15 @@ fn build_reservations(
             .flat_map(|c| vec![c.path_a.clone(), c.path_b.clone()])
             .collect();
         let filtered: Vec<_> = scoped_all_active
-            .into_iter()
+            .iter()
             .filter(|e| conflict_paths.contains(&e.path))
+            .cloned()
             .collect();
         return Ok((
             ReservationsData {
                 my_reservations: vec![],
-                all_active: filtered,
+                all_active: scoped_all_active,
+                conflicting_active: Some(filtered),
                 conflicts: scoped_conflicts,
                 expiring_soon: vec![],
                 playbooks: scoped_playbooks,
@@ -7925,6 +7931,7 @@ fn build_reservations(
             ReservationsData {
                 my_reservations: my_reservations.clone(),
                 all_active: scoped_all_active,
+                conflicting_active: None,
                 conflicts: scoped_conflicts,
                 expiring_soon: scoped_expiring_soon,
                 playbooks: scoped_playbooks,
@@ -7940,6 +7947,7 @@ fn build_reservations(
         ReservationsData {
             my_reservations,
             all_active,
+            conflicting_active: None,
             conflicts,
             expiring_soon,
             playbooks,
@@ -14033,6 +14041,16 @@ pub fn handle_robot(args: RobotArgs) -> Result<(), CliError> {
             )?;
             let mut env = RobotEnvelope::new(cmd_name, format, data);
             env._meta.project = Some(scope.project_slug);
+            if conflicts && env.data.conflicts.is_empty() && !env.data.all_active.is_empty() {
+                env = env.with_alert(
+                    "info",
+                    "No overlapping active reservation pairs found",
+                    Some(
+                        "`all_active` is the authoritative lease snapshot; use `am file_reservations conflicts <project> <agent> --paths <path...>` to check proposed edits."
+                            .to_string(),
+                    ),
+                );
+            }
             for a in actions {
                 env = env.with_action(&a);
             }
@@ -17704,6 +17722,14 @@ mod tests {
                     granted_at: Some("55m ago".into()),
                 },
             ],
+            conflicting_active: Some(vec![ReservationEntry {
+                agent: Some("RedFox".into()),
+                path: "src/auth/jwt.rs".into(),
+                exclusive: true,
+                remaining_seconds: 300,
+                remaining: Some("5m \u{26a0}".into()),
+                granted_at: Some("55m ago".into()),
+            }]),
             conflicts: vec![ReservationConflict {
                 agent_a: "BlueLake".into(),
                 path_a: "src/auth/**".into(),
@@ -17746,6 +17772,7 @@ mod tests {
 
         let json = serde_json::to_value(&data).unwrap();
         assert_eq!(json["all_active"].as_array().unwrap().len(), 2);
+        assert_eq!(json["conflicting_active"].as_array().unwrap().len(), 1);
         assert_eq!(json["conflicts"].as_array().unwrap().len(), 1);
         assert_eq!(json["conflicts"][0]["agent_a"], "BlueLake");
         assert_eq!(json["expiring_soon"].as_array().unwrap().len(), 1);

--- a/crates/mcp-agent-mail-cli/src/robot.rs
+++ b/crates/mcp-agent-mail-cli/src/robot.rs
@@ -14046,7 +14046,7 @@ pub fn handle_robot(args: RobotArgs) -> Result<(), CliError> {
                     "info",
                     "No overlapping active reservation pairs found",
                     Some(
-                        "`all_active` is the authoritative lease snapshot; use `am file_reservations conflicts <project> <agent> --paths <path...>` to check proposed edits."
+                        "`all_active` is the authoritative lease snapshot within the selected project/agent scope; use `am file_reservations conflicts <PROJECT> <PATHS>...` to check proposed edits."
                             .to_string(),
                     ),
                 );
@@ -24007,19 +24007,42 @@ mod tests {
              (id, project_id, agent_id, path_pattern, exclusive, reason, created_ts, expires_ts, released_ts)
              VALUES
                 (?, 1, 1, 'src/*/foo.rs', 1, 'a', 0, ?, NULL),
-                (?, 1, 2, 'src/bar/*.rs', 1, 'b', 0, ?, NULL)",
+                (?, 1, 2, 'src/bar/*.rs', 1, 'b', 0, ?, NULL),
+                (?, 1, 3, 'docs/**', 1, 'unrelated', 0, ?, NULL)",
             &[
                 mcp_agent_mail_db::sqlmodel_core::Value::BigInt(1),
                 mcp_agent_mail_db::sqlmodel_core::Value::BigInt(now_us + 3_600_000_000),
                 mcp_agent_mail_db::sqlmodel_core::Value::BigInt(2),
                 mcp_agent_mail_db::sqlmodel_core::Value::BigInt(now_us + 3_600_000_000),
+                mcp_agent_mail_db::sqlmodel_core::Value::BigInt(3),
+                mcp_agent_mail_db::sqlmodel_core::Value::BigInt(now_us + 3_600_000_000),
             ],
         )
         .expect("insert glob reservations");
 
-        let (data, _actions) = build_reservations(&conn, 1, "proj", None, false, false, Some(10))
+        let (data, _actions) = build_reservations(&conn, 1, "proj", None, false, true, Some(10))
             .expect("build reservations");
 
+        assert_eq!(data.all_active.len(), 3);
+        assert!(
+            data.all_active.iter().any(|entry| entry.path == "docs/**"),
+            "authoritative scoped snapshot should retain unrelated active leases"
+        );
+        assert_eq!(
+            data.conflicting_active
+                .as_ref()
+                .expect("conflict projection")
+                .len(),
+            2
+        );
+        assert!(
+            data.conflicting_active
+                .as_ref()
+                .expect("conflict projection")
+                .iter()
+                .all(|entry| entry.path != "docs/**"),
+            "conflict projection should exclude unrelated active leases"
+        );
         assert_eq!(data.conflicts.len(), 1);
         assert_eq!(data.conflicts[0].agent_a, "Alice");
         assert_eq!(data.conflicts[0].path_a, "src/*/foo.rs");

--- a/tests/e2e/test_reservation_read_parity.sh
+++ b/tests/e2e/test_reservation_read_parity.sh
@@ -118,6 +118,7 @@ e2e_case_banner "All read surfaces agree while the lease is active"
 amrun "${ART}/alias_path.json" reservations --project "${PROJECT_KEY}" --agent GoldFox --json
 amrun "${ART}/robot_slug.json" robot --project "${PROJECT_SLUG}" --agent GoldFox reservations --all --format json
 amrun "${ART}/conflict_focus.json" reservations --project "${PROJECT_KEY}" --agent GoldFox --conflicts --json
+amrun "${ART}/recovery_command.txt" file_reservations conflicts "${PROJECT_KEY}" "src/alpha/**"
 amrun "${ART}/active_path.txt" file_reservations active "${PROJECT_KEY}"
 amrun "${ART}/active_slug.txt" file_reservations active "${PROJECT_SLUG}"
 amrun "${ART}/list_path.txt" file_reservations list "${PROJECT_KEY}"
@@ -130,9 +131,16 @@ for view in alias_path robot_slug conflict_focus; do
         '.all_active | any(.path == "src/alpha/**" and .remaining_seconds > 0 and .remaining_seconds <= 3600)'
 done
 json_assert "conflict focus has a distinct empty projection" "${ART}/conflict_focus.json" \
-    '(.conflicts == null or (.conflicts | length == 0)) and (.conflicting_active | length == 0)'
+    'has("conflicting_active") and (.conflicting_active | type == "array" and length == 0) and (.conflicts == null or (.conflicts | type == "array" and length == 0))'
 json_assert "conflict focus explains no-overlap vs no-active" "${ART}/conflict_focus.json" \
     '._alerts | any(.summary == "No overlapping active reservation pairs found" and .action == "`all_active` is the authoritative lease snapshot within the selected project/agent scope; use `am file_reservations conflicts <PROJECT> <PATHS>...` to check proposed edits.")'
+if grep -Fq "1 conflict(s) found" "${ART}/recovery_command.txt.err" \
+    && grep -Fq "GoldFox" "${ART}/recovery_command.txt" \
+    && grep -Fq "src/alpha/**" "${ART}/recovery_command.txt"; then
+    e2e_pass "surfaced recovery command executes and finds the live lease"
+else
+    e2e_fail "surfaced recovery command did not find the live lease"
+fi
 
 for view in active_path active_slug list_path list_slug; do
     if grep -Fq "GoldFox" "${ART}/${view}.txt" && grep -Fq "src/alpha/**" "${ART}/${view}.txt"; then
@@ -157,10 +165,11 @@ amrun "${ART}/alias_after.json" reservations --project "${PROJECT_SLUG}" --agent
 amrun "${ART}/conflict_after.json" reservations --project "${PROJECT_KEY}" --agent GoldFox --conflicts --json
 amrun "${ART}/active_after.txt" file_reservations active "${PROJECT_SLUG}"
 amrun "${ART}/list_after.txt" file_reservations list "${PROJECT_KEY}"
-for view in alias_after conflict_after; do
-    json_assert "${view}: released lease absent" "${ART}/${view}.json" \
-        '.all_active | all(.agent != "GoldFox" or .path != "src/alpha/**")'
-done
+json_assert "alias_after: authoritative snapshot is explicitly empty" "${ART}/alias_after.json" \
+    'has("all_active") and (.all_active | type == "array" and length == 0)'
+json_assert "conflict_after: authoritative and conflict projections are explicitly empty" \
+    "${ART}/conflict_after.json" \
+    'has("all_active") and (.all_active | type == "array" and length == 0) and has("conflicting_active") and (.conflicting_active | type == "array" and length == 0)'
 for view in active_after list_after; do
     if grep -Fq "src/alpha/**" "${ART}/${view}.txt"; then
         e2e_fail "${view}: released lease still visible"

--- a/tests/e2e/test_reservation_read_parity.sh
+++ b/tests/e2e/test_reservation_read_parity.sh
@@ -35,27 +35,45 @@ export HTTP_PORT="${AM_E2E_UNUSED_PORT:-8799}"
 INIT_REQ='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"reservation-read-parity","version":"1"}}}'
 
 stdio_session() {
-    local output="$1"
-    shift
-    local session_dir fifo server_pid writer_pid
+    local output="$1" expected_id="$2"
+    shift 2
+    local session_dir fifo server_pid writer_fd request response_seen
     session_dir="$(mktemp -d "${WORK}/stdio.XXXXXX")"
     fifo="${session_dir}/stdin"
     mkfifo "${fifo}"
     DATABASE_URL="${DATABASE_URL}" STORAGE_ROOT="${STORAGE_ROOT}" RUST_LOG=error \
         "${AM_BIN}" serve-stdio <"${fifo}" >"${output}" 2>"${output}.err" &
     server_pid=$!
-    sleep 0.3
-    {
-        printf '%s\n' "${INIT_REQ}"
-        local request
-        for request in "$@"; do
-            sleep 0.3
-            printf '%s\n' "${request}"
-        done
-        sleep 0.5
-    } >"${fifo}" &
-    writer_pid=$!
-    wait "${writer_pid}" 2>/dev/null || true
+    exec {writer_fd}>"${fifo}"
+    printf '%s\n' "${INIT_REQ}" >&"${writer_fd}"
+    for request in "$@"; do
+        printf '%s\n' "${request}" >&"${writer_fd}"
+    done
+    exec {writer_fd}>&-
+
+    response_seen=false
+    for _ in {1..200}; do
+        if jq -e --argjson id "${expected_id}" 'select(.id == $id)' "${output}" >/dev/null 2>&1; then
+            response_seen=true
+            break
+        fi
+        if ! kill -0 "${server_pid}" 2>/dev/null; then
+            break
+        fi
+        sleep 0.05
+    done
+    if [[ "${response_seen}" != true ]]; then
+        kill "${server_pid}" 2>/dev/null || true
+        wait "${server_pid}" 2>/dev/null || true
+        e2e_log "stdio response id ${expected_id} was not observed; stderr=$(head -c 320 "${output}.err")"
+        return 1
+    fi
+    for _ in {1..100}; do
+        if ! kill -0 "${server_pid}" 2>/dev/null; then
+            break
+        fi
+        sleep 0.02
+    done
     kill "${server_pid}" 2>/dev/null || true
     wait "${server_pid}" 2>/dev/null || true
 }
@@ -83,7 +101,7 @@ json_assert() {
 }
 
 e2e_case_banner "MCP grant"
-stdio_session "${ART}/grant.jsonl" \
+stdio_session "${ART}/grant.jsonl" 12 \
     "{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"tools/call\",\"params\":{\"name\":\"ensure_project\",\"arguments\":{\"human_key\":\"${PROJECT_KEY}\"}}}" \
     "{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":\"${PROJECT_KEY}\",\"program\":\"e2e\",\"model\":\"test\",\"name\":\"GoldFox\"}}}" \
     "{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":\"tools/call\",\"params\":{\"name\":\"file_reservation_paths\",\"arguments\":{\"project_key\":\"${PROJECT_KEY}\",\"agent_name\":\"GoldFox\",\"paths\":[\"src/alpha/**\"],\"ttl_seconds\":3600,\"exclusive\":true,\"reason\":\"read parity\"}}}"
@@ -114,7 +132,7 @@ done
 json_assert "conflict focus has a distinct empty projection" "${ART}/conflict_focus.json" \
     '(.conflicts == null or (.conflicts | length == 0)) and (.conflicting_active | length == 0)'
 json_assert "conflict focus explains no-overlap vs no-active" "${ART}/conflict_focus.json" \
-    '._alerts | any(.summary == "No overlapping active reservation pairs found" and (.action | contains("all_active")))'
+    '._alerts | any(.summary == "No overlapping active reservation pairs found" and .action == "`all_active` is the authoritative lease snapshot within the selected project/agent scope; use `am file_reservations conflicts <PROJECT> <PATHS>...` to check proposed edits.")'
 
 for view in active_path active_slug list_path list_slug; do
     if grep -Fq "GoldFox" "${ART}/${view}.txt" && grep -Fq "src/alpha/**" "${ART}/${view}.txt"; then
@@ -130,7 +148,7 @@ else
 fi
 
 e2e_case_banner "MCP release disappears from every read surface"
-stdio_session "${ART}/release.jsonl" \
+stdio_session "${ART}/release.jsonl" 20 \
     "{\"jsonrpc\":\"2.0\",\"id\":20,\"method\":\"tools/call\",\"params\":{\"name\":\"release_file_reservations\",\"arguments\":{\"project_key\":\"${PROJECT_KEY}\",\"agent_name\":\"GoldFox\",\"paths\":[\"src/alpha/**\"]}}}"
 printf '%s\n' "$(tool_result "${ART}/release.jsonl" 20)" >"${ART}/release.json"
 json_assert "MCP releases exactly one lease" "${ART}/release.json" '.released == 1'

--- a/tests/e2e/test_reservation_read_parity.sh
+++ b/tests/e2e/test_reservation_read_parity.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# test_reservation_read_parity.sh — MCP/robot/operator active-lease read parity.
+# @tags: reservations, parity, robot, mcp
+
+set -euo pipefail
+
+E2E_SUITE="reservation_read_parity"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+source "${PROJECT_ROOT}/scripts/e2e_lib.sh"
+
+e2e_init_artifacts
+e2e_banner "Reservation Read Surface Parity E2E"
+
+if ! command -v jq >/dev/null 2>&1; then
+    e2e_skip "jq required"
+    e2e_summary
+    exit 0
+fi
+
+AM_BIN="$(e2e_ensure_binary am)"
+WORK="$(e2e_mktemp reservation_read_parity)"
+ART="${E2E_ARTIFACT_DIR}/scenarios"
+DB_PATH="${WORK}/mail.sqlite3"
+STORAGE_ROOT="${WORK}/storage"
+PROJECT_KEY="${WORK}/repo"
+mkdir -p "${ART}" "${STORAGE_ROOT}" "${PROJECT_KEY}"
+
+export AM_INTERFACE_MODE=cli
+export DATABASE_URL="sqlite:///${DB_PATH}"
+export STORAGE_ROOT
+export HTTP_HOST=127.0.0.1
+export HTTP_PORT="${AM_E2E_UNUSED_PORT:-8799}"
+
+INIT_REQ='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"reservation-read-parity","version":"1"}}}'
+
+stdio_session() {
+    local output="$1"
+    shift
+    local session_dir fifo server_pid writer_pid
+    session_dir="$(mktemp -d "${WORK}/stdio.XXXXXX")"
+    fifo="${session_dir}/stdin"
+    mkfifo "${fifo}"
+    DATABASE_URL="${DATABASE_URL}" STORAGE_ROOT="${STORAGE_ROOT}" RUST_LOG=error \
+        "${AM_BIN}" serve-stdio <"${fifo}" >"${output}" 2>"${output}.err" &
+    server_pid=$!
+    sleep 0.3
+    {
+        printf '%s\n' "${INIT_REQ}"
+        local request
+        for request in "$@"; do
+            sleep 0.3
+            printf '%s\n' "${request}"
+        done
+        sleep 0.5
+    } >"${fifo}" &
+    writer_pid=$!
+    wait "${writer_pid}" 2>/dev/null || true
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+}
+
+tool_result() {
+    local file="$1" request_id="$2"
+    jq -r --argjson id "${request_id}" \
+        'select(.id == $id) | .result.content[0].text // empty' "${file}" | head -1
+}
+
+amrun() {
+    local output="$1"
+    shift
+    "${AM_BIN}" "$@" >"${output}" 2>"${output}.err"
+}
+
+json_assert() {
+    local label="$1" file="$2" filter="$3"
+    if jq -e "${filter}" "${file}" >/dev/null 2>&1; then
+        e2e_pass "${label}"
+    else
+        e2e_fail "${label}"
+        e2e_log "filter=${filter}; got=$(jq -c . "${file}" 2>/dev/null | head -c 320)"
+    fi
+}
+
+e2e_case_banner "MCP grant"
+stdio_session "${ART}/grant.jsonl" \
+    "{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"tools/call\",\"params\":{\"name\":\"ensure_project\",\"arguments\":{\"human_key\":\"${PROJECT_KEY}\"}}}" \
+    "{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"tools/call\",\"params\":{\"name\":\"register_agent\",\"arguments\":{\"project_key\":\"${PROJECT_KEY}\",\"program\":\"e2e\",\"model\":\"test\",\"name\":\"GoldFox\"}}}" \
+    "{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":\"tools/call\",\"params\":{\"name\":\"file_reservation_paths\",\"arguments\":{\"project_key\":\"${PROJECT_KEY}\",\"agent_name\":\"GoldFox\",\"paths\":[\"src/alpha/**\"],\"ttl_seconds\":3600,\"exclusive\":true,\"reason\":\"read parity\"}}}"
+
+PROJECT_JSON="$(tool_result "${ART}/grant.jsonl" 10)"
+GRANT_JSON="$(tool_result "${ART}/grant.jsonl" 12)"
+printf '%s\n' "${GRANT_JSON}" >"${ART}/grant.json"
+PROJECT_SLUG="$(jq -r '.slug // empty' <<<"${PROJECT_JSON}")"
+EXPIRES_TS="$(jq -r '.granted[0].expires_ts // empty' "${ART}/grant.json")"
+json_assert "MCP grants one exclusive lease" "${ART}/grant.json" \
+    '.granted | any(.path_pattern == "src/alpha/**" and .exclusive == true)'
+
+e2e_case_banner "All read surfaces agree while the lease is active"
+amrun "${ART}/alias_path.json" reservations --project "${PROJECT_KEY}" --agent GoldFox --json
+amrun "${ART}/robot_slug.json" robot --project "${PROJECT_SLUG}" --agent GoldFox reservations --all --format json
+amrun "${ART}/conflict_focus.json" reservations --project "${PROJECT_KEY}" --agent GoldFox --conflicts --json
+amrun "${ART}/active_path.txt" file_reservations active "${PROJECT_KEY}"
+amrun "${ART}/active_slug.txt" file_reservations active "${PROJECT_SLUG}"
+amrun "${ART}/list_path.txt" file_reservations list "${PROJECT_KEY}"
+amrun "${ART}/list_slug.txt" file_reservations list "${PROJECT_SLUG}"
+
+for view in alias_path robot_slug conflict_focus; do
+    json_assert "${view}: authoritative holder/path visible" "${ART}/${view}.json" \
+        '.all_active | any(.agent == "GoldFox" and .path == "src/alpha/**" and .exclusive == true)'
+    json_assert "${view}: live expiry visible" "${ART}/${view}.json" \
+        '.all_active | any(.path == "src/alpha/**" and .remaining_seconds > 0 and .remaining_seconds <= 3600)'
+done
+json_assert "conflict focus has a distinct empty projection" "${ART}/conflict_focus.json" \
+    '(.conflicts == null or (.conflicts | length == 0)) and (.conflicting_active | length == 0)'
+json_assert "conflict focus explains no-overlap vs no-active" "${ART}/conflict_focus.json" \
+    '._alerts | any(.summary == "No overlapping active reservation pairs found" and (.action | contains("all_active")))'
+
+for view in active_path active_slug list_path list_slug; do
+    if grep -Fq "GoldFox" "${ART}/${view}.txt" && grep -Fq "src/alpha/**" "${ART}/${view}.txt"; then
+        e2e_pass "${view}: authoritative holder/path visible"
+    else
+        e2e_fail "${view}: authoritative holder/path missing"
+    fi
+done
+if [ -n "${EXPIRES_TS}" ] && grep -Fq "${EXPIRES_TS:0:19}" "${ART}/list_path.txt"; then
+    e2e_pass "operator expiry matches MCP grant"
+else
+    e2e_fail "operator expiry does not match MCP grant"
+fi
+
+e2e_case_banner "MCP release disappears from every read surface"
+stdio_session "${ART}/release.jsonl" \
+    "{\"jsonrpc\":\"2.0\",\"id\":20,\"method\":\"tools/call\",\"params\":{\"name\":\"release_file_reservations\",\"arguments\":{\"project_key\":\"${PROJECT_KEY}\",\"agent_name\":\"GoldFox\",\"paths\":[\"src/alpha/**\"]}}}"
+printf '%s\n' "$(tool_result "${ART}/release.jsonl" 20)" >"${ART}/release.json"
+json_assert "MCP releases exactly one lease" "${ART}/release.json" '.released == 1'
+
+amrun "${ART}/alias_after.json" reservations --project "${PROJECT_SLUG}" --agent GoldFox --json
+amrun "${ART}/conflict_after.json" reservations --project "${PROJECT_KEY}" --agent GoldFox --conflicts --json
+amrun "${ART}/active_after.txt" file_reservations active "${PROJECT_SLUG}"
+amrun "${ART}/list_after.txt" file_reservations list "${PROJECT_KEY}"
+for view in alias_after conflict_after; do
+    json_assert "${view}: released lease absent" "${ART}/${view}.json" \
+        '.all_active | all(.agent != "GoldFox" or .path != "src/alpha/**")'
+done
+for view in active_after list_after; do
+    if grep -Fq "src/alpha/**" "${ART}/${view}.txt"; then
+        e2e_fail "${view}: released lease still visible"
+    else
+        e2e_pass "${view}: released lease absent"
+    fi
+done
+
+e2e_summary

--- a/tests/fixtures/cli_help/reservations.txt
+++ b/tests/fixtures/cli_help/reservations.txt
@@ -8,6 +8,6 @@ Options:
       --project <PROJECT>    Project key (absolute path or slug). Falls back to AGENT_MAIL_PROJECT, then CWD
       --agent <AGENT>        Agent name. Falls back to AGENT_MAIL_AGENT, then AGENT_NAME
       --all                  Show reservations for all agents, not just the selected agent
-      --conflicts            Show only conflicting reservations
+      --conflicts            Add a `conflicting_active` projection; `all_active` stays authoritative
       --expiring <EXPIRING>  Warn about reservations expiring within N minutes
   -h, --help                 Print help


### PR DESCRIPTION
## What changed

- Keep `all_active` as the authoritative scoped lease snapshot when callers request conflict-focused reservation JSON.
- Add the narrower `conflicting_active` projection for leases that actually participate in an overlap.
- Correct the operator guidance to point to the real command: `am file_reservations conflicts <PROJECT> <PATHS>...`.
- Add a bounded response-ID-synchronized E2E covering grant, absolute-path/slug reads, conflict-focused reads, the executable recovery command, release, and post-release absence.

## Why

The conflict-focused CLI path replaced `all_active` with only overlapping leases. That made a live, non-overlapping reservation disappear from one read surface while remaining visible in normal, active, list, and robot views. Operators could therefore mistake “no overlaps” for “no active reservations,” and the suggested recovery syntax did not match the installed CLI.

## Impact

`all_active` is now consistent across reservation read surfaces. Conflict consumers can use the additive `conflicting_active` field without losing the authoritative lease snapshot. Legacy consumers that treated `all_active` under `--conflicts` as an overlap-only list should migrate to `conflicting_active`.

## Validation

- Exact candidate: `c6e8bb747133a285bcc7942345745ba6a8c42828`
- DB-backed three-lease unit: `all_active=3`, `conflicting_active=2`, `conflicts=1`
- Strengthened E2E: 20/20, including explicit empty-array shape checks and execution of the surfaced recovery command
- Focused serialization and help-snapshot tests
- Candidate build, focused rustfmt, `bash -n`, and `git diff --check`
- Fresh exact-SHA review quorum: Claude PASS, Grok PASS, Antigravity PASS

No service, database, or production Bifrost process was changed while preparing this PR.
