### PR TITLE
Reference patch for #204: make reply_message tolerate forked project rows for one identity

### DIFF
--- a/crates/mcp-agent-mail-tools/src/messaging.rs
+++ b/crates/mcp-agent-mail-tools/src/messaging.rs
@@ -2413,15 +2413,34 @@ effective_free_bytes={free}"
         mcp_agent_mail_db::queries::get_message(ctx.cx(), &pool, message_id).await,
     )?;
     if original.project_id != project_id {
-        return Err(legacy_tool_error(
-            "NOT_FOUND",
-            format!("Message not found: {message_id}"),
-            true,
-            json!({
-                "entity": "Message",
-                "identifier": message_id,
-            }),
-        ));
+        // The message may hang off a forked row for the same project identity
+        // (case-variant or reassigned project ids: #186/#187/#194). Every other
+        // message surface scopes by agent/recipient rather than project-row
+        // equality, so compare project identity, not row id, before rejecting.
+        let owner_is_alias = match mcp_agent_mail_db::queries::get_project_by_id(
+            ctx.cx(),
+            &pool,
+            original.project_id,
+        )
+        .await
+        {
+            Outcome::Ok(owner) => {
+                owner.slug == project.slug
+                    || owner.human_key.eq_ignore_ascii_case(&project.human_key)
+            }
+            _ => false,
+        };
+        if !owner_is_alias {
+            return Err(legacy_tool_error(
+                "NOT_FOUND",
+                format!("Message not found: {message_id}"),
+                true,
+                json!({
+                    "entity": "Message",
+                    "identifier": message_id,
+                }),
+            ));
+        }
     }
 
     // Resolve importance: use override if provided, otherwise inherit from original.


### PR DESCRIPTION
Addresses #204.

I understand this project does not accept outside contributions and that PRs are not merged; this is offered purely as a reference diff for the maintainer to evaluate and reimplement independently. Feel free to close at will.

**Status: untested — code-inspection patch.** The repro evidence in #204 is against the prebuilt aarch64-apple-darwin release binaries (v0.3.21 and v0.3.22), so this diff has not been compiled or run.

## What it changes

`reply_message` is the only message surface that requires the original message's `project_id` to equal the row id returned by `resolve_project(project_key)`; `fetch_inbox` and `mark_message_read` scope through agent/recipient ids instead. When identity forking duplicates rows for one canonical project key (case-variant keys, reconstruct-reassigned ids — the #186/#187/#194 class, observed live on a fresh v0.3.21 mailbox in #204), that strict row-id equality rejects messages every other tool resolves, surfacing as `Message not found: N` for ids `fetch_inbox` just returned.

On a row-id mismatch, the patch loads the owning project row via the existing `queries::get_project_by_id` and accepts the reply when it aliases the requested project identity — same `slug`, or case-insensitively equal `human_key` (the #194 collapse semantics). Any other mismatch still returns the existing NOT_FOUND error unchanged.

## What it deliberately does not do

- No change to the underlying id-allocation/continuity behavior (the fresh-mailbox trigger already appears fixed at HEAD by the #186/#187/#191 wave); this only stops mailboxes that already carry forked rows from failing on the reply path.
- Does not alter the error payload shape; #204 separately suggests making the mismatch error name the owning project row, which would be a one-line follow-up here if wanted.
