### PR TITLE
fix(doctor): complete MCP self-test lifecycle

### DIFF
--- a/crates/mcp-agent-mail-cli/src/doctor/selftest.rs
+++ b/crates/mcp-agent-mail-cli/src/doctor/selftest.rs
@@ -1194,11 +1194,8 @@ fn run_mcp_session(project_key: &str) -> Result<Vec<Value>, String> {
 
     let requests = vec![
         serde_json::to_vec(&build_initialize_request(1)),
-        serde_json::to_vec(&JsonRpcRequest::notification(
-            "notifications/initialized",
-            None,
-        )),
-        serde_json::to_vec(&JsonRpcRequest::new("tools/list", Some(json!({})), 2_i64)),
+        serde_json::to_vec(&JsonRpcRequest::initialized_notification()),
+        serde_json::to_vec(&JsonRpcRequest::new("tools/list", None, 2_i64)),
         serde_json::to_vec(&tools_call_request(
             "ensure_project",
             json!({ "human_key": project_key }),

--- a/crates/mcp-agent-mail-cli/src/doctor/selftest.rs
+++ b/crates/mcp-agent-mail-cli/src/doctor/selftest.rs
@@ -1194,8 +1194,11 @@ fn run_mcp_session(project_key: &str) -> Result<Vec<Value>, String> {
 
     let requests = vec![
         serde_json::to_vec(&build_initialize_request(1)),
-        serde_json::to_vec(&JsonRpcRequest::notification("initialized", None)),
-        serde_json::to_vec(&JsonRpcRequest::new("tools/list", None, 2_i64)),
+        serde_json::to_vec(&JsonRpcRequest::notification(
+            "notifications/initialized",
+            None,
+        )),
+        serde_json::to_vec(&JsonRpcRequest::new("tools/list", Some(json!({})), 2_i64)),
         serde_json::to_vec(&tools_call_request(
             "ensure_project",
             json!({ "human_key": project_key }),

--- a/crates/mcp-agent-mail-conformance/tests/protocol_compliance.rs
+++ b/crates/mcp-agent-mail-conformance/tests/protocol_compliance.rs
@@ -267,7 +267,7 @@ fn json_rpc_invariants_hold_across_stdio_and_http_round_trips() {
 #[test]
 fn notifications_do_not_emit_responses_across_transports() {
     let notifications = vec![
-        Payload::Json(JsonRpcRequest::notification("initialized", None)),
+        Payload::Json(JsonRpcRequest::initialized_notification()),
         Payload::Json(JsonRpcRequest::notification(
             "notifications/cancelled",
             Some(json!({"requestId": 7, "reason": "operator cancel"})),
@@ -312,7 +312,7 @@ fn error_shape_and_standard_codes_are_stable() {
                 transport,
                 vec![
                     Payload::Json(initialize_request("init-error-shape")),
-                    Payload::Json(JsonRpcRequest::notification("initialized", None)),
+                    Payload::Json(JsonRpcRequest::initialized_notification()),
                     Payload::Json(request.clone()),
                 ],
             );
@@ -444,7 +444,7 @@ fn transport_framing_and_utf8_round_trip_are_stable() {
 fn protocol_lifecycle_initialize_then_initialized_then_tools_list() {
     let payloads = vec![
         Payload::Json(initialize_request(1_i64)),
-        Payload::Json(JsonRpcRequest::notification("initialized", None)),
+        Payload::Json(JsonRpcRequest::initialized_notification()),
         Payload::Json(JsonRpcRequest::new("tools/list", None, 2_i64)),
     ];
 


### PR DESCRIPTION
Fixes #248.

`doctor mcp-selftest` now uses FastMCP's native `JsonRpcRequest::initialized_notification()` helper and the default `tools/list` request shape. The conformance lifecycle coverage uses the same helper, so the exercised sequence matches the protocol implementation rather than duplicating a legacy method literal.

This affects only the in-memory doctor probe and conformance fixtures; it does not change the writer or client-facing MCP transport.

Validation: `rustfmt --edition 2024 --check crates/mcp-agent-mail-cli/src/doctor/selftest.rs crates/mcp-agent-mail-conformance/tests/protocol_compliance.rs` and `git diff --check`.