### PR TITLE
Reference patch for #203: publish archive-read builds on exact-generation stability only

### DIFF
--- a/crates/mcp-agent-mail-tools/src/archive_read.rs
+++ b/crates/mcp-agent-mail-tools/src/archive_read.rs
@@ -804,7 +804,15 @@ fn run_build(slot: &Slot, database_url: &str, build: &Build) -> Result<BuildOutp
         }
         let after = exact_generation(&slot.scope, build.deadline)?;
         let cheap_after = cheap_generation(&slot.scope, build.deadline)?;
-        if before == after && cheap_before == cheap_after {
+        // Only the exact (content) generation is compared across the probe
+        // window: the snapshot decision itself opens the live database, and a
+        // FrankenSQLite open can perturb file metadata without changing
+        // content (observed on macOS/APFS: every open bumps the db mtime and
+        // checkpoints the WAL when it can), so a metadata-based cheap
+        // comparison spanning the probes never converges. The published cheap
+        // baseline is taken after the probes, so the ready fast-path stays
+        // stable until a durable write actually lands.
+        if before == after {
             return Ok(BuildOutput {
                 generation: after,
                 cheap: cheap_after,


### PR DESCRIPTION
Addresses #203.

I understand this project does not accept outside contributions and that PRs are not merged; this is offered purely as a reference diff for the maintainer to evaluate and reimplement independently. Feel free to close at will.

**Status: untested — code-inspection patch.** The repro and root-cause evidence in #203 are against the prebuilt aarch64-apple-darwin release binaries (building from source requires the patched sibling repos), so this diff has not been compiled or run.

## What it changes

`archive_read::run_build` currently requires both the exact (content) and cheap (metadata) generations to be identical across its snapshot-decision probes before publishing. The probes themselves open the live database, and on macOS/APFS a FrankenSQLite open bumps the db file's mtime on every open without changing content (#203, evidence items 2–4), so the cheap comparison never converges inside a serving daemon: every build returns Busy, `acquire_if_needed` re-claims in a tight loop, and every DB-read tool call burns the full 30 s dispatch budget.

The change publishes on exact-generation stability alone (`before == after` — content hashes, which the evidence shows are byte-stable across the probe window) and records the **post-probe** cheap generation as the ready-revalidation baseline. The ready fast-path performs no live-db opens, so that baseline stays stable until a durable write lands — at which point the writer-epoch/archive-epoch checks already invalidate the entry regardless.

`cheap_before` remains in use by the ready-shortcut arm inside `run_build`, where no probes run between the two cheap reads, so that comparison is still sound.

## What it deliberately does not do

- No change to the generation definitions, the epoch/invalidation machinery, `finish_build` publication fencing, or the #198 contract's fail-closed behavior for genuine archive/live movement.
- Does not touch the 30 s dispatch timeout vs 120 s `BUILD_TIMEOUT` mismatch or the 1 s `EXACT_AUDIT_INTERVAL` hot-path probing noted at the end of #203 — both are separable.
