### PR TITLE
fix(identity): release dead pane bindings safely

### DIFF
--- a/crates/mcp-agent-mail-cli/src/lib.rs
+++ b/crates/mcp-agent-mail-cli/src/lib.rs
@@ -2884,6 +2884,39 @@ pub enum AgentsCommand {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    /// Release a dead pane's identity binding (refuses live tmux panes).
+    Release {
+        /// Project key (slug or human_key / absolute path).
+        #[arg(long = "project", short = 'p')]
+        project_key: String,
+        /// Pane id to release (for example `%42`).
+        #[arg(long)]
+        pane: String,
+        /// Expected agent currently bound to the pane.
+        #[arg(long)]
+        agent: String,
+        /// Output format: table, json, or toon (default: auto-detect).
+        #[arg(long, value_parser)]
+        format: Option<output::CliOutputFormat>,
+        /// Output JSON (shorthand for --format json).
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Find stale pane bindings and release them only after direct tmux checks.
+    Sweep {
+        /// Project key (slug or human_key / absolute path).
+        #[arg(long = "project", short = 'p')]
+        project_key: String,
+        /// Apply releases. Without this flag, report live and abandoned rows only.
+        #[arg(long, default_value_t = false)]
+        yes: bool,
+        /// Output format: table, json, or toon (default: auto-detect).
+        #[arg(long, value_parser)]
+        format: Option<output::CliOutputFormat>,
+        /// Output JSON (shorthand for --format json).
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Create a new, unique agent identity (never updates existing).
     Create {
         /// Project key (slug or human_key / absolute path).
@@ -3484,6 +3517,7 @@ fn agents_command_is_read_only(action: &AgentsCommand) -> bool {
             | AgentsCommand::Show { .. }
             | AgentsCommand::Detect { .. }
             | AgentsCommand::ResolvePane { .. }
+            | AgentsCommand::Sweep { yes: false, .. }
     )
 }
 
@@ -37349,6 +37383,14 @@ async fn handle_agents_async(action: AgentsCommand) -> CliResult<()> {
 
             let resolved = candidate_keys.iter().find_map(|key| {
                 mcp_agent_mail_core::resolve_identity_with_binding(key, &effective_pane)
+                    .map(|(name, path, binding)| (name, path, binding.as_str().to_string()))
+            });
+
+            let resolved = resolved.or_else(|| {
+                candidate_keys.iter().find_map(|key| {
+                    mcp_agent_mail_core::resolve_released_identity(key, &effective_pane)
+                        .map(|(name, path)| (name, path, "released".to_string()))
+                })
             });
 
             let Some((agent_name, resolved_path, binding)) = resolved else {
@@ -37363,22 +37405,211 @@ async fn handle_agents_async(action: AgentsCommand) -> CliResult<()> {
             // file path or contents. GH#252 adds the binding status
             // (verified-live / adopted-dead / legacy-unverified) alongside it.
             let source = mcp_agent_mail_core::identity_source_category(&resolved_path);
-            let binding = binding.as_str();
             let data = serde_json::json!({
                 "schema_version": "am.agents.resolve-pane.v1",
                 "agent_name": agent_name,
+                "binding": &binding,
                 "pane_id": effective_pane,
                 "project_key": project_key,
                 "source": source,
-                "binding": binding,
             });
             output::emit_output(&data, fmt, || {
                 output::section("Pane Identity");
                 output::kv("Agent", &agent_name);
+                output::kv("Binding", &binding);
                 output::kv("Pane", &effective_pane);
                 output::kv("Project", &project_key);
                 output::kv("Source", source);
-                output::kv("Binding", binding);
+            });
+            Ok(())
+        }
+
+        AgentsCommand::Release {
+            project_key,
+            pane,
+            agent,
+            format,
+            json,
+        } => {
+            let fmt = output::CliOutputFormat::resolve(format, json);
+            let pane = pane.trim().to_string();
+            let agent = agent.trim().to_string();
+            if pane.is_empty() || agent.is_empty() {
+                return Err(CliError::InvalidArgument(
+                    "--pane and --agent must not be empty".into(),
+                ));
+            }
+
+            let mut candidate_keys = vec![project_key.clone()];
+            if !std::path::Path::new(&project_key).is_absolute()
+                && let Ok(ctx) = context::AsyncCliContext::open()
+            {
+                let cx = asupersync::Cx::for_request();
+                if let Ok(proj) = resolve_project_async(&cx, &ctx.pool, &project_key).await
+                    && proj.human_key != project_key
+                {
+                    candidate_keys.push(proj.human_key);
+                }
+            }
+            let release_key = candidate_keys
+                .iter()
+                .find(|key| mcp_agent_mail_core::resolve_identity(key, &pane).is_some())
+                .ok_or_else(|| {
+                    CliError::InvalidArgument(format!(
+                        "no identity registered for pane '{pane}' in project '{project_key}'"
+                    ))
+                })?;
+            let (released_agent, released_path) =
+                mcp_agent_mail_core::release_identity(release_key, &pane, &agent)
+                    .map_err(|error| CliError::InvalidArgument(error.to_string()))?;
+            let source = mcp_agent_mail_core::identity_source_category(&released_path);
+            let data = serde_json::json!({
+                "schema_version": "am.agents.release.v1",
+                "released": true,
+                "released_at": Utc::now().to_rfc3339(),
+                "agent_name": released_agent,
+                "pane_id": pane,
+                "state": "released",
+                "project_key": project_key,
+                "source": source,
+            });
+            output::emit_output(&data, fmt, || {
+                output::section("Pane Identity Released");
+                output::kv("Agent", &released_agent);
+                output::kv("Pane", &pane);
+                output::kv("Project", &project_key);
+                output::kv("Source", source);
+            });
+            Ok(())
+        }
+
+        AgentsCommand::Sweep {
+            project_key,
+            yes,
+            format,
+            json,
+        } => {
+            let fmt = output::CliOutputFormat::resolve(format, json);
+            let mut candidate_keys = vec![project_key.clone()];
+            if !std::path::Path::new(&project_key).is_absolute()
+                && let Ok(ctx) = context::AsyncCliContext::open()
+            {
+                let cx = asupersync::Cx::for_request();
+                if let Ok(proj) = resolve_project_async(&cx, &ctx.pool, &project_key).await
+                    && proj.human_key != project_key
+                {
+                    candidate_keys.push(proj.human_key);
+                }
+            }
+
+            let (release_key, bindings) = candidate_keys
+                .iter()
+                .find_map(|key| {
+                    let bindings = mcp_agent_mail_core::list_identities_with_paths(key);
+                    (!bindings.is_empty()).then_some((key.as_str(), bindings))
+                })
+                .unwrap_or((project_key.as_str(), Vec::new()));
+            let mut rows = Vec::with_capacity(bindings.len());
+            let mut live = 0_usize;
+            let mut abandoned = 0_usize;
+            let mut released = 0_usize;
+            let mut refused = 0_usize;
+
+            for (pane_id, agent_name, path) in bindings {
+                let source = mcp_agent_mail_core::identity_source_category(&path);
+                match mcp_agent_mail_core::identity_binding_state(&pane_id, &path) {
+                    Ok("verified-live" | "live-unverified") => {
+                        live += 1;
+                        rows.push(serde_json::json!({
+                            "agent_name": agent_name,
+                            "pane_id": pane_id,
+                            "state": "live",
+                            "source": source,
+                        }));
+                    }
+                    Ok("abandoned") if !yes => {
+                        abandoned += 1;
+                        rows.push(serde_json::json!({
+                            "agent_name": agent_name,
+                            "pane_id": pane_id,
+                            "state": "abandoned",
+                            "source": source,
+                        }));
+                    }
+                    Ok("abandoned") => match mcp_agent_mail_core::release_identity(
+                        release_key,
+                        &pane_id,
+                        &agent_name,
+                    ) {
+                        Ok((released_agent, released_path)) => {
+                            released += 1;
+                            rows.push(serde_json::json!({
+                                "schema_version": "am.agents.release.v1",
+                                "released": true,
+                                "released_at": Utc::now().to_rfc3339(),
+                                "agent_name": released_agent,
+                                "pane_id": pane_id,
+                                "state": "released",
+                                "project_key": project_key,
+                                "source": mcp_agent_mail_core::identity_source_category(
+                                    &released_path
+                                ),
+                            }));
+                        }
+                        Err(error) => {
+                            refused += 1;
+                            rows.push(serde_json::json!({
+                                "agent_name": agent_name,
+                                "pane_id": pane_id,
+                                "state": "refused",
+                                "source": source,
+                                "error": error.to_string(),
+                            }));
+                        }
+                    },
+                    Ok(state) => {
+                        refused += 1;
+                        rows.push(serde_json::json!({
+                            "agent_name": agent_name,
+                            "pane_id": pane_id,
+                            "state": "refused",
+                            "source": source,
+                            "error": format!("unknown binding state {state}"),
+                        }));
+                    }
+                    Err(error) => {
+                        refused += 1;
+                        rows.push(serde_json::json!({
+                            "agent_name": agent_name,
+                            "pane_id": pane_id,
+                            "state": "refused",
+                            "source": source,
+                            "error": error.to_string(),
+                        }));
+                    }
+                }
+            }
+
+            let data = serde_json::json!({
+                "schema_version": "am.agents.sweep.v1",
+                "applied": yes,
+                "project_key": project_key,
+                "counts": {
+                    "live": live,
+                    "abandoned": abandoned,
+                    "released": released,
+                    "refused": refused,
+                },
+                "bindings": rows,
+            });
+            output::emit_output(&data, fmt, || {
+                output::section("Pane Binding Sweep");
+                output::kv("Project", &project_key);
+                output::kv("Applied", if yes { "yes" } else { "no (preview)" });
+                output::kv("Live", &live.to_string());
+                output::kv("Abandoned", &abandoned.to_string());
+                output::kv("Released", &released.to_string());
+                output::kv("Refused", &refused.to_string());
             });
             Ok(())
         }
@@ -63050,6 +63281,93 @@ startup_timeout_sec = 42
             Commands::Agents {
                 action: AgentsCommand::ResolvePane { pane, .. },
             } => assert_eq!(pane, None),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_release_requires_expected_agent_and_is_write_classified() {
+        let cli = Cli::try_parse_from([
+            "am",
+            "agents",
+            "release",
+            "--project",
+            "/home/me/projects/foo",
+            "--pane",
+            "%42",
+            "--agent",
+            "BlueLake",
+            "--json",
+        ])
+        .expect("agents release must parse");
+        match cli.command.expect("expected command") {
+            Commands::Agents { action } => {
+                assert!(!agents_command_is_read_only(&action));
+                match action {
+                    AgentsCommand::Release {
+                        project_key,
+                        pane,
+                        agent,
+                        json,
+                        ..
+                    } => {
+                        assert_eq!(project_key, "/home/me/projects/foo");
+                        assert_eq!(pane, "%42");
+                        assert_eq!(agent, "BlueLake");
+                        assert!(json);
+                    }
+                    other => panic!("unexpected agents action: {other:?}"),
+                }
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agents_sweep_preview_is_read_only_and_yes_is_write_classified() {
+        let preview = Cli::try_parse_from([
+            "am",
+            "agents",
+            "sweep",
+            "--project",
+            "/home/me/projects/foo",
+            "--json",
+        ])
+        .expect("agents sweep preview must parse");
+        match preview.command.expect("expected preview command") {
+            Commands::Agents { action } => {
+                assert!(agents_command_is_read_only(&action));
+                match action {
+                    AgentsCommand::Sweep {
+                        project_key,
+                        yes,
+                        json,
+                        ..
+                    } => {
+                        assert_eq!(project_key, "/home/me/projects/foo");
+                        assert!(!yes);
+                        assert!(json);
+                    }
+                    other => panic!("unexpected agents action: {other:?}"),
+                }
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+
+        let apply = Cli::try_parse_from([
+            "am",
+            "agents",
+            "sweep",
+            "--project",
+            "/home/me/projects/foo",
+            "--yes",
+        ])
+        .expect("agents sweep apply must parse");
+        match apply.command.expect("expected apply command") {
+            Commands::Agents { action } => {
+                assert!(!agents_command_is_read_only(&action));
+                assert!(matches!(action, AgentsCommand::Sweep { yes: true, .. }));
+            }
             other => panic!("unexpected command: {other:?}"),
         }
     }

--- a/crates/mcp-agent-mail-core/src/lib.rs
+++ b/crates/mcp-agent-mail-core/src/lib.rs
@@ -196,11 +196,12 @@ pub use models::{
 pub use pane_identity::{
     PaneBindingLiveness, PaneBindingStatus, PaneIdentityRecord, binding_liveness,
     binding_liveness_with, canonical_identity_path, cleanup_all_stale_identities,
-    cleanup_stale_identities, get_composite_tmux_pane_id, identity_source_category,
-    is_agent_pane_command, list_identities, list_identities_with_paths, read_identity_record,
-    resolve_identity, resolve_identity_current_pane, resolve_identity_with_binding,
-    resolve_identity_with_optional_pane, resolve_identity_with_path, write_identity,
-    write_identity_current_pane, write_identity_with_optional_pane,
+    cleanup_stale_identities, get_composite_tmux_pane_id, identity_binding_state,
+    identity_source_category, is_agent_pane_command, list_identities, list_identities_with_paths,
+    read_identity_record, release_identity, resolve_identity, resolve_identity_current_pane,
+    resolve_identity_with_binding, resolve_identity_with_optional_pane, resolve_identity_with_path,
+    resolve_released_identity, tmux_pane_is_live, write_identity, write_identity_current_pane,
+    write_identity_with_optional_pane,
 };
 pub use search_types::{
     DateRange, DocChange, DocId, DocKind, Document, ExplainComposerConfig, ExplainReasonCode,

--- a/crates/mcp-agent-mail-core/src/pane_identity.rs
+++ b/crates/mcp-agent-mail-core/src/pane_identity.rs
@@ -581,6 +581,7 @@ fn tmux_pane_is_live_with_socket(
     Ok(false)
 }
 
+#[allow(clippy::literal_string_with_formatting_args)] // tmux interpolation syntax, not Rust format syntax
 fn tmux_server_has_pane(pane_id: &str, socket: Option<&Path>) -> std::io::Result<bool> {
     let mut command = tmux_command();
     if let Some(socket) = socket {
@@ -794,6 +795,7 @@ fn binding_release_liveness(pane_id: &str, content: Option<&str>) -> std::io::Re
     }
 }
 
+#[allow(clippy::literal_string_with_formatting_args)] // tmux interpolation syntax, not Rust format syntax
 fn tmux_server_binding_generation(
     pane_id: &str,
     socket: Option<&Path>,
@@ -1125,7 +1127,7 @@ fn release_resolved_identity(
     // subsequent live check restores the exact inode we moved (or leaves a
     // concurrently written replacement in place). This closes the
     // check-then-unlink race that could otherwise delete a new live binding.
-    let anchored = AnchoredIdentity::open(&path)?;
+    let anchored = AnchoredIdentity::open(path)?;
     let source_name = anchored.file_name.clone();
     let already_pending = is_release_pending_name(&source_name);
     let quarantine_name = if already_pending {
@@ -1134,7 +1136,7 @@ fn release_resolved_identity(
         let mut random = [0_u8; 16];
         getrandom::fill(&mut random)
             .map_err(|error| std::io::Error::other(format!("randomness failed: {error}")))?;
-        let nonce: String = random.iter().map(|byte| format!("{byte:02x}")).collect();
+        let nonce = hex::encode(random);
         let file_name = source_name.to_string_lossy();
         std::ffi::OsString::from(format!(
             ".{file_name}.release-{}-{nonce}",
@@ -1147,7 +1149,7 @@ fn release_resolved_identity(
     }
 
     let quarantined_content = anchored.read(&quarantine_name).ok();
-    let quarantined_agent = quarantined_content.clone().and_then(parse_identity);
+    let quarantined_agent = quarantined_content.as_deref().and_then(parse_identity);
     let live_after_quarantine =
         match binding_release_liveness(pane_id, quarantined_content.as_deref()) {
             Ok(live) => live,
@@ -1564,9 +1566,8 @@ fn cleanup_identity_directory(project_dir: &Path) -> Vec<PathBuf> {
             continue;
         }
         let pending = pending_original_name(&raw_name);
-        let filename_pane_id = pending
-            .map(str::to_owned)
-            .unwrap_or_else(|| raw_name.to_string_lossy().into_owned());
+        let filename_pane_id =
+            pending.map_or_else(|| raw_name.to_string_lossy().into_owned(), str::to_owned);
         let path = entry.path();
         // agent-factory-3tf: report/act on the pane id a caller can hand back
         // to resolve-pane and release (`%99`), not the sanitized on-disk file
@@ -1641,9 +1642,8 @@ pub fn list_identities_with_paths(project_key: &str) -> Vec<(String, String, Pat
             continue;
         }
         let pending = pending_original_name(&raw_name);
-        let filename_pane_id = pending
-            .map(str::to_owned)
-            .unwrap_or_else(|| raw_name.to_string_lossy().into_owned());
+        let filename_pane_id =
+            pending.map_or_else(|| raw_name.to_string_lossy().into_owned(), str::to_owned);
         let path = entry.path();
         // agent-factory-3tf: report/act on the pane id a caller can hand back
         // to resolve-pane and release (`%99`), not the sanitized on-disk file
@@ -1736,7 +1736,7 @@ fn ensure_real_directory(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn parse_identity(content: String) -> Option<String> {
+fn parse_identity(content: &str) -> Option<String> {
     let trimmed = content.trim().to_string();
     if trimmed.is_empty() {
         return None;
@@ -1868,7 +1868,7 @@ fn resolve_unique_v1_by_bare_pane(
         if !pane_ids_are_authoritatively_compatible(pane_id, &binding.tmux_pane_id) {
             continue;
         }
-        let name = parse_identity(content)?;
+        let name = parse_identity(&content)?;
         if match_found.is_some() {
             return None;
         }
@@ -2183,7 +2183,7 @@ fn resolve_released_by_bare_pane(project_key: &str, pane_id: &str) -> Option<(St
         if !pane_ids_are_authoritatively_compatible(pane_id, &generation.tmux_pane_id) {
             continue;
         }
-        let Some(name) = parse_identity(content) else {
+        let Some(name) = parse_identity(&content) else {
             continue;
         };
         let modified = entry
@@ -2442,7 +2442,7 @@ fn record_from_facts(
         record.socket_device = Some(generation.socket_device);
         record.socket_inode = Some(generation.socket_inode);
         record.server_pid = Some(generation.server_pid);
-        record.tmux_pane_id = Some(generation.tmux_pane_id.clone());
+        record.tmux_pane_id = Some(generation.tmux_pane_id);
     }
     record
 }
@@ -2577,10 +2577,8 @@ fn identity_entry_is_stale(entry: &std::fs::DirEntry, live_panes: &[String]) -> 
         .as_deref()
         .and_then(parse_binding_generation)
     {
-        return match binding_generation_is_live(&generation.tmux_pane_id, Some(&generation)) {
-            Ok(live) => !live,
-            Err(_) => false,
-        };
+        return binding_generation_is_live(&generation.tmux_pane_id, Some(&generation))
+            .is_ok_and(|live| !live);
     }
 
     let record = read_identity_record(&path);
@@ -2606,8 +2604,7 @@ fn identity_entry_is_stale(entry: &std::fs::DirEntry, live_panes: &[String]) -> 
 
 fn file_name_matches_live_pane(file_name: &OsStr, live_panes: &[String]) -> bool {
     let key = pending_original_name(file_name)
-        .map(str::to_owned)
-        .unwrap_or_else(|| file_name.to_string_lossy().into_owned());
+        .map_or_else(|| file_name.to_string_lossy().into_owned(), str::to_owned);
     live_panes
         .iter()
         .any(|pane| sanitize_pane_id(pane) == key || pane.trim() == key)
@@ -3230,6 +3227,7 @@ mod tests {
             Some("BlueLake")
         );
         assert!(resolve_identity(&project, "foo@bar:1:1").is_none());
+        drop(config);
     }
 
     #[test]
@@ -3867,14 +3865,17 @@ mod tests {
         std::fs::rename(&global, &global_pending).expect("quarantine global identity");
         set_test_live_tmux_panes(Some(vec!["42".to_string()]));
 
-        assert!(cleanup_stale_identities(&scoped_project).is_empty());
+        assert_eq!(
+            cleanup_stale_identities(&scoped_project),
+            Vec::<PathBuf>::new()
+        );
         assert!(scoped_pending.exists());
         assert_eq!(
             list_identities(&scoped_project),
             vec![("%42".to_string(), "BlueLake".to_string())]
         );
 
-        assert!(cleanup_all_stale_identities().is_empty());
+        assert_eq!(cleanup_all_stale_identities(), Vec::<PathBuf>::new());
         assert!(scoped_pending.exists());
         assert!(global_pending.exists());
         drop(config);
@@ -3913,7 +3914,7 @@ mod tests {
         let binding = write_identity(&project, "%42", "BlueLake").expect("write identity binding");
         let _tmux = LiveTmuxPanesGuard::new(vec!["__QUERY_ERROR__".to_string()]);
 
-        assert!(cleanup_stale_identities(&project).is_empty());
+        assert_eq!(cleanup_stale_identities(&project), Vec::<PathBuf>::new());
         assert!(binding.exists());
         drop(config);
     }
@@ -3932,7 +3933,7 @@ mod tests {
         );
         let _tmux = LiveTmuxPanesGuard::new(vec![pane.to_string()]);
 
-        assert!(cleanup_stale_identities(&project).is_empty());
+        assert_eq!(cleanup_stale_identities(&project), Vec::<PathBuf>::new());
         assert!(binding.exists());
         drop(config);
     }
@@ -5313,7 +5314,7 @@ mod tests {
     /// default socket?". That is not this binding's liveness: pane ids are
     /// global per tmux server and get reissued across sockets, so the answer
     /// was about a different server as often as not. A decorrelated review
-    /// (StormyOsprey, FAIL, 191253a) rode that arm to release LIVE panes six
+    /// (`StormyOsprey`, FAIL, 191253a) rode that arm to release LIVE panes six
     /// times. The 70-of-81 legacy population is exactly the input that reached
     /// it, so the refusal is asserted here directly rather than left implied by
     /// the tests that happen to route around it.

--- a/crates/mcp-agent-mail-core/src/pane_identity.rs
+++ b/crates/mcp-agent-mail-core/src/pane_identity.rs
@@ -611,11 +611,59 @@ fn tmux_server_has_pane(pane_id: &str, socket: Option<&Path>) -> std::io::Result
     }))
 }
 
+/// Test-only stand-in for a real tmux server generation.
+///
+/// agent-factory-3tf: before steer 1 the unit suite could only ever produce
+/// *unevidenced* rows, because liveness was injected at `tmux_pane_is_live` while
+/// generation capture went to a deliberately-absent tmux binary. Every release
+/// test therefore exercised the legacy fall-through and none of them exercised
+/// the path production actually uses. Synthesising one stable generation here,
+/// and honouring the injected inventory in `tmux_server_binding_generation`,
+/// moves the whole suite onto the evidenced path. Rows that must stay legacy are
+/// written directly by `write_legacy_fixture`, not through this.
+#[cfg(test)]
+fn test_generation_socket() -> &'static Path {
+    static SOCKET: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    SOCKET.get_or_init(|| {
+        let path = std::env::temp_dir().join(format!(
+            "am-test-generation-socket-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::write(&path, b"");
+        path
+    })
+}
+
+#[cfg(test)]
+fn test_binding_generation(pane_id: &str) -> Option<BindingGeneration> {
+    use std::os::unix::fs::MetadataExt as _;
+    let socket = test_generation_socket();
+    let metadata = std::fs::metadata(socket).ok()?;
+    let requested = pane_id.trim();
+    if requested.is_empty() {
+        return None;
+    }
+    Some(BindingGeneration {
+        pane_id: requested.to_string(),
+        socket_path: socket.to_path_buf(),
+        socket_device: metadata.dev(),
+        socket_inode: metadata.ino(),
+        server_pid: 424_242,
+        // Keep the injected inventory the single source of liveness truth:
+        // `tmux_pane_ids_match` already understands composite/bare aliasing, so
+        // carrying the requested key here preserves the existing match
+        // semantics exactly.
+        tmux_pane_id: requested.to_string(),
+    })
+}
+
 fn capture_binding_generation(pane_id: &str) -> std::io::Result<Option<BindingGeneration>> {
     #[cfg(test)]
-    if test_live_tmux_panes().is_some() {
-        // Unit tests inject liveness independently of a real tmux server.
-        return Ok(None);
+    if crate::config::process_env_value("AM_TEST_TMUX_BIN")
+        .is_none_or(|value| value.trim().is_empty()) {
+        // Unit tests have no tmux server. Record the same evidence a real
+        // registration would, so the suite exercises the evidenced path.
+        return Ok(test_binding_generation(pane_id));
     }
 
     // A registration request carries only a pane id, not a trusted tmux
@@ -680,7 +728,66 @@ fn binding_generation_is_live(
             }
             tmux_binding_generation_matches(expected)
         }
-        None => tmux_pane_is_live(pane_id),
+        // agent-factory-3tf, binding steer 1: an unevidenced row is REFUSED,
+        // never grandfathered.
+        //
+        // This arm used to fall through to `tmux_pane_is_live(pane_id)`, which
+        // asks "is SOME pane with this bare id alive on the default socket?".
+        // That is not the question the release gate needs answered. Pane ids
+        // are global per tmux server and are reissued across sockets, so the
+        // fall-through happily reported a DIFFERENT server's live pane as this
+        // binding's liveness -- and, worse, reported dead whenever the id had
+        // been recycled away, which is how a decorrelated review (StormyOsprey,
+        // FAIL, 191253a) reproduced release of LIVE panes 6 times.
+        //
+        // The legacy population this arm served is the 70-of-81 rows written
+        // before `am.pane-binding.v1`. They are not grandfathered: a row that
+        // cannot prove which tmux server generation it belongs to cannot be
+        // proven dead, and a destructive gate that cannot prove death must not
+        // fire. Unknown is an error here, exactly as a failed tmux query is.
+        // Re-registration rewrites such a row with evidence; that is the
+        // recovery path, not a silent release.
+        None => Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing to release pane {pane_id}: binding carries no \
+                 {BINDING_SCHEMA_V1} generation evidence, so it cannot be \
+                 proven dead"
+            ),
+        )),
+    }
+}
+
+/// Release-time liveness, decided on whatever evidence the row actually carries.
+///
+/// agent-factory-3tf, binding steer 1. A destructive release must never fire on
+/// an absence of information, so this returns three outcomes, not two:
+///
+/// * `Ok(true)`  -- proven LIVE. Refuse.
+/// * `Ok(false)` -- proven DEAD. Release may proceed.
+/// * `Err(..)`   -- UNPROVABLE. Refuse, fail closed.
+///
+/// The tiers, strongest evidence first:
+///
+/// 1. An `am.pane-binding.v1` generation. This is the only evidence that
+///    identifies the tmux *server* the binding belongs to, so it is the only
+///    one immune to a pane id being reissued on a different socket.
+/// 2. A GH#252 structured record. Its own `binding_liveness` predicate is real
+///    evidence -- recorded socket gone, or session/pid/command checked against
+///    the recorded socket -- and is reused verbatim rather than reimplemented.
+///    Its `Unverifiable` verdict is deliberately NOT read as dead.
+/// 3. Anything else -- the bare `Name\n` legacy file, which is the 70-of-81
+///    population. It carries no evidence at all and is REFUSED, never
+///    grandfathered. Its heal path is re-registration, which overwrites an
+///    unverifiable row (see `write_identity`) and now records evidence.
+fn binding_release_liveness(pane_id: &str, content: Option<&str>) -> std::io::Result<bool> {
+    if let Some(generation) = content.and_then(parse_binding_generation) {
+        return binding_generation_is_live(pane_id, Some(&generation));
+    }
+    match content.and_then(parse_identity_record).as_ref().map(binding_liveness) {
+        Some(PaneBindingLiveness::Live) => Ok(true),
+        Some(PaneBindingLiveness::Dead) => Ok(false),
+        _ => binding_generation_is_live(pane_id, None),
     }
 }
 
@@ -688,6 +795,30 @@ fn tmux_server_binding_generation(
     pane_id: &str,
     socket: Option<&Path>,
 ) -> std::io::Result<Option<BindingGeneration>> {
+    #[cfg(test)]
+    if let Some(panes) = test_live_tmux_panes() {
+        let call = TEST_TMUX_QUERY_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if panes.iter().any(|candidate| candidate == "__QUERY_ERROR__") {
+            return Err(std::io::Error::other("injected tmux liveness failure"));
+        }
+        if call >= 1
+            && panes
+                .iter()
+                .any(|candidate| candidate == "__QUERY_ERROR_AFTER_1__")
+        {
+            return Err(std::io::Error::other("injected late tmux liveness failure"));
+        }
+        let live = panes.iter().any(|candidate| {
+            candidate
+                .strip_prefix("__LIVE_AFTER_1__:")
+                .map_or_else(
+                    || tmux_pane_ids_match(pane_id, candidate.trim()),
+                    |candidate| call >= 1 && tmux_pane_ids_match(pane_id, candidate),
+                )
+        });
+        return Ok(live.then(|| test_binding_generation(pane_id)).flatten());
+    }
+
     let mut command = tmux_command();
     if let Some(socket) = socket {
         command.arg("-S").arg(socket);
@@ -980,17 +1111,8 @@ fn release_resolved_identity(
         .into_iter()
         .filter_map(|pending| pending.file_name().map(OsStr::to_os_string))
         .collect();
-    let recorded_generation = read_identity_file_no_follow(path)
-        .ok()
-        .and_then(|content| parse_binding_generation(&content));
-    #[cfg(not(target_os = "linux"))]
-    if recorded_generation.is_none() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "refusing to release an unnamespaced legacy pane binding on this platform",
-        ));
-    }
-    if binding_generation_is_live(pane_id, recorded_generation.as_ref())? {
+    let recorded_content = read_identity_file_no_follow(path).ok();
+    if binding_release_liveness(pane_id, recorded_content.as_deref())? {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
             format!("refusing to release recycled live tmux pane {pane_id}"),
@@ -1025,11 +1147,8 @@ fn release_resolved_identity(
 
     let quarantined_content = anchored.read(&quarantine_name).ok();
     let quarantined_agent = quarantined_content.clone().and_then(parse_identity);
-    let quarantined_generation = quarantined_content
-        .as_deref()
-        .and_then(parse_binding_generation);
     let live_after_quarantine =
-        match binding_generation_is_live(pane_id, quarantined_generation.as_ref()) {
+        match binding_release_liveness(pane_id, quarantined_content.as_deref()) {
             Ok(live) => live,
             Err(error) => {
                 if !already_pending {
@@ -2253,24 +2372,41 @@ fn record_from_facts(
     identity_key: &str,
     facts: Option<&TargetPaneFacts>,
 ) -> PaneIdentityRecord {
-    let Some(f) = facts else {
-        let mut record = PaneIdentityRecord::bare(name);
-        record.identity_key = Some(identity_key.trim().to_string());
-        return record;
-    };
-
     // agent-factory-3tf: the GH#252 writer recorded only the "is an agent
     // running here" facts, which left `parse_binding_generation` returning
     // None for every row production wrote. That silently downgraded the
-    // destructive release gate to the `tmux_pane_is_live` fallback — the
+    // destructive release gate to the `tmux_pane_is_live` fallback -- the
     // exact path that was proven to grant release of LIVE panes. The write
     // path therefore captures the server generation too, and a row that
     // cannot capture one unambiguously stays deliberately non-authoritative
     // (schema_version absent -> live-unverified, never verified-live).
+    //
+    // The two evidence sets are INDEPENDENT and neither gates the other.
+    // GH#252's facts come from `display-message -t <pane>` ("is an agent
+    // running in this pane"); the generation comes from `list-panes -a`
+    // ("which tmux server does this pane belong to"). Either query can fail
+    // while the other succeeds, so capturing the generation must not sit
+    // behind the facts. It did, and that is why a row with no facts was
+    // written unevidenced and then became unreleasable under steer 1.
     let generation = capture_binding_generation(identity_key)
         .ok()
         .flatten()
         .filter(|generation| binding_authorizes_pane(generation, identity_key));
+
+    let Some(f) = facts else {
+        let mut record = PaneIdentityRecord::bare(name);
+        record.identity_key = Some(identity_key.trim().to_string());
+        if let Some(generation) = generation {
+            record.schema_version = Some(BINDING_SCHEMA_V1.to_string());
+            record.pane_id = Some(generation.pane_id.clone());
+            record.socket_path = Some(generation.socket_path.to_string_lossy().into_owned());
+            record.socket_device = Some(generation.socket_device);
+            record.socket_inode = Some(generation.socket_inode);
+            record.server_pid = Some(generation.server_pid);
+            record.tmux_pane_id = Some(generation.tmux_pane_id);
+        }
+        return record;
+    };
 
     let mut record = PaneIdentityRecord {
         name: name.trim().to_string(),
@@ -2902,6 +3038,20 @@ mod tests {
         }
     }
 
+    /// A pre-`am.pane-binding.v1` row: a bare agent name and nothing else.
+    ///
+    /// agent-factory-3tf: `write_identity` now records generation evidence, so a
+    /// test that needs the LEGACY population must write it directly. Going
+    /// through the production path would quietly produce an evidenced row and
+    /// the test would stop testing what it names.
+    fn write_legacy_fixture(project: &str, pane_id: &str, agent: &str) -> PathBuf {
+        let path = canonical_identity_path(project, pane_id);
+        std::fs::create_dir_all(path.parent().expect("identity parent"))
+            .expect("create identity parent");
+        std::fs::write(&path, format!("{agent}\n")).expect("write legacy fixture");
+        path
+    }
+
     fn write_v1_fixture(project: &str, composite: &str, bare: &str, agent: &str) -> PathBuf {
         let path = canonical_identity_path(project, composite);
         std::fs::create_dir_all(path.parent().expect("identity parent"))
@@ -3270,7 +3420,7 @@ mod tests {
         let config = IsolatedConfigBaseDir::new();
         let project = config.project_key("legacy-live-state");
         let tmux = LiveTmuxPanesGuard::new(vec!["%42".into()]);
-        let path = write_identity(&project, "%42", "BlueLake").expect("write legacy binding");
+        let path = write_legacy_fixture(&project, "%42", "BlueLake");
 
         assert_eq!(
             identity_binding_state("%42", &path).expect("classify binding"),
@@ -4896,13 +5046,21 @@ mod tests {
                     "dead structured record must be released with a receipt: {removed:?}"
                 );
                 assert!(!dead_path.exists(), "dead binding must no longer resolve");
+                // agent-factory-3tf, binding steer 1: this file used to be
+                // swept here. It carries no evidence at all, so the only thing
+                // that ever condemned it was "the host's live-pane inventory
+                // does not list this key" -- and that inventory does not cover
+                // the server the row belongs to. Sweeping on it is the
+                // grandfathering the steer removes. Retention is non-
+                // destructive and the row heals on re-registration.
                 assert!(
-                    contains_release_receipt_for(&removed, &legacy_stale_path),
-                    "stale legacy file must be released with a receipt: {removed:?}"
+                    !contains_release_receipt_for(&removed, &legacy_stale_path),
+                    "an unevidenced legacy row must never be swept on inventory \
+                     evidence alone: {removed:?}"
                 );
                 assert!(
-                    !legacy_stale_path.exists(),
-                    "stale legacy binding must no longer resolve"
+                    legacy_stale_path.exists(),
+                    "an unevidenced legacy row must be retained, not destroyed"
                 );
                 assert!(
                     live_path.exists(),
@@ -5017,8 +5175,14 @@ mod tests {
     }
 
     /// A record with a present socket that tmux cannot check (not executable)
-    /// is treated like a legacy file even when local panes exist: kept when
-    /// its file name matches a live pane key, purged otherwise.
+    /// is RETAINED whether or not its file name matches a live pane key.
+    ///
+    /// agent-factory-3tf, binding steer 1: upstream purged the non-matching one
+    /// on the strength of the host's live-pane inventory. "tmux could not be
+    /// executed" is the textbook unprovable case -- the process learned nothing
+    /// about this binding -- so a destructive sweep must not fire on it. Note
+    /// this is the same verdict `binding_liveness` already reaches on its own
+    /// (`Unverifiable`, explicitly not `Dead`); only the sweep disagreed.
     #[test]
     fn cleanup_applies_legacy_rule_to_uncheckable_structured_records() {
         let config = IsolatedConfigBaseDir::new();
@@ -5042,13 +5206,13 @@ mod tests {
         crate::config::with_process_env_overrides_for_test(&[("AM_TEST_TMUX_BIN", "")], || {
             let removed = cleanup_stale_identities(&project);
             assert!(
-                contains_release_receipt_for(&removed, &stale_path),
-                "uncheckable record not matching a live pane key must be released \
-                 with a receipt: {removed:?}"
+                removed.is_empty(),
+                "a sweep that cannot execute tmux must destroy nothing: {removed:?}"
             );
             assert!(
-                !stale_path.exists(),
-                "uncheckable stale binding must no longer resolve"
+                stale_path.exists(),
+                "an uncheckable record must be retained, not swept on inventory \
+                 evidence alone"
             );
             assert!(
                 kept_path.exists(),
@@ -5136,6 +5300,103 @@ mod tests {
                 assert!(record.is_verifiable());
             },
         );
+        drop(config);
+    }
+    /// agent-factory-3tf, binding steer 1: an unevidenced legacy binding is
+    /// REFUSED, not grandfathered.
+    ///
+    /// The old `None` arm answered "is SOME pane with this bare id alive on the
+    /// default socket?". That is not this binding's liveness: pane ids are
+    /// global per tmux server and get reissued across sockets, so the answer
+    /// was about a different server as often as not. A decorrelated review
+    /// (StormyOsprey, FAIL, 191253a) rode that arm to release LIVE panes six
+    /// times. The 70-of-81 legacy population is exactly the input that reached
+    /// it, so the refusal is asserted here directly rather than left implied by
+    /// the tests that happen to route around it.
+    #[test]
+    fn legacy_binding_without_generation_evidence_refuses_release() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("legacy-refusal-project");
+        let pane = "%42";
+        let path = write_legacy_fixture(&project, pane, "BlueLake");
+        // The inventory reports the pane as absent -- which under the old arm
+        // was read as "dead, go ahead and release".
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+
+        let error = release_identity(&project, pane, "BlueLake")
+            .expect_err("an unevidenced legacy binding must never be released");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains(BINDING_SCHEMA_V1),
+            "the refusal must name the missing evidence: {error}"
+        );
+        assert!(path.exists(), "a refused release must leave the row intact");
+        assert_eq!(resolve_identity(&project, pane).as_deref(), Some("BlueLake"));
+
+        // The heal path: re-registration overwrites the unverifiable row and
+        // records evidence, after which the row is releasable on its own terms.
+        write_identity(&project, pane, "BlueLake").expect("re-registration must heal the row");
+        let (agent, receipt) =
+            release_identity(&project, pane, "BlueLake").expect("healed row releases");
+        assert_eq!(agent, "BlueLake");
+        assert!(receipt.exists(), "release must leave a durable receipt");
+        drop(config);
+    }
+
+    /// agent-factory-3tf: a release is keyed on (project, pane), and a pane id
+    /// alone never reaches across projects.
+    ///
+    /// Pane ids are global per tmux server while Agent Mail scopes identity per
+    /// project, so the same `%N` legitimately names a different agent in each
+    /// project on this machine. Releasing one must leave the others untouched.
+    #[test]
+    fn release_is_scoped_to_its_project() {
+        let config = IsolatedConfigBaseDir::new();
+        let project_a = config.project_key("scope-project-a");
+        let project_b = config.project_key("scope-project-b");
+        let pane = "%42";
+        write_identity(&project_a, pane, "AgentA").expect("bind in project A");
+        let path_b = write_identity(&project_b, pane, "AgentB").expect("bind in project B");
+        assert_ne!(
+            canonical_identity_path(&project_a, pane),
+            canonical_identity_path(&project_b, pane),
+            "two projects must not share one identity file"
+        );
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+
+        release_identity(&project_a, pane, "AgentA").expect("release project A binding");
+
+        assert!(
+            resolve_identity(&project_a, pane).is_none(),
+            "project A binding must be gone"
+        );
+        assert!(path_b.exists(), "project B binding must survive untouched");
+        assert_eq!(
+            resolve_identity(&project_b, pane).as_deref(),
+            Some("AgentB"),
+            "a release in one project must never reach into another"
+        );
+        drop(config);
+    }
+
+    /// agent-factory-3tf: compare-and-release refuses when the caller names an
+    /// agent that does not hold the binding, so one agent cannot release
+    /// another's pane by guessing the id.
+    #[test]
+    fn release_refuses_when_named_agent_does_not_hold_the_binding() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("wrong-agent-project");
+        let pane = "%42";
+        let path = write_identity(&project, pane, "BlueLake").expect("write identity");
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+
+        let error = release_identity(&project, pane, "GreenHarbor")
+            .expect_err("a release naming the wrong agent must refuse");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(path.exists(), "the binding must survive a refused release");
+        assert_eq!(resolve_identity(&project, pane).as_deref(), Some("BlueLake"));
         drop(config);
     }
 }

--- a/crates/mcp-agent-mail-core/src/pane_identity.rs
+++ b/crates/mcp-agent-mail-core/src/pane_identity.rs
@@ -52,6 +52,11 @@ const IDENTITY_DIR_NAME: &str = "agent-mail/identity";
 /// How many hex chars of the project hash to use in the directory name.
 const PROJECT_HASH_LEN: usize = 12;
 
+/// Schema marker for rows carrying tmux server-generation evidence.
+/// `parse_binding_generation` requires it, so only rows that captured a
+/// complete, unambiguous generation may carry it (agent-factory-3tf).
+const BINDING_SCHEMA_V1: &str = "am.pane-binding.v1";
+
 /// tmux format used to probe a recorded binding's liveness on its own server.
 const LIVENESS_PROBE_FORMAT: &str = "#{session_name}\t#{pane_pid}\t#{pane_current_command}";
 
@@ -118,6 +123,27 @@ pub struct PaneIdentityRecord {
     /// RFC 3339 timestamp of the write.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub written_at: Option<String>,
+    /// `am.pane-binding.v1` marker when the row carries generation evidence
+    /// (agent-factory-3tf). Absent on rows written by the GH#252-only writer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<String>,
+    /// Identity key the row was written under (bare `%25` or composite
+    /// `session:window:pane`). Distinct from `pane_id`, whose meaning is
+    /// version-dependent; never probe tmux with this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_key: Option<String>,
+    /// Authoritative bare tmux pane id (`%25`) for this binding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tmux_pane_id: Option<String>,
+    /// `st_dev` of the tmux server socket, pinning the server generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub socket_device: Option<u64>,
+    /// `st_ino` of the tmux server socket, pinning the server generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub socket_inode: Option<u64>,
+    /// tmux server pid, pinning the server generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_pid: Option<u32>,
 }
 
 impl PaneIdentityRecord {
@@ -131,14 +157,35 @@ impl PaneIdentityRecord {
             pane_pid: None,
             socket_path: None,
             written_at: None,
+            schema_version: None,
+            identity_key: None,
+            tmux_pane_id: None,
+            socket_device: None,
+            socket_inode: None,
+            server_pid: None,
         }
+    }
+
+    /// Bare tmux pane id to probe tmux with.
+    ///
+    /// `tmux_pane_id` is authoritative when present. Rows written by the
+    /// GH#252-only writer put the bare id in `pane_id`, so that is the
+    /// fallback. A composite `pane_id` is NOT a valid tmux target and is
+    /// deliberately not returned here (agent-factory-3tf).
+    #[must_use]
+    pub fn probe_pane_id(&self) -> Option<&str> {
+        if let Some(bare) = self.tmux_pane_id.as_deref() {
+            return Some(bare);
+        }
+        let pane = self.pane_id.as_deref()?;
+        (!pane.contains(':')).then_some(pane)
     }
 
     /// Whether the record carries every fact the liveness predicate needs.
     #[must_use]
-    pub const fn is_verifiable(&self) -> bool {
+    pub fn is_verifiable(&self) -> bool {
         self.session_name.is_some()
-            && self.pane_id.is_some()
+            && self.probe_pane_id().is_some()
             && self.pane_pid.is_some()
             && self.socket_path.is_some()
     }
@@ -270,7 +317,7 @@ where
 {
     let (Some(session_name), Some(recorded_pane), Some(recorded_pid), Some(socket_path)) = (
         record.session_name.as_deref(),
-        record.pane_id.as_deref(),
+        record.probe_pane_id(),
         record.pane_pid,
         record.socket_path.as_deref(),
     ) else {
@@ -398,7 +445,7 @@ pub fn write_identity(
         && binding_liveness(&existing) == PaneBindingLiveness::Live
     {
         let same_holder = facts.as_ref().is_some_and(|f| {
-            existing.pane_id.as_deref() == Some(f.pane_id.as_str())
+            existing.probe_pane_id() == Some(f.pane_id.as_str())
                 && existing.socket_path.as_deref() == Some(f.socket_path.as_str())
         });
         if !same_holder {
@@ -414,7 +461,7 @@ pub fn write_identity(
         }
     }
 
-    let record = record_from_facts(agent_name, facts.as_ref());
+    let record = record_from_facts(agent_name, pane_id, facts.as_ref());
     write_record_content_no_follow(&path, &record)?;
     Ok(path)
 }
@@ -1063,6 +1110,19 @@ pub fn resolve_identity_with_binding(
         return Some(hit);
     }
 
+    // 1a. A release that was quarantined but not completed (the process died
+    //     inside the rename window) leaves the binding in a `.NAME.release-*`
+    //     sibling. That row still holds the binding, so it must stay
+    //     resolvable until a retry completes or restores it — otherwise a
+    //     crash mid-release silently orphans a live agent's identity.
+    //     Restored in agent-factory-3tf: the GH#252 merge dropped this step,
+    //     so every pending row resolved as NotFound.
+    for pending in pending_release_paths(&canonical_identity_path(project_key, pane_id)) {
+        if let Some(hit) = resolver.consider(pending) {
+            return Some(hit);
+        }
+    }
+
     // 1b. If pane_id is a composite key, try legacy bare $TMUX_PANE canonical path.
     //     A composite key contains `:`, e.g., `main:0:2`. The bare pane env var
     //     is something like `%3`. We check the env so we can find files written
@@ -1312,6 +1372,7 @@ fn cleanup_identity_directory(project_dir: &Path) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(project_dir) else {
         return Vec::new();
     };
+    let live_panes = list_live_tmux_panes();
     let mut bindings = std::collections::BTreeMap::new();
     for entry in entries.flatten() {
         if !dir_entry_is_real_file(&entry) {
@@ -1321,12 +1382,28 @@ fn cleanup_identity_directory(project_dir: &Path) -> Vec<PathBuf> {
         if is_released_name(&raw_name) {
             continue;
         }
+        // agent-factory-3tf: upstream decides WHICH rows are stale (liveness
+        // predicate, socket-gone rule, and the "retain everything when this
+        // host has no live panes" guard); 7x5 decides WHAT HAPPENS to a stale
+        // row (durable release receipt, never an unlink). Before this, the
+        // 7x5 merge released every row and delegated the decision entirely to
+        // the release gate, which tombstoned rows that were merely
+        // unverifiable and left `identity_entry_is_stale` with no callers.
+        if !identity_entry_is_stale(&entry, &live_panes) {
+            continue;
+        }
         let pending = pending_original_name(&raw_name);
         let filename_pane_id = pending
             .map(str::to_owned)
             .unwrap_or_else(|| raw_name.to_string_lossy().into_owned());
         let path = entry.path();
-        let pane_id = binding_pane_id(&path).unwrap_or(filename_pane_id);
+        // agent-factory-3tf: report/act on the pane id a caller can hand back
+        // to resolve-pane and release (`%99`), not the sanitized on-disk file
+        // name (`99`). The recorded identity key is authoritative; a v1 row's
+        // stored pane is next; the file name is the last resort.
+        let pane_id = recorded_identity_key(&path)
+            .or_else(|| binding_pane_id(&path))
+            .unwrap_or(filename_pane_id);
         if let Some(agent_name) = read_identity_file(&path) {
             let replace = bindings
                 .get(&pane_id)
@@ -1386,12 +1463,24 @@ pub fn list_identities_with_paths(project_key: &str) -> Vec<(String, String, Pat
         if is_released_name(&raw_name) {
             continue;
         }
+        // agent-factory-3tf: upstream skips every dotfile as an internal
+        // atomic-write artifact, but 7x5's pending-release rows are dotfiles
+        // that still hold a real binding. Skip artifacts, keep pending rows.
+        if pending_original_name(&raw_name).is_none() && identity_entry_is_internal(&entry) {
+            continue;
+        }
         let pending = pending_original_name(&raw_name);
         let filename_pane_id = pending
             .map(str::to_owned)
             .unwrap_or_else(|| raw_name.to_string_lossy().into_owned());
         let path = entry.path();
-        let pane_id = binding_pane_id(&path).unwrap_or(filename_pane_id);
+        // agent-factory-3tf: report/act on the pane id a caller can hand back
+        // to resolve-pane and release (`%99`), not the sanitized on-disk file
+        // name (`99`). The recorded identity key is authoritative; a v1 row's
+        // stored pane is next; the file name is the last resort.
+        let pane_id = recorded_identity_key(&path)
+            .or_else(|| binding_pane_id(&path))
+            .unwrap_or(filename_pane_id);
         if let Some(name) = read_identity_file(&path) {
             let replace = result
                 .get(&pane_id)
@@ -1492,7 +1581,7 @@ fn parse_identity(content: String) -> Option<String> {
 
 fn parse_binding_generation(content: &str) -> Option<BindingGeneration> {
     let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
-    if value.get("schema_version")?.as_str()? != "am.pane-binding.v1" {
+    if value.get("schema_version")?.as_str()? != BINDING_SCHEMA_V1 {
         return None;
     }
     let tmux_pane_id = value.get("tmux_pane_id")?.as_str()?.trim();
@@ -1512,16 +1601,76 @@ fn parse_binding_generation(content: &str) -> Option<BindingGeneration> {
 
 fn parse_binding_pane_id(content: &str) -> Option<String> {
     let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
-    if value.get("schema_version")?.as_str()? != "am.pane-binding.v1" {
+    if value.get("schema_version")?.as_str()? != BINDING_SCHEMA_V1 {
         return None;
     }
     let pane_id = value.get("pane_id")?.as_str()?.trim();
     (!pane_id.is_empty()).then(|| pane_id.to_string())
 }
 
+/// Query tmux for all live pane IDs (sanitized).
+///
+/// Returns composite keys (`session_name:window_index:pane_index`) for each
+/// live pane, plus the legacy bare pane ID (e.g., `%3` -> `3`) for backwards
+/// compatibility during cleanup. Returns an empty vec if tmux is not running
+/// or the command fails.
+///
+/// Restored in agent-factory-3tf: the 7x5 merge dropped this along with the
+/// staleness rule that consumes it.
+fn list_live_tmux_panes() -> Vec<String> {
+    #[cfg(test)]
+    if let Some(panes) = test_live_tmux_panes() {
+        return panes;
+    }
+
+    let output = tmux_command()
+        .args([
+            "list-panes",
+            "-a",
+            "-F",
+            "#{session_name}:#{window_index}:#{pane_index}:#{pane_id}",
+        ])
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            let mut ids = Vec::new();
+            for line in text.lines().filter(|l| !l.is_empty()) {
+                let line = line.trim();
+                // Parse "session:window:pane_idx:pane_id" format.
+                // The composite key is the first three fields joined by `:`.
+                // We also include the bare pane_id for backwards compat.
+                if let Some((composite, bare_id)) = line.rsplit_once(':') {
+                    ids.push(sanitize_pane_id(composite));
+                    ids.push(sanitize_pane_id(bare_id));
+                } else {
+                    // Fallback: treat the entire line as a bare pane ID
+                    ids.push(sanitize_pane_id(line));
+                }
+            }
+            ids.sort();
+            ids.dedup();
+            ids
+        }
+        _ => Vec::new(),
+    }
+}
+
 fn binding_pane_id(path: &Path) -> Option<String> {
     let content = read_identity_file_no_follow(path).ok()?;
     parse_binding_pane_id(&content)
+}
+
+/// Identity key a record was written under, when it recorded one.
+///
+/// Lets listings and cleanup report/act on the caller-facing pane id even
+/// when the file name had to be sanitized (agent-factory-3tf).
+fn recorded_identity_key(path: &Path) -> Option<String> {
+    let content = read_identity_file_no_follow(path).ok()?;
+    let value = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+    let key = value.get("identity_key")?.as_str()?.trim();
+    (!key.is_empty()).then(|| key.to_string())
 }
 
 fn resolve_unique_v1_by_bare_pane(
@@ -1998,36 +2147,77 @@ fn tmux_env_socket_path() -> Option<String> {
 }
 
 /// Build a structured record for `name` from optional target-pane facts.
-fn record_from_facts(name: &str, facts: Option<&TargetPaneFacts>) -> PaneIdentityRecord {
-    facts.map_or_else(
-        || PaneIdentityRecord::bare(name),
-        |f| PaneIdentityRecord {
-            name: name.trim().to_string(),
-            session_name: Some(f.session_name.clone()),
-            pane_id: Some(f.pane_id.clone()),
-            pane_pid: Some(f.pane_pid),
-            socket_path: if f.socket_path.is_empty() {
-                None
-            } else {
-                Some(f.socket_path.clone())
-            },
-            written_at: Some(chrono::Utc::now().to_rfc3339()),
+fn record_from_facts(
+    name: &str,
+    identity_key: &str,
+    facts: Option<&TargetPaneFacts>,
+) -> PaneIdentityRecord {
+    let Some(f) = facts else {
+        let mut record = PaneIdentityRecord::bare(name);
+        record.identity_key = Some(identity_key.trim().to_string());
+        return record;
+    };
+
+    // agent-factory-3tf: the GH#252 writer recorded only the "is an agent
+    // running here" facts, which left `parse_binding_generation` returning
+    // None for every row production wrote. That silently downgraded the
+    // destructive release gate to the `tmux_pane_is_live` fallback — the
+    // exact path that was proven to grant release of LIVE panes. The write
+    // path therefore captures the server generation too, and a row that
+    // cannot capture one unambiguously stays deliberately non-authoritative
+    // (schema_version absent -> live-unverified, never verified-live).
+    let generation = capture_binding_generation(identity_key)
+        .ok()
+        .flatten()
+        .filter(|generation| binding_authorizes_pane(generation, identity_key));
+
+    let mut record = PaneIdentityRecord {
+        name: name.trim().to_string(),
+        session_name: Some(f.session_name.clone()),
+        pane_id: Some(f.pane_id.clone()),
+        pane_pid: Some(f.pane_pid),
+        socket_path: if f.socket_path.is_empty() {
+            None
+        } else {
+            Some(f.socket_path.clone())
         },
-    )
+        written_at: Some(chrono::Utc::now().to_rfc3339()),
+        schema_version: None,
+        identity_key: Some(identity_key.trim().to_string()),
+        tmux_pane_id: Some(f.pane_id.clone()),
+        socket_device: None,
+        socket_inode: None,
+        server_pid: None,
+    };
+
+    if let Some(generation) = generation {
+        // v1 contract: `pane_id` is the composite tmux address that
+        // `binding_authorizes_pane` compares against, and `tmux_pane_id` is
+        // the bare id. `probe_pane_id()` keeps GH#252's liveness probe on the
+        // bare id, so both readers stay correct on one row.
+        record.schema_version = Some(BINDING_SCHEMA_V1.to_string());
+        record.pane_id = Some(generation.pane_id.clone());
+        record.socket_path = Some(generation.socket_path.to_string_lossy().into_owned());
+        record.socket_device = Some(generation.socket_device);
+        record.socket_inode = Some(generation.socket_inode);
+        record.server_pid = Some(generation.server_pid);
+        record.tmux_pane_id = Some(generation.tmux_pane_id.clone());
+    }
+    record
 }
 
 /// Best-effort adoption rewrite: bind `name` to the adopter's pane facts at
 /// the identity file that produced the candidate (upgrading legacy files to
 /// structured records in place). IO failures are ignored — adoption must not
 /// break resolution.
-fn adopt_record_at(path: &Path, name: &str, facts: &TargetPaneFacts) {
+fn adopt_record_at(path: &Path, name: &str, identity_key: &str, facts: &TargetPaneFacts) {
     if path_has_symlinked_parent(path).unwrap_or(true) {
         return;
     }
     if std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
         return;
     }
-    let record = record_from_facts(name, Some(facts));
+    let record = record_from_facts(name, identity_key, Some(facts));
     let _ = write_record_content_no_follow(path, &record);
 }
 
@@ -2069,7 +2259,7 @@ impl PaneBindingResolver {
         match binding_liveness(&record) {
             PaneBindingLiveness::Live => {
                 let holder_matches = self.target_facts().is_some_and(|f| {
-                    record.pane_id.as_deref() == Some(f.pane_id.as_str())
+                    record.probe_pane_id() == Some(f.pane_id.as_str())
                         && record.socket_path.as_deref() == Some(f.socket_path.as_str())
                 });
                 if holder_matches {
@@ -2080,7 +2270,7 @@ impl PaneBindingResolver {
             }
             PaneBindingLiveness::Dead => {
                 if let Some(facts) = self.target_facts().cloned() {
-                    adopt_record_at(&path, &record.name, &facts);
+                    adopt_record_at(&path, &record.name, &self.pane_arg.clone(), &facts);
                 }
                 Some((record.name, path, PaneBindingStatus::AdoptedDead))
             }
@@ -2099,7 +2289,7 @@ impl PaneBindingResolver {
                         Some((record.name, path, PaneBindingStatus::LegacyUnverified))
                     }
                     Some(facts) => {
-                        adopt_record_at(&path, &record.name, &facts);
+                        adopt_record_at(&path, &record.name, &self.pane_arg.clone(), &facts);
                         Some((record.name, path, PaneBindingStatus::AdoptedDead))
                     }
                     None => Some((record.name, path, PaneBindingStatus::LegacyUnverified)),
@@ -2126,6 +2316,24 @@ impl PaneBindingResolver {
 /// harmless to keep and become adoptable/purgeable once a local server runs.
 fn identity_entry_is_stale(entry: &std::fs::DirEntry, live_panes: &[String]) -> bool {
     let path = entry.path();
+
+    // agent-factory-3tf: a row carrying tmux server-generation evidence is
+    // judgeable on its own terms, so it does not need the legacy live-pane
+    // inventory. Upstream's "retain everything when this host reports no
+    // live panes" guard exists because an unverifiable row cannot be judged;
+    // a v1 row can. A failed tmux query stays fail-closed (retained), never
+    // read as evidence of absence.
+    if let Some(generation) = read_identity_file_no_follow(&path)
+        .ok()
+        .as_deref()
+        .and_then(parse_binding_generation)
+    {
+        return match binding_generation_is_live(&generation.tmux_pane_id, Some(&generation)) {
+            Ok(live) => !live,
+            Err(_) => false,
+        };
+    }
+
     let record = read_identity_record(&path);
     match record.as_ref().map(binding_liveness) {
         Some(PaneBindingLiveness::Live) => false,
@@ -3484,9 +3692,13 @@ mod tests {
             .map(|entry| entry.file_name().to_string_lossy().into_owned())
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["99"]);
+        // agent-factory-3tf: the on-disk FILE name stays sanitized ("99"),
+        // but the listing reports the pane id a caller can hand back to
+        // resolve-pane/release ("%99") under 7x5's semantics. The test's
+        // intent — exactly one complete visible record — is unchanged.
         assert_eq!(
             list_identities(&unique_key),
-            vec![("99".into(), "BlueLake".into())]
+            vec![("%99".into(), "BlueLake".into())]
         );
         drop(config);
     }
@@ -3508,7 +3720,7 @@ mod tests {
 
         assert_eq!(
             list_identities(&unique_key),
-            vec![("4".into(), "RedFox".into())]
+            vec![("%4".into(), "RedFox".into())]
         );
         drop(config);
     }
@@ -3865,6 +4077,7 @@ mod tests {
             pane_pid: Some(root_pid),
             socket_path: Some(socket.to_string()),
             written_at: Some("2026-08-20T09:00:00Z".to_string()),
+            ..PaneIdentityRecord::bare(name)
         })
         .expect("serialize record")
     }
@@ -3942,6 +4155,7 @@ mod tests {
             pane_pid: Some(3_452_123),
             socket_path: Some("/tmp/tmux-1000/default".to_string()),
             written_at: None,
+            ..PaneIdentityRecord::bare("AmberRabbit")
         }
     }
 

--- a/crates/mcp-agent-mail-core/src/pane_identity.rs
+++ b/crates/mcp-agent-mail-core/src/pane_identity.rs
@@ -625,10 +625,8 @@ fn tmux_server_has_pane(pane_id: &str, socket: Option<&Path>) -> std::io::Result
 fn test_generation_socket() -> &'static Path {
     static SOCKET: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
     SOCKET.get_or_init(|| {
-        let path = std::env::temp_dir().join(format!(
-            "am-test-generation-socket-{}",
-            std::process::id()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("am-test-generation-socket-{}", std::process::id()));
         let _ = std::fs::write(&path, b"");
         path
     })
@@ -660,7 +658,8 @@ fn test_binding_generation(pane_id: &str) -> Option<BindingGeneration> {
 fn capture_binding_generation(pane_id: &str) -> std::io::Result<Option<BindingGeneration>> {
     #[cfg(test)]
     if crate::config::process_env_value("AM_TEST_TMUX_BIN")
-        .is_none_or(|value| value.trim().is_empty()) {
+        .is_none_or(|value| value.trim().is_empty())
+    {
         // Unit tests have no tmux server. Record the same evidence a real
         // registration would, so the suite exercises the evidenced path.
         return Ok(test_binding_generation(pane_id));
@@ -784,7 +783,11 @@ fn binding_release_liveness(pane_id: &str, content: Option<&str>) -> std::io::Re
     if let Some(generation) = content.and_then(parse_binding_generation) {
         return binding_generation_is_live(pane_id, Some(&generation));
     }
-    match content.and_then(parse_identity_record).as_ref().map(binding_liveness) {
+    match content
+        .and_then(parse_identity_record)
+        .as_ref()
+        .map(binding_liveness)
+    {
         Some(PaneBindingLiveness::Live) => Ok(true),
         Some(PaneBindingLiveness::Dead) => Ok(false),
         _ => binding_generation_is_live(pane_id, None),
@@ -809,12 +812,10 @@ fn tmux_server_binding_generation(
             return Err(std::io::Error::other("injected late tmux liveness failure"));
         }
         let live = panes.iter().any(|candidate| {
-            candidate
-                .strip_prefix("__LIVE_AFTER_1__:")
-                .map_or_else(
-                    || tmux_pane_ids_match(pane_id, candidate.trim()),
-                    |candidate| call >= 1 && tmux_pane_ids_match(pane_id, candidate),
-                )
+            candidate.strip_prefix("__LIVE_AFTER_1__:").map_or_else(
+                || tmux_pane_ids_match(pane_id, candidate.trim()),
+                |candidate| call >= 1 && tmux_pane_ids_match(pane_id, candidate),
+            )
         });
         return Ok(live.then(|| test_binding_generation(pane_id)).flatten());
     }
@@ -4353,7 +4354,10 @@ mod tests {
     /// restart. 7x5 wins on the action, so these assertions check that the
     /// binding is gone AND that a receipt for it was returned.
     fn contains_release_receipt_for(removed: &[PathBuf], original: &Path) -> bool {
-        let Some(name) = original.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+        let Some(name) = original
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+        else {
             return false;
         };
         let prefix = format!(".{name}.released-");
@@ -5332,7 +5336,10 @@ mod tests {
             "the refusal must name the missing evidence: {error}"
         );
         assert!(path.exists(), "a refused release must leave the row intact");
-        assert_eq!(resolve_identity(&project, pane).as_deref(), Some("BlueLake"));
+        assert_eq!(
+            resolve_identity(&project, pane).as_deref(),
+            Some("BlueLake")
+        );
 
         // The heal path: re-registration overwrites the unverifiable row and
         // records evidence, after which the row is releasable on its own terms.
@@ -5396,7 +5403,10 @@ mod tests {
 
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
         assert!(path.exists(), "the binding must survive a refused release");
-        assert_eq!(resolve_identity(&project, pane).as_deref(), Some("BlueLake"));
+        assert_eq!(
+            resolve_identity(&project, pane).as_deref(),
+            Some("BlueLake")
+        );
         drop(config);
     }
 }

--- a/crates/mcp-agent-mail-core/src/pane_identity.rs
+++ b/crates/mcp-agent-mail-core/src/pane_identity.rs
@@ -439,6 +439,27 @@ pub fn write_identity(
 
     let facts = query_target_pane_facts(pane_id);
 
+    // agent-factory-3tf: refuse a lossy-sanitization collision BEFORE the
+    // liveness rule. Two different composite keys can sanitize to one file
+    // name, and the GH#252 rule only refuses a *verifiably live* holder --
+    // so without this an unverifiable row belonging to a different pane is
+    // silently overwritten and two panes share one identity file.
+    if let Some(existing_key) = read_identity_record(&path)
+        .as_ref()
+        .and_then(|record| record.identity_key.as_deref())
+        && identity_keys_collide_lossily(existing_key, pane_id)
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            format!(
+                "refusing to overwrite pane identity at {}: it is bound to key \
+                 '{existing_key}', which sanitizes to the same file name as \
+                 '{pane_id}' but is a different pane",
+                path.display()
+            ),
+        ));
+    }
+
     // GH#252: never overwrite a verifiably live binding held by another pane.
     if let Some(existing) = read_identity_record(&path)
         && existing.is_verifiable()
@@ -642,7 +663,23 @@ fn binding_generation_is_live(
     generation: Option<&BindingGeneration>,
 ) -> std::io::Result<bool> {
     match generation {
-        Some(expected) => tmux_binding_generation_matches(expected),
+        Some(expected) => {
+            // agent-factory-3tf: a tmux server's socket exists for as long as
+            // the server does, so its absence is positive evidence that this
+            // generation is gone -- the same rule GH#252's binding_liveness
+            // already applies to a recorded socket_path. Concluding DEAD here
+            // is what lets a genuinely dead binding be released on a host
+            // where tmux cannot be executed at all; without it the row stays
+            // poisoned forever, which is the bug this line exists to fix.
+            //
+            // This stays a DEAD-only shortcut. A tmux query that FAILS is
+            // still an error and never evidence of absence, so the release
+            // gate remains fail-closed everywhere else.
+            if !expected.socket_path.exists() {
+                return Ok(false);
+            }
+            tmux_binding_generation_matches(expected)
+        }
         None => tmux_pane_is_live(pane_id),
     }
 }
@@ -852,6 +889,20 @@ fn tmux_pane_id_is_exact_match(requested: &str, composite: &str, bare: &str) -> 
         (numeric_bare_pane(requested), numeric_bare_pane(bare)),
         (Some(left), Some(right)) if left == right
     )
+}
+
+/// Whether a stored identity key and a requested key are a lossy-sanitization
+/// collision: both composite, and different.
+///
+/// `foo bar:1:1` and `foo@bar:1:1` both sanitize to `foo_bar-1-1`, so the file
+/// name cannot tell them apart. The recorded `identity_key` can
+/// (agent-factory-3tf). Deliberately scoped to composite-vs-composite: a bare
+/// id resolving to its own composite key is normal recovery (GH#177 Defect 2),
+/// not a collision.
+fn identity_keys_collide_lossily(stored: &str, requested: &str) -> bool {
+    let stored = stored.trim();
+    let requested = requested.trim();
+    stored.contains(':') && requested.contains(':') && stored != requested
 }
 
 fn pane_ids_are_authoritatively_compatible(requested: &str, stored: &str) -> bool {
@@ -1969,10 +2020,60 @@ fn identity_sibling_paths(path: &Path, marker: &str) -> Vec<PathBuf> {
 /// Resolve the newest durable release receipt for a pane.
 #[must_use]
 pub fn resolve_released_identity(project_key: &str, pane_id: &str) -> Option<(String, PathBuf)> {
-    released_identity_paths(&canonical_identity_path(project_key, pane_id))
+    if let Some(hit) = released_identity_paths(&canonical_identity_path(project_key, pane_id))
         .into_iter()
         .rev()
         .find_map(|path| read_identity_record(&path).map(|record| (record.name, path)))
+    {
+        return Some(hit);
+    }
+
+    // agent-factory-3tf: a tombstone for a COMPOSITE-keyed row is a sibling of
+    // that composite file name, so a lookup by the bare id misses it entirely
+    // -- the same gap resolve_unique_v1_by_bare_pane already closes for live
+    // rows. Recover it by the bare id recorded in the receipt's own
+    // generation. Newest wins, matching the canonical path above: a tombstone
+    // records who WAS released, it never grants authority to bind.
+    if pane_id.contains(':') {
+        return None;
+    }
+    resolve_released_by_bare_pane(project_key, pane_id)
+}
+
+/// Newest release receipt whose recorded generation names `pane_id`.
+fn resolve_released_by_bare_pane(project_key: &str, pane_id: &str) -> Option<(String, PathBuf)> {
+    let project_dir = config_base_dir()
+        .join(IDENTITY_DIR_NAME)
+        .join(project_hash(project_key));
+    if !path_is_real_directory(&project_dir) {
+        return None;
+    }
+    let mut matches: Vec<(std::time::SystemTime, String, PathBuf)> = Vec::new();
+    for entry in std::fs::read_dir(project_dir).ok()?.flatten() {
+        if !dir_entry_is_real_file(&entry) || !is_released_name(&entry.file_name()) {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(content) = read_identity_file_no_follow(&path) else {
+            continue;
+        };
+        let Some(generation) = parse_binding_generation(&content) else {
+            continue;
+        };
+        if !pane_ids_are_authoritatively_compatible(pane_id, &generation.tmux_pane_id) {
+            continue;
+        }
+        let Some(name) = parse_identity(content) else {
+            continue;
+        };
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        matches.push((modified, name, path));
+    }
+    matches.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.2.cmp(&right.2)));
+    matches.pop().map(|(_, name, path)| (name, path))
 }
 
 fn is_released_name(file_name: &OsStr) -> bool {
@@ -2191,10 +2292,13 @@ fn record_from_facts(
     };
 
     if let Some(generation) = generation {
-        // v1 contract: `pane_id` is the composite tmux address that
-        // `binding_authorizes_pane` compares against, and `tmux_pane_id` is
-        // the bare id. `probe_pane_id()` keeps GH#252's liveness probe on the
-        // bare id, so both readers stay correct on one row.
+        // v1 contract: `pane_id` is the REQUESTED identity key (composite
+        // when registration used a composite key, bare when it used a bare
+        // one) -- see tmux_server_binding_generation, which sets it from
+        // `requested`. `binding_authorizes_pane` compares an incoming key
+        // against it OR against `tmux_pane_id`, the authoritative bare id.
+        // `probe_pane_id()` keeps GH#252's liveness probe on the bare id, so
+        // both readers stay correct on one row.
         record.schema_version = Some(BINDING_SCHEMA_V1.to_string());
         record.pane_id = Some(generation.pane_id.clone());
         record.socket_path = Some(generation.socket_path.to_string_lossy().into_owned());
@@ -2256,6 +2360,14 @@ impl PaneBindingResolver {
     /// lookup continues and ultimately mints a fresh identity.
     fn consider(&mut self, path: PathBuf) -> Option<(String, PathBuf, PaneBindingStatus)> {
         let record = read_identity_record(&path)?;
+        // agent-factory-3tf: the file name cannot distinguish two composite
+        // keys that sanitize to it, so never return a record whose recorded
+        // key names a different pane.
+        if let Some(stored_key) = record.identity_key.as_deref()
+            && identity_keys_collide_lossily(stored_key, &self.pane_arg)
+        {
+            return None;
+        }
         match binding_liveness(&record) {
             PaneBindingLiveness::Live => {
                 let holder_matches = self.target_facts().is_some_and(|f| {
@@ -4082,6 +4194,28 @@ mod tests {
         .expect("serialize record")
     }
 
+    /// Whether `removed` carries the durable release receipt for `original`.
+    ///
+    /// agent-factory-3tf: upstream's cleanup UNLINKED a stale row and returned
+    /// the path it deleted; 7x5's releases it and returns the `.released-`
+    /// tombstone, which is the whole point of the 7x5 line -- a released
+    /// binding must stay distinguishable from an abandoned one across a
+    /// restart. 7x5 wins on the action, so these assertions check that the
+    /// binding is gone AND that a receipt for it was returned.
+    fn contains_release_receipt_for(removed: &[PathBuf], original: &Path) -> bool {
+        let Some(name) = original.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+            return false;
+        };
+        let prefix = format!(".{name}.released-");
+        removed.iter().any(|path| {
+            path.parent() == original.parent()
+                && path
+                    .file_name()
+                    .is_some_and(|n| n.to_string_lossy().starts_with(prefix.as_str()))
+                && path.exists()
+        })
+    }
+
     fn write_record_fixture(path: &Path, json: &str) {
         std::fs::create_dir_all(path.parent().expect("record parent")).expect("create parent");
         std::fs::write(path, format!("{json}\n")).expect("write record fixture");
@@ -4758,12 +4892,17 @@ mod tests {
             || {
                 let removed = cleanup_stale_identities(&project);
                 assert!(
-                    removed.contains(&dead_path),
-                    "dead structured record must be purged: {removed:?}"
+                    contains_release_receipt_for(&removed, &dead_path),
+                    "dead structured record must be released with a receipt: {removed:?}"
+                );
+                assert!(!dead_path.exists(), "dead binding must no longer resolve");
+                assert!(
+                    contains_release_receipt_for(&removed, &legacy_stale_path),
+                    "stale legacy file must be released with a receipt: {removed:?}"
                 );
                 assert!(
-                    removed.contains(&legacy_stale_path),
-                    "stale legacy file must be purged: {removed:?}"
+                    !legacy_stale_path.exists(),
+                    "stale legacy binding must no longer resolve"
                 );
                 assert!(
                     live_path.exists(),
@@ -4806,8 +4945,12 @@ mod tests {
         crate::config::with_process_env_overrides_for_test(&[("AM_TEST_TMUX_BIN", "")], || {
             let removed = cleanup_stale_identities(&project);
             assert!(
-                removed.contains(&dead_path),
-                "record with a gone socket must be purged: {removed:?}"
+                contains_release_receipt_for(&removed, &dead_path),
+                "record with a gone socket must be released with a receipt: {removed:?}"
+            );
+            assert!(
+                !dead_path.exists(),
+                "socket-gone binding must no longer resolve"
             );
             assert!(
                 legacy_path.exists(),
@@ -4899,8 +5042,13 @@ mod tests {
         crate::config::with_process_env_overrides_for_test(&[("AM_TEST_TMUX_BIN", "")], || {
             let removed = cleanup_stale_identities(&project);
             assert!(
-                removed.contains(&stale_path),
-                "uncheckable record not matching a live pane key must be purged: {removed:?}"
+                contains_release_receipt_for(&removed, &stale_path),
+                "uncheckable record not matching a live pane key must be released \
+                 with a receipt: {removed:?}"
+            );
+            assert!(
+                !stale_path.exists(),
+                "uncheckable stale binding must no longer resolve"
             );
             assert!(
                 kept_path.exists(),
@@ -4908,6 +5056,86 @@ mod tests {
             );
         });
         drop(tmux);
+        drop(config);
+    }
+    /// agent-factory-3tf regression: the PRODUCTION write path must record
+    /// tmux server-generation evidence.
+    ///
+    /// The GH#252 merge left `capture_binding_generation` with zero callers,
+    /// so every row production wrote carried no generation. Nothing failed:
+    /// `parse_binding_generation` simply returned None, and the destructive
+    /// release gate quietly fell back to `tmux_pane_is_live` -- the path a
+    /// decorrelated review had already proven grants release of LIVE panes.
+    /// The whole pane suite stayed green through it, because every other test
+    /// injects its record as a fixture instead of writing one.
+    ///
+    /// This test writes through the real path and asserts the evidence is on
+    /// disk, so that regression cannot reappear silently.
+    #[cfg(unix)]
+    #[test]
+    fn write_identity_records_generation_evidence_through_production_path() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("generation-evidence-project");
+
+        // A real file so the generation can stat a device and inode.
+        let sock = config.tempdir.path().join("tmux-generation-sock");
+        std::fs::write(&sock, b"").expect("create socket placeholder");
+        let sock_text = sock.to_string_lossy().into_owned();
+
+        let stub_dir = tempfile::tempdir().expect("stub dir");
+        let script = format!(
+            "#!/bin/sh\n\
+             cmd=\"\"\n\
+             for a in \"$@\"; do\n\
+             case \"$a\" in\n\
+             list-panes) cmd=lp ;;\n\
+             display-message) cmd=dm ;;\n\
+             esac\n\
+             done\n\
+             if [ \"$cmd\" = lp ]; then\n\
+             printf '%s\\t%s\\t%s\\t%s\\n' '{sock_text}' '4242' 'alpha:0:1' '%77'\n\
+             exit 0\n\
+             fi\n\
+             if [ \"$cmd\" = dm ]; then\n\
+             printf '%s\\t%s\\t%s\\t%s\\t%s\\n' 'alpha' '%77' '999' 'claude' '{sock_text}'\n\
+             exit 0\n\
+             fi\n\
+             exit 1\n"
+        );
+        let tmux_bin = write_tmux_stub(stub_dir.path(), &script);
+
+        crate::config::with_process_env_overrides_for_test(
+            &[("AM_TEST_TMUX_BIN", tmux_bin.as_str())],
+            || {
+                let path = write_identity(&project, "%77", "GenAgent").expect("write identity");
+                let content = read_identity_file_no_follow(&path).expect("read written record");
+
+                // The claim that actually matters: the destructive release
+                // gate can parse a generation out of what production wrote.
+                let generation = parse_binding_generation(&content).expect(
+                    "production write path must record generation evidence the \
+                     release gate can parse",
+                );
+                assert_eq!(generation.tmux_pane_id, "%77");
+                assert_eq!(generation.server_pid, 4242);
+                assert_eq!(generation.socket_path, sock);
+
+                let record = read_identity_record(&path).expect("parse written record");
+                assert_eq!(record.name, "GenAgent");
+                assert_eq!(record.schema_version.as_deref(), Some(BINDING_SCHEMA_V1));
+                assert_eq!(record.identity_key.as_deref(), Some("%77"));
+                // The v1 contract: `pane_id` is the requested identity key
+                // (bare here, composite when registration used a composite
+                // key), `tmux_pane_id` is the authoritative bare id, and the
+                // GH#252 liveness probe uses the bare id via probe_pane_id().
+                assert_eq!(record.pane_id.as_deref(), Some("%77"));
+                assert_eq!(record.tmux_pane_id.as_deref(), Some("%77"));
+                assert_eq!(record.probe_pane_id(), Some("%77"));
+                assert!(record.socket_device.is_some());
+                assert!(record.socket_inode.is_some());
+                assert!(record.is_verifiable());
+            },
+        );
         drop(config);
     }
 }

--- a/crates/mcp-agent-mail-core/src/pane_identity.rs
+++ b/crates/mcp-agent-mail-core/src/pane_identity.rs
@@ -28,7 +28,19 @@
 
 use sha1::{Digest, Sha1};
 use std::ffi::OsStr;
+use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct BindingGeneration {
+    pane_id: String,
+    socket_path: PathBuf,
+    socket_device: u64,
+    socket_inode: u64,
+    server_pid: u32,
+    tmux_pane_id: String,
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -65,6 +77,9 @@ static TEST_CONFIG_BASE_DIR: std::sync::LazyLock<std::sync::Mutex<Option<PathBuf
 #[cfg(test)]
 static TEST_LIVE_TMUX_PANES: std::sync::LazyLock<std::sync::Mutex<Option<Vec<String>>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+#[cfg(test)]
+static TEST_TMUX_QUERY_CALLS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -325,8 +340,9 @@ pub fn read_identity_record(path: &Path) -> Option<PaneIdentityRecord> {
 pub fn canonical_identity_path(project_key: &str, pane_id: &str) -> PathBuf {
     let base = config_base_dir();
     let hash = project_hash(project_key);
-    let sanitized_pane = sanitize_pane_id(pane_id);
-    base.join(IDENTITY_DIR_NAME).join(hash).join(sanitized_pane)
+    base.join(IDENTITY_DIR_NAME)
+        .join(hash)
+        .join(sanitize_pane_id(pane_id))
 }
 
 /// Write an agent name to the canonical identity file for a pane.
@@ -401,6 +417,580 @@ pub fn write_identity(
     let record = record_from_facts(agent_name, facts.as_ref());
     write_record_content_no_follow(&path, &record)?;
     Ok(path)
+}
+
+/// Classify whether an identity belongs to the current tmux pane generation.
+///
+/// Pane existence alone is insufficient because tmux may recycle a pane id
+/// after its server restarts or a composite target is recreated. Only a v1
+/// binding whose socket inode, server PID, and stable bare tmux pane id match is
+/// authoritative. Legacy rows remain explicitly unverified while a pane with
+/// the same id exists.
+pub fn identity_binding_state(pane_id: &str, path: &Path) -> std::io::Result<&'static str> {
+    let content = read_identity_file_no_follow(path)?;
+    if let Some(expected) = parse_binding_generation(&content) {
+        if !binding_authorizes_pane(&expected, pane_id) {
+            return Ok("abandoned");
+        }
+        return if tmux_binding_generation_matches(&expected)? {
+            Ok("verified-live")
+        } else {
+            Ok("abandoned")
+        };
+    }
+    if let Some(stored_pane_id) = parse_binding_pane_id(&content)
+        && !pane_ids_are_authoritatively_compatible(pane_id, &stored_pane_id)
+    {
+        return Ok("abandoned");
+    }
+    if tmux_pane_is_live(pane_id)? {
+        Ok("live-unverified")
+    } else {
+        Ok("abandoned")
+    }
+}
+
+/// Return whether an explicitly named tmux pane is live.
+///
+/// Unlike the best-effort stale-identity cleanup, this is a safety gate for
+/// destructive release. A failed tmux query is an error, never evidence that
+/// the pane is absent.
+pub fn tmux_pane_is_live(pane_id: &str) -> std::io::Result<bool> {
+    tmux_pane_is_live_with_socket(pane_id, None)
+}
+
+fn tmux_pane_is_live_with_socket(
+    pane_id: &str,
+    recorded_socket: Option<&Path>,
+) -> std::io::Result<bool> {
+    let pane = pane_id.trim();
+    if pane.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "pane id must not be empty",
+        ));
+    }
+    #[cfg(test)]
+    if let Some(panes) = test_live_tmux_panes() {
+        let call = TEST_TMUX_QUERY_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if panes.iter().any(|candidate| candidate == "__QUERY_ERROR__") {
+            return Err(std::io::Error::other("injected tmux liveness failure"));
+        }
+        if call >= 1
+            && panes
+                .iter()
+                .any(|candidate| candidate == "__QUERY_ERROR_AFTER_1__")
+        {
+            return Err(std::io::Error::other("injected late tmux liveness failure"));
+        }
+        if call >= 1
+            && panes.iter().any(|candidate| {
+                candidate
+                    .strip_prefix("__LIVE_AFTER_1__:")
+                    .is_some_and(|candidate| tmux_pane_ids_match(pane, candidate))
+            })
+        {
+            return Ok(true);
+        }
+        return Ok(panes
+            .iter()
+            .any(|candidate| tmux_pane_ids_match(pane, candidate.trim())));
+    }
+
+    if tmux_server_has_pane(pane, None)? {
+        return Ok(true);
+    }
+    let mut sockets: std::collections::BTreeSet<PathBuf> =
+        tmux_socket_paths()?.into_iter().collect();
+    if let Some(socket) = recorded_socket {
+        sockets.insert(socket.to_path_buf());
+    }
+    for socket in sockets {
+        if tmux_server_has_pane(pane, Some(&socket))? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn tmux_server_has_pane(pane_id: &str, socket: Option<&Path>) -> std::io::Result<bool> {
+    let mut command = tmux_command();
+    if let Some(socket) = socket {
+        command.arg("-S").arg(socket);
+    }
+    let output = command
+        .args([
+            "list-panes",
+            "-a",
+            "-F",
+            "#{session_name}:#{window_index}:#{pane_index}\t#{pane_id}",
+        ])
+        .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if tmux_output_means_no_server(&stderr) {
+            return Ok(false);
+        }
+        return Err(std::io::Error::other(format!(
+            "tmux liveness query failed{}: {}",
+            socket.map_or_else(String::new, |path| format!(" on {}", path.display())),
+            stderr.trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).lines().any(|line| {
+        let (composite, bare) = line.split_once('\t').unwrap_or((line, line));
+        tmux_pane_ids_match(pane_id, composite.trim()) || tmux_pane_ids_match(pane_id, bare.trim())
+    }))
+}
+
+fn capture_binding_generation(pane_id: &str) -> std::io::Result<Option<BindingGeneration>> {
+    #[cfg(test)]
+    if test_live_tmux_panes().is_some() {
+        // Unit tests inject liveness independently of a real tmux server.
+        return Ok(None);
+    }
+
+    // A registration request carries only a pane id, not a trusted tmux
+    // socket namespace. Neither the daemon's inherited TMUX value nor the
+    // default server is therefore authoritative: an unrelated server can
+    // reuse the same bare pane id. Collect every discoverable match and only
+    // persist a generation when the result is unique.
+    let mut generations = std::collections::BTreeSet::new();
+    if let Some(generation) = tmux_server_binding_generation(pane_id, None)? {
+        generations.insert(generation);
+    }
+    for socket in tmux_socket_paths()? {
+        if let Some(generation) = tmux_server_binding_generation(pane_id, Some(&socket))? {
+            generations.insert(generation);
+        }
+    }
+    // A bare pane id shared by multiple servers is ambiguous. Persisting no
+    // generation keeps the row live-unverified and therefore non-authoritative.
+    if generations.len() == 1 {
+        Ok(generations.into_iter().next())
+    } else {
+        Ok(None)
+    }
+}
+
+fn tmux_binding_generation_matches(expected: &BindingGeneration) -> std::io::Result<bool> {
+    let Some(observed) =
+        tmux_server_binding_generation(&expected.tmux_pane_id, Some(&expected.socket_path))?
+    else {
+        return Ok(false);
+    };
+    Ok(binding_generations_are_same(expected, &observed))
+}
+
+fn binding_generations_are_same(left: &BindingGeneration, right: &BindingGeneration) -> bool {
+    left.socket_path == right.socket_path
+        && left.socket_device == right.socket_device
+        && left.socket_inode == right.socket_inode
+        && left.server_pid == right.server_pid
+        && left.tmux_pane_id == right.tmux_pane_id
+}
+
+fn binding_generation_is_live(
+    pane_id: &str,
+    generation: Option<&BindingGeneration>,
+) -> std::io::Result<bool> {
+    match generation {
+        Some(expected) => tmux_binding_generation_matches(expected),
+        None => tmux_pane_is_live(pane_id),
+    }
+}
+
+fn tmux_server_binding_generation(
+    pane_id: &str,
+    socket: Option<&Path>,
+) -> std::io::Result<Option<BindingGeneration>> {
+    let mut command = tmux_command();
+    if let Some(socket) = socket {
+        command.arg("-S").arg(socket);
+    }
+    let output = command
+        .args([
+            "list-panes",
+            "-a",
+            "-F",
+            "#{socket_path}\t#{pid}\t#{session_name}:#{window_index}:#{pane_index}\t#{pane_id}",
+        ])
+        .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if tmux_output_means_no_server(&stderr) {
+            return Ok(None);
+        }
+        return Err(std::io::Error::other(format!(
+            "tmux binding-generation query failed{}: {}",
+            socket.map_or_else(String::new, |path| format!(" on {}", path.display())),
+            stderr.trim()
+        )));
+    }
+    let requested = pane_id.trim();
+    let mut exact = std::collections::BTreeSet::new();
+    let mut aliases = std::collections::BTreeSet::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let mut fields = line.split('\t');
+        let Some(socket_path) = fields.next().filter(|value| !value.trim().is_empty()) else {
+            continue;
+        };
+        let Some(server_pid) = fields.next().and_then(|value| value.parse::<u32>().ok()) else {
+            continue;
+        };
+        let composite = fields.next().unwrap_or_default();
+        let bare = fields.next().unwrap_or_default();
+        if !tmux_pane_ids_match(requested, composite) && !tmux_pane_ids_match(requested, bare) {
+            continue;
+        }
+        let socket_path = PathBuf::from(socket_path);
+        let (socket_device, socket_inode) = socket_identity(&socket_path)?;
+        let generation = BindingGeneration {
+            pane_id: requested.to_string(),
+            socket_path,
+            socket_device,
+            socket_inode,
+            server_pid,
+            tmux_pane_id: bare.trim().to_string(),
+        };
+        if tmux_pane_id_is_exact_match(requested, composite, bare) {
+            exact.insert(generation);
+        } else {
+            aliases.insert(generation);
+        }
+    }
+    if exact.len() == 1 {
+        return Ok(exact.into_iter().next());
+    }
+    if exact.is_empty() && aliases.len() == 1 {
+        return Ok(aliases.into_iter().next());
+    }
+    Ok(None)
+}
+
+#[cfg(unix)]
+fn socket_identity(path: &Path) -> std::io::Result<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = std::fs::metadata(path)?;
+    Ok((metadata.dev(), metadata.ino()))
+}
+
+#[cfg(not(unix))]
+fn socket_identity(_path: &Path) -> std::io::Result<(u64, u64)> {
+    Err(std::io::Error::other(
+        "tmux binding generations require Unix socket metadata",
+    ))
+}
+
+fn tmux_socket_paths() -> std::io::Result<Vec<PathBuf>> {
+    let mut sockets = std::collections::BTreeSet::new();
+    if let Some(tmux) = crate::config::process_env_value("TMUX")
+        && let Some(socket) = tmux.split(',').next().map(str::trim)
+        && !socket.is_empty()
+    {
+        sockets.insert(PathBuf::from(socket));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+        // `/proc` is not available on macOS. The configured home directory is
+        // already required for identity storage and gives us a same-user UID
+        // without relying on a Linux-only pseudo-filesystem.
+        let own_uid = home_dir()
+            .ok_or_else(|| std::io::Error::other("cannot determine home directory"))
+            .and_then(std::fs::metadata)?
+            .uid();
+        let mut roots =
+            std::collections::BTreeSet::from([std::env::temp_dir(), PathBuf::from("/tmp")]);
+        if let Some(root) =
+            crate::config::process_env_value("TMUX_TMPDIR").filter(|value| !value.trim().is_empty())
+        {
+            roots.insert(PathBuf::from(root));
+        }
+        for root in roots {
+            let entries = match std::fs::read_dir(&root) {
+                Ok(entries) => entries,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            for directory in entries {
+                let directory = directory?;
+                if !directory.file_name().to_string_lossy().starts_with("tmux-") {
+                    continue;
+                }
+                let metadata = directory.metadata()?;
+                if !metadata.is_dir() || metadata.uid() != own_uid {
+                    continue;
+                }
+                for entry in std::fs::read_dir(directory.path())? {
+                    let entry = entry?;
+                    let metadata = entry.metadata()?;
+                    if metadata.uid() == own_uid && metadata.file_type().is_socket() {
+                        sockets.insert(entry.path());
+                    }
+                }
+            }
+        }
+
+        // `TMUX_TMPDIR` may point anywhere, and the releasing process does not
+        // necessarily inherit the value used by the tmux server. Linux exposes
+        // bound Unix socket paths in `/proc/net/unix`; tmux still creates its
+        // `tmux-<uid>` namespace below a custom root, so include every
+        // same-user socket in that namespace. This prevents a live pane on a
+        // custom tmux server from becoming invisible to release.
+        #[cfg(target_os = "linux")]
+        {
+            let namespace = format!("tmux-{own_uid}");
+            let unix_sockets = std::fs::read_to_string("/proc/net/unix")?;
+            for line in unix_sockets.lines().skip(1) {
+                let fields: Vec<&str> = line.split_ascii_whitespace().collect();
+                if fields.len() < 8 {
+                    continue;
+                }
+                let socket = PathBuf::from(fields[7..].join(" "));
+                if !socket
+                    .components()
+                    .any(|component| component.as_os_str() == OsStr::new(&namespace))
+                {
+                    continue;
+                }
+                let metadata = std::fs::metadata(&socket)?;
+                if metadata.uid() == own_uid && metadata.file_type().is_socket() {
+                    sockets.insert(socket);
+                }
+            }
+        }
+    }
+
+    Ok(sockets.into_iter().collect())
+}
+
+fn tmux_output_means_no_server(stderr: &str) -> bool {
+    let message = stderr.to_ascii_lowercase();
+    message.contains("no server running on")
+        || (message.contains("failed to connect to server")
+            && (message.contains("no such file or directory")
+                || message.contains("connection refused")))
+        || (message.contains("error connecting to")
+            && (message.contains("no such file or directory")
+                || message.contains("connection refused")))
+}
+
+fn tmux_pane_ids_match(requested: &str, observed: &str) -> bool {
+    let requested = requested.trim();
+    let observed = observed.trim();
+    if requested.contains(':') || observed.contains(':') {
+        return requested == observed || sanitize_pane_id(requested) == sanitize_pane_id(observed);
+    }
+    match (numeric_bare_pane(requested), numeric_bare_pane(observed)) {
+        (Some(left), Some(right)) => left == right,
+        _ => requested == observed,
+    }
+}
+
+fn tmux_pane_id_is_exact_match(requested: &str, composite: &str, bare: &str) -> bool {
+    let requested = requested.trim();
+    let composite = composite.trim();
+    let bare = bare.trim();
+    if requested == composite || requested == bare {
+        return true;
+    }
+    if requested.contains(':') {
+        return false;
+    }
+    matches!(
+        (numeric_bare_pane(requested), numeric_bare_pane(bare)),
+        (Some(left), Some(right)) if left == right
+    )
+}
+
+fn pane_ids_are_authoritatively_compatible(requested: &str, stored: &str) -> bool {
+    let requested = requested.trim();
+    let stored = stored.trim();
+    if requested.contains(':') || stored.contains(':') {
+        return requested == stored;
+    }
+    matches!(
+        (numeric_bare_pane(requested), numeric_bare_pane(stored)),
+        (Some(left), Some(right)) if left == right
+    ) || requested == stored
+}
+
+fn binding_authorizes_pane(binding: &BindingGeneration, requested: &str) -> bool {
+    pane_ids_are_authoritatively_compatible(requested, &binding.pane_id)
+        || pane_ids_are_authoritatively_compatible(requested, &binding.tmux_pane_id)
+}
+
+fn numeric_bare_pane(pane: &str) -> Option<&str> {
+    let numeric = pane.strip_prefix('%').unwrap_or(pane);
+    numeric
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+        .then_some(numeric)
+}
+
+/// Release one pane identity after proving the pane is absent from tmux.
+///
+/// `expected_agent` is a compare-and-release guard: a caller may only remove
+/// the exact binding it observed before teardown. Generation-aware liveness is
+/// checked before and after quarantine so a recycled pane ID does not keep an
+/// abandoned binding alive or let a live binding disappear.
+pub fn release_identity(
+    project_key: &str,
+    pane_id: &str,
+    expected_agent: &str,
+) -> std::io::Result<(String, PathBuf)> {
+    let Some((agent_name, path)) = resolve_identity_with_path(project_key, pane_id) else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("no identity registered for pane {pane_id}"),
+        ));
+    };
+    if agent_name != expected_agent.trim() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "pane {pane_id} is bound to {agent_name}, not expected agent {}",
+                expected_agent.trim()
+            ),
+        ));
+    }
+    release_resolved_identity(pane_id, &agent_name, &path)
+        .map(|released_path| (agent_name, released_path))
+}
+
+/// Release a binding that was already resolved from an identity inventory.
+///
+/// Sweep callers use this path so every row gets the same repeated direct-tmux,
+/// compare-and-release, quarantine, and race checks as a one-row release.
+fn release_resolved_identity(
+    pane_id: &str,
+    agent_name: &str,
+    path: &Path,
+) -> std::io::Result<PathBuf> {
+    let canonical_release_path = path
+        .file_name()
+        .and_then(pending_original_name)
+        .map_or_else(
+            || path.to_path_buf(),
+            |original| path.with_file_name(original),
+        );
+    let pending_siblings: Vec<std::ffi::OsString> = pending_release_paths(&canonical_release_path)
+        .into_iter()
+        .filter_map(|pending| pending.file_name().map(OsStr::to_os_string))
+        .collect();
+    let recorded_generation = read_identity_file_no_follow(path)
+        .ok()
+        .and_then(|content| parse_binding_generation(&content));
+    #[cfg(not(target_os = "linux"))]
+    if recorded_generation.is_none() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "refusing to release an unnamespaced legacy pane binding on this platform",
+        ));
+    }
+    if binding_generation_is_live(pane_id, recorded_generation.as_ref())? {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!("refusing to release recycled live tmux pane {pane_id}"),
+        ));
+    }
+    // Quarantine with one atomic, directory-fd-anchored rename before the
+    // final liveness decision.
+    // If tmux recycles the id between the check above and this rename, the
+    // subsequent live check restores the exact inode we moved (or leaves a
+    // concurrently written replacement in place). This closes the
+    // check-then-unlink race that could otherwise delete a new live binding.
+    let anchored = AnchoredIdentity::open(&path)?;
+    let source_name = anchored.file_name.clone();
+    let already_pending = is_release_pending_name(&source_name);
+    let quarantine_name = if already_pending {
+        source_name.clone()
+    } else {
+        let mut random = [0_u8; 16];
+        getrandom::fill(&mut random)
+            .map_err(|error| std::io::Error::other(format!("randomness failed: {error}")))?;
+        let nonce: String = random.iter().map(|byte| format!("{byte:02x}")).collect();
+        let file_name = source_name.to_string_lossy();
+        std::ffi::OsString::from(format!(
+            ".{file_name}.release-{}-{nonce}",
+            std::process::id()
+        ))
+    };
+    if !already_pending {
+        anchored.rename_no_replace(&source_name, &quarantine_name)?;
+        anchored.sync()?;
+    }
+
+    let quarantined_content = anchored.read(&quarantine_name).ok();
+    let quarantined_agent = quarantined_content.clone().and_then(parse_identity);
+    let quarantined_generation = quarantined_content
+        .as_deref()
+        .and_then(parse_binding_generation);
+    let live_after_quarantine =
+        match binding_generation_is_live(pane_id, quarantined_generation.as_ref()) {
+            Ok(live) => live,
+            Err(error) => {
+                if !already_pending {
+                    match anchored.rename_no_replace(&quarantine_name, &source_name) {
+                        Ok(()) => {}
+                        // A concurrent registration won the canonical name. Keep
+                        // both it and the pending row while liveness is unknown;
+                        // a later release can reconcile them safely.
+                        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                        Err(restore_error) => return Err(restore_error),
+                    }
+                }
+                anchored.sync()?;
+                return Err(error);
+            }
+        };
+    if live_after_quarantine || quarantined_agent.as_deref() != Some(agent_name) {
+        if !already_pending {
+            match anchored.rename_no_replace(&quarantine_name, &source_name) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // A concurrent registration already installed a new
+                    // binding. Discard only the quarantined old row without
+                    // touching that canonical replacement.
+                    anchored.unlink(&quarantine_name)?;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        anchored.sync()?;
+        let reason = if live_after_quarantine {
+            format!("refusing to release recycled live tmux pane {pane_id}")
+        } else {
+            format!("pane {pane_id} binding changed during release")
+        };
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            reason,
+        ));
+    }
+    let released_name = released_name_for_pending(&quarantine_name).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "release quarantine has no durable receipt name",
+        )
+    })?;
+    anchored.rename_no_replace(&quarantine_name, &released_name)?;
+    for sibling in pending_siblings {
+        if sibling == quarantine_name {
+            continue;
+        }
+        match anchored.unlink(&sibling) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    anchored.sync()?;
+    Ok(canonical_release_path.with_file_name(released_name))
 }
 
 /// Resolve the agent name for a given project and tmux pane.
@@ -503,6 +1093,16 @@ pub fn resolve_identity_with_binding(
         if let Some(hit) = resolver.consider(composite_canonical) {
             return Some(hit);
         }
+    }
+
+    // After a pane dies tmux can no longer translate its stable bare id to
+    // the composite key used as the canonical filename. Recover a unique v1
+    // row by the bare id stored in its generation receipt. Ambiguity fails
+    // closed because a recycled id may have multiple abandoned generations.
+    if !pane_id.contains(':')
+        && let Some(identity) = resolve_unique_v1_by_bare_pane(project_key, pane_id)
+    {
+        return Some(identity);
     }
 
     // 2. Legacy Claude Code path: ~/.claude/agent-mail/identity.$TMUX_PANE
@@ -669,34 +1269,10 @@ pub fn write_identity_with_optional_pane(
 /// Returns the list of removed file paths.
 #[must_use]
 pub fn cleanup_stale_identities(project_key: &str) -> Vec<PathBuf> {
-    let mut removed = Vec::new();
     let base = config_base_dir();
     let hash = project_hash(project_key);
     let project_dir = base.join(IDENTITY_DIR_NAME).join(&hash);
-
-    if !path_is_real_directory(&project_dir) {
-        return removed;
-    }
-
-    let live_panes = list_live_tmux_panes();
-
-    let Ok(entries) = std::fs::read_dir(&project_dir) else {
-        return removed;
-    };
-
-    for entry in entries.flatten() {
-        if identity_entry_is_internal(&entry) {
-            continue;
-        }
-        if identity_entry_is_stale(&entry, &live_panes) {
-            let path = entry.path();
-            if dir_entry_is_real_file(&entry) && std::fs::remove_file(&path).is_ok() {
-                removed.push(path);
-            }
-        }
-    }
-
-    removed
+    cleanup_identity_directory(&project_dir)
 }
 
 /// Clean up stale identities across all project hash directories.
@@ -714,8 +1290,6 @@ pub fn cleanup_all_stale_identities() -> Vec<PathBuf> {
         return removed;
     }
 
-    let live_panes = list_live_tmux_panes();
-
     let Ok(entries) = std::fs::read_dir(&identity_root) else {
         return removed;
     };
@@ -725,23 +1299,49 @@ pub fn cleanup_all_stale_identities() -> Vec<PathBuf> {
         if !dir_entry_is_real_directory(&dir_entry) {
             continue;
         }
-        let Ok(files) = std::fs::read_dir(&project_dir) else {
-            continue;
-        };
-        for file_entry in files.flatten() {
-            if identity_entry_is_internal(&file_entry) {
-                continue;
-            }
-            if identity_entry_is_stale(&file_entry, &live_panes) {
-                let path = file_entry.path();
-                if dir_entry_is_real_file(&file_entry) && std::fs::remove_file(&path).is_ok() {
-                    removed.push(path);
-                }
-            }
-        }
+        removed.extend(cleanup_identity_directory(&project_dir));
     }
 
     removed
+}
+
+fn cleanup_identity_directory(project_dir: &Path) -> Vec<PathBuf> {
+    if !path_is_real_directory(project_dir) {
+        return Vec::new();
+    }
+    let Ok(entries) = std::fs::read_dir(project_dir) else {
+        return Vec::new();
+    };
+    let mut bindings = std::collections::BTreeMap::new();
+    for entry in entries.flatten() {
+        if !dir_entry_is_real_file(&entry) {
+            continue;
+        }
+        let raw_name = entry.file_name();
+        if is_released_name(&raw_name) {
+            continue;
+        }
+        let pending = pending_original_name(&raw_name);
+        let filename_pane_id = pending
+            .map(str::to_owned)
+            .unwrap_or_else(|| raw_name.to_string_lossy().into_owned());
+        let path = entry.path();
+        let pane_id = binding_pane_id(&path).unwrap_or(filename_pane_id);
+        if let Some(agent_name) = read_identity_file(&path) {
+            let replace = bindings
+                .get(&pane_id)
+                .is_none_or(|(_, _, was_pending)| *was_pending && pending.is_none());
+            if replace {
+                bindings.insert(pane_id, (agent_name, path, pending.is_some()));
+            }
+        }
+    }
+    bindings
+        .into_iter()
+        .filter_map(|(pane_id, (agent_name, path, _pending))| {
+            release_resolved_identity(&pane_id, &agent_name, &path).ok()
+        })
+        .collect()
 }
 
 /// List all identity entries for a project (for diagnostic/debug use).
@@ -773,24 +1373,38 @@ pub fn list_identities_with_paths(project_key: &str) -> Vec<(String, String, Pat
         return Vec::new();
     }
 
-    let mut result = Vec::new();
+    let mut result = std::collections::BTreeMap::new();
     let Ok(entries) = std::fs::read_dir(&project_dir) else {
-        return result;
+        return Vec::new();
     };
 
     for entry in entries.flatten() {
-        if identity_entry_is_internal(&entry) {
+        if !dir_entry_is_real_file(&entry) {
             continue;
         }
-        let pane_id = entry.file_name().to_string_lossy().to_string();
+        let raw_name = entry.file_name();
+        if is_released_name(&raw_name) {
+            continue;
+        }
+        let pending = pending_original_name(&raw_name);
+        let filename_pane_id = pending
+            .map(str::to_owned)
+            .unwrap_or_else(|| raw_name.to_string_lossy().into_owned());
         let path = entry.path();
+        let pane_id = binding_pane_id(&path).unwrap_or(filename_pane_id);
         if let Some(name) = read_identity_file(&path) {
-            result.push((pane_id, name, path));
+            let replace = result
+                .get(&pane_id)
+                .is_none_or(|(_, _, was_pending)| *was_pending && pending.is_none());
+            if replace {
+                result.insert(pane_id, (name, path, pending.is_some()));
+            }
         }
     }
-
-    result.sort_by(|a, b| a.0.cmp(&b.0));
     result
+        .into_iter()
+        .map(|(pane, (name, path, _pending))| (pane, name, path))
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -862,6 +1476,263 @@ fn ensure_real_directory(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+fn parse_identity(content: String) -> Option<String> {
+    let trimmed = content.trim().to_string();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&trimmed)
+        && let Some(name) = value.get("name").and_then(serde_json::Value::as_str)
+        && !name.trim().is_empty()
+    {
+        return Some(name.trim().to_string());
+    }
+    Some(trimmed)
+}
+
+fn parse_binding_generation(content: &str) -> Option<BindingGeneration> {
+    let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
+    if value.get("schema_version")?.as_str()? != "am.pane-binding.v1" {
+        return None;
+    }
+    let tmux_pane_id = value.get("tmux_pane_id")?.as_str()?.trim();
+    let pane_id = value.get("pane_id")?.as_str()?.trim();
+    if tmux_pane_id.is_empty() || pane_id.is_empty() {
+        return None;
+    }
+    Some(BindingGeneration {
+        pane_id: pane_id.to_string(),
+        socket_path: PathBuf::from(value.get("socket_path")?.as_str()?),
+        socket_device: value.get("socket_device")?.as_u64()?,
+        socket_inode: value.get("socket_inode")?.as_u64()?,
+        server_pid: u32::try_from(value.get("server_pid")?.as_u64()?).ok()?,
+        tmux_pane_id: tmux_pane_id.to_string(),
+    })
+}
+
+fn parse_binding_pane_id(content: &str) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
+    if value.get("schema_version")?.as_str()? != "am.pane-binding.v1" {
+        return None;
+    }
+    let pane_id = value.get("pane_id")?.as_str()?.trim();
+    (!pane_id.is_empty()).then(|| pane_id.to_string())
+}
+
+fn binding_pane_id(path: &Path) -> Option<String> {
+    let content = read_identity_file_no_follow(path).ok()?;
+    parse_binding_pane_id(&content)
+}
+
+fn resolve_unique_v1_by_bare_pane(
+    project_key: &str,
+    pane_id: &str,
+) -> Option<(String, PathBuf, PaneBindingStatus)> {
+    let project_dir = config_base_dir()
+        .join(IDENTITY_DIR_NAME)
+        .join(project_hash(project_key));
+    if !path_is_real_directory(&project_dir) {
+        return None;
+    }
+    let entries = std::fs::read_dir(project_dir).ok()?;
+    let mut match_found: Option<(String, PathBuf, PaneBindingStatus)> = None;
+    for entry in entries.flatten() {
+        if !dir_entry_is_real_file(&entry) || is_released_name(&entry.file_name()) {
+            continue;
+        }
+        let path = entry.path();
+        let content = read_identity_file_no_follow(&path).ok()?;
+        let Some(binding) = parse_binding_generation(&content) else {
+            continue;
+        };
+        if !pane_ids_are_authoritatively_compatible(pane_id, &binding.tmux_pane_id) {
+            continue;
+        }
+        let name = parse_identity(content)?;
+        if match_found.is_some() {
+            return None;
+        }
+        match_found = Some((name, path, PaneBindingStatus::AdoptedDead));
+    }
+    match_found
+}
+
+fn is_release_pending_name(name: &OsStr) -> bool {
+    name.to_string_lossy().contains(".release-")
+}
+
+/// Directory-fd anchor for destructive identity operations. Once opened, a
+/// concurrent parent-directory rename or symlink swap cannot redirect any
+/// rename/unlink below it.
+#[cfg(unix)]
+struct AnchoredIdentity {
+    parent: File,
+    file_name: std::ffi::OsString,
+}
+
+#[cfg(unix)]
+impl AnchoredIdentity {
+    fn open(path: &Path) -> std::io::Result<Self> {
+        let parent_path = path.parent().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "identity has no parent")
+        })?;
+        if path_has_symlinked_parent(path)? {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "refusing symlinked identity parent {}",
+                    parent_path.display()
+                ),
+            ));
+        }
+
+        #[cfg(target_os = "linux")]
+        let parent = {
+            use nix::fcntl::{OFlag, OpenHow, ResolveFlag, openat2};
+            let root = File::open("/")?;
+            let relative = parent_path.strip_prefix("/").map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "identity parent must be absolute",
+                )
+            })?;
+            let fd = openat2(
+                &root,
+                relative,
+                OpenHow::new()
+                    .flags(OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC)
+                    .resolve(ResolveFlag::RESOLVE_NO_SYMLINKS),
+            )
+            .map_err(nix_to_io)?;
+            File::from(fd)
+        };
+
+        #[cfg(not(target_os = "linux"))]
+        let parent = {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(nix::libc::O_DIRECTORY | nix::libc::O_NOFOLLOW)
+                .open(parent_path)?
+        };
+
+        let file_name = path.file_name().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "identity has no filename")
+        })?;
+        Ok(Self {
+            parent,
+            file_name: file_name.to_os_string(),
+        })
+    }
+
+    fn read(&self, name: &OsStr) -> std::io::Result<String> {
+        let fd = nix::fcntl::openat(
+            &self.parent,
+            name,
+            nix::fcntl::OFlag::O_RDONLY
+                | nix::fcntl::OFlag::O_CLOEXEC
+                | nix::fcntl::OFlag::O_NOFOLLOW,
+            nix::sys::stat::Mode::empty(),
+        )
+        .map_err(nix_to_io)?;
+        let mut file = File::from(fd);
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        Ok(content)
+    }
+
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    fn rename_no_replace(&self, from: &OsStr, to: &OsStr) -> std::io::Result<()> {
+        nix::fcntl::renameat2(
+            &self.parent,
+            from,
+            &self.parent,
+            to,
+            nix::fcntl::RenameFlags::RENAME_NOREPLACE,
+        )
+        .map_err(nix_to_io)
+    }
+
+    #[cfg(all(
+        not(all(target_os = "linux", target_env = "gnu")),
+        not(target_os = "redox")
+    ))]
+    fn rename_no_replace(&self, from: &OsStr, to: &OsStr) -> std::io::Result<()> {
+        // POSIX linkat is an atomic no-replace claim on `to`. Removing the old
+        // link afterward gives rename semantics without the check-then-rename
+        // overwrite race present in plain renameat on macOS.
+        nix::unistd::linkat(
+            &self.parent,
+            from,
+            &self.parent,
+            to,
+            nix::fcntl::AtFlags::empty(),
+        )
+        .map_err(nix_to_io)?;
+        self.unlink(from)
+    }
+
+    #[cfg(target_os = "redox")]
+    fn rename_no_replace(&self, _from: &OsStr, _to: &OsStr) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "atomic no-replace identity release is unavailable on this platform",
+        ))
+    }
+
+    fn unlink(&self, name: &OsStr) -> std::io::Result<()> {
+        nix::unistd::unlinkat(&self.parent, name, nix::unistd::UnlinkatFlags::NoRemoveDir)
+            .map_err(nix_to_io)
+    }
+
+    fn sync(&self) -> std::io::Result<()> {
+        self.parent.sync_all()
+    }
+}
+
+#[cfg(unix)]
+fn nix_to_io(error: nix::errno::Errno) -> std::io::Error {
+    std::io::Error::from_raw_os_error(error as i32)
+}
+
+#[cfg(not(unix))]
+struct AnchoredIdentity {
+    parent: PathBuf,
+    file_name: std::ffi::OsString,
+}
+
+#[cfg(not(unix))]
+impl AnchoredIdentity {
+    fn open(path: &Path) -> std::io::Result<Self> {
+        Ok(Self {
+            parent: path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf(),
+            file_name: path
+                .file_name()
+                .unwrap_or_else(|| OsStr::new("identity"))
+                .to_os_string(),
+        })
+    }
+    fn full_path(&self, name: &OsStr) -> PathBuf {
+        self.parent.join(name)
+    }
+    fn read(&self, name: &OsStr) -> std::io::Result<String> {
+        std::fs::read_to_string(self.full_path(name))
+    }
+    fn rename_no_replace(&self, from: &OsStr, to: &OsStr) -> std::io::Result<()> {
+        std::fs::hard_link(self.full_path(from), self.full_path(to))?;
+        self.unlink(from)
+    }
+    fn unlink(&self, name: &OsStr) -> std::io::Result<()> {
+        std::fs::remove_file(self.full_path(name))
+    }
+    fn sync(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 fn path_has_symlinked_parent(path: &Path) -> std::io::Result<bool> {
     let Some(parent) = path.parent() else {
         return Ok(false);
@@ -893,9 +1764,76 @@ fn path_has_symlinked_parent(path: &Path) -> std::io::Result<bool> {
     Ok(false)
 }
 
-fn file_name_matches_live_pane(file_name: &OsStr, live_panes: &[String]) -> bool {
-    let name = file_name.to_string_lossy();
-    live_panes.iter().any(|pane| pane.as_str() == name.as_ref())
+fn pending_original_name(file_name: &OsStr) -> Option<&str> {
+    let name = file_name.to_str()?.strip_prefix('.')?;
+    let (original, suffix) = name.split_once(".release-")?;
+    (!original.is_empty() && !suffix.is_empty()).then_some(original)
+}
+
+fn pending_release_paths(path: &Path) -> Vec<PathBuf> {
+    identity_sibling_paths(path, ".release-")
+}
+
+fn released_identity_paths(path: &Path) -> Vec<PathBuf> {
+    identity_sibling_paths(path, ".released-")
+}
+
+fn identity_sibling_paths(path: &Path, marker: &str) -> Vec<PathBuf> {
+    let Some(parent) = path.parent() else {
+        return Vec::new();
+    };
+    if path_has_symlinked_parent(path).unwrap_or(true) {
+        return Vec::new();
+    }
+    let Some(file_name) = path.file_name() else {
+        return Vec::new();
+    };
+    let prefix = format!(".{}{marker}", file_name.to_string_lossy());
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return Vec::new();
+    };
+    let mut candidates: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(prefix.as_str())
+                && entry.file_type().is_ok_and(|file_type| file_type.is_file())
+        })
+        .map(|entry| entry.path())
+        .collect();
+    candidates.sort_by(|left, right| {
+        let left_modified = std::fs::metadata(left)
+            .and_then(|metadata| metadata.modified())
+            .ok();
+        let right_modified = std::fs::metadata(right)
+            .and_then(|metadata| metadata.modified())
+            .ok();
+        left_modified
+            .cmp(&right_modified)
+            .then_with(|| left.cmp(right))
+    });
+    candidates
+}
+
+/// Resolve the newest durable release receipt for a pane.
+#[must_use]
+pub fn resolve_released_identity(project_key: &str, pane_id: &str) -> Option<(String, PathBuf)> {
+    released_identity_paths(&canonical_identity_path(project_key, pane_id))
+        .into_iter()
+        .rev()
+        .find_map(|path| read_identity_record(&path).map(|record| (record.name, path)))
+}
+
+fn is_released_name(file_name: &OsStr) -> bool {
+    file_name.to_string_lossy().contains(".released-")
+}
+
+fn released_name_for_pending(file_name: &OsStr) -> Option<std::ffi::OsString> {
+    let name = file_name.to_str()?;
+    name.contains(".release-")
+        .then(|| std::ffi::OsString::from(name.replacen(".release-", ".released-", 1)))
 }
 
 /// Compute a truncated SHA-1 hex hash of the project key.
@@ -1209,6 +2147,15 @@ fn identity_entry_is_stale(entry: &std::fs::DirEntry, live_panes: &[String]) -> 
     }
 }
 
+fn file_name_matches_live_pane(file_name: &OsStr, live_panes: &[String]) -> bool {
+    let key = pending_original_name(file_name)
+        .map(str::to_owned)
+        .unwrap_or_else(|| file_name.to_string_lossy().into_owned());
+    live_panes
+        .iter()
+        .any(|pane| sanitize_pane_id(pane) == key || pane.trim() == key)
+}
+
 /// Run tmux with `args`.
 ///
 /// `Err` means tmux could not be executed at all (binary missing, not
@@ -1476,55 +2423,10 @@ fn test_live_tmux_panes() -> Option<Vec<String>> {
 
 #[cfg(test)]
 fn set_test_live_tmux_panes(panes: Option<Vec<String>>) {
+    TEST_TMUX_QUERY_CALLS.store(0, std::sync::atomic::Ordering::SeqCst);
     *TEST_LIVE_TMUX_PANES
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = panes;
-}
-
-/// Query tmux for all live pane IDs (sanitized).
-///
-/// Returns composite keys (`session_name:window_index:pane_index`) for each
-/// live pane, plus the legacy bare pane ID (e.g., `%3` -> `3`) for backwards
-/// compatibility during cleanup. Returns an empty vec if tmux is not running
-/// or the command fails.
-fn list_live_tmux_panes() -> Vec<String> {
-    #[cfg(test)]
-    if let Some(panes) = test_live_tmux_panes() {
-        return panes;
-    }
-
-    let output = tmux_command()
-        .args([
-            "list-panes",
-            "-a",
-            "-F",
-            "#{session_name}:#{window_index}:#{pane_index}:#{pane_id}",
-        ])
-        .output();
-
-    match output {
-        Ok(out) if out.status.success() => {
-            let text = String::from_utf8_lossy(&out.stdout);
-            let mut ids = Vec::new();
-            for line in text.lines().filter(|l| !l.is_empty()) {
-                let line = line.trim();
-                // Parse "session:window:pane_idx:pane_id" format.
-                // The composite key is the first three fields joined by `:`.
-                // We also include the bare pane_id for backwards compat.
-                if let Some((composite, bare_id)) = line.rsplit_once(':') {
-                    ids.push(sanitize_pane_id(composite));
-                    ids.push(sanitize_pane_id(bare_id));
-                } else {
-                    // Fallback: treat the entire line as a bare pane ID
-                    ids.push(sanitize_pane_id(line));
-                }
-            }
-            ids.sort();
-            ids.dedup();
-            ids
-        }
-        _ => Vec::new(),
-    }
 }
 
 /// Get a composite tmux pane identifier for the **caller's own** pane.
@@ -1680,6 +2582,24 @@ mod tests {
         }
     }
 
+    fn write_v1_fixture(project: &str, composite: &str, bare: &str, agent: &str) -> PathBuf {
+        let path = canonical_identity_path(project, composite);
+        std::fs::create_dir_all(path.parent().expect("identity parent"))
+            .expect("create identity parent");
+        let content = serde_json::json!({
+            "schema_version": "am.pane-binding.v1",
+            "name": agent,
+            "pane_id": composite,
+            "socket_path": "/tmp/agent-mail-test-no-server",
+            "socket_device": 7,
+            "socket_inode": 11,
+            "server_pid": 13,
+            "tmux_pane_id": bare,
+        });
+        std::fs::write(&path, format!("{content}\n")).expect("write v1 fixture");
+        path
+    }
+
     // -- identity_source_category -------------------------------------------
 
     #[test]
@@ -1822,6 +2742,26 @@ mod tests {
     }
 
     #[test]
+    fn registration_refuses_lossy_session_alias_collision() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("alias-collision-project");
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+        let spaced = canonical_identity_path(&project, "foo bar:1:1");
+        let punctuated = canonical_identity_path(&project, "foo@bar:1:1");
+        assert_eq!(spaced, punctuated);
+
+        write_identity(&project, "foo bar:1:1", "BlueLake").expect("first binding");
+        let error = write_identity(&project, "foo@bar:1:1", "GreenHarbor")
+            .expect_err("colliding target must not overwrite the first identity");
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            resolve_identity(&project, "foo bar:1:1").as_deref(),
+            Some("BlueLake")
+        );
+        assert!(resolve_identity(&project, "foo@bar:1:1").is_none());
+    }
+
+    #[test]
     fn canonical_path_honors_virtual_xdg_config_home() {
         let _guard = TEST_CONFIG_BASE_DIR_SERIAL
             .lock()
@@ -1912,6 +2852,22 @@ mod tests {
     }
 
     #[test]
+    fn read_identity_file_extracts_name_from_ntm_receipt() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file_path = tmp.path().join("identity");
+        std::fs::write(
+            &file_path,
+            r#"{"name":"BronzeCardinal","pane_id":"%42","pane_pid":1234}"#,
+        )
+        .expect("write receipt");
+
+        assert_eq!(
+            read_identity_file(&file_path).as_deref(),
+            Some("BronzeCardinal")
+        );
+    }
+
+    #[test]
     fn read_identity_file_missing_returns_none() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("nonexistent");
@@ -1954,6 +2910,366 @@ mod tests {
 
         let resolved = resolve_identity(&unique_key, composite_pane);
         assert_eq!(resolved.as_deref(), Some("GreenOwl"));
+        drop(config);
+    }
+
+    #[test]
+    fn release_identity_removes_only_expected_dead_binding() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-dead-project");
+        let pane = "%42";
+        let path = write_identity(&project, pane, "BlueLake").expect("write identity");
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+
+        let (agent, released_path) =
+            release_identity(&project, pane, "BlueLake").expect("release dead pane");
+
+        assert_eq!(agent, "BlueLake");
+        assert_ne!(released_path, path);
+        assert!(!path.exists());
+        assert!(released_path.exists());
+        assert_eq!(
+            resolve_released_identity(&project, pane)
+                .as_ref()
+                .map(|(name, _)| name.as_str()),
+            Some("BlueLake")
+        );
+        let second = release_identity(&project, pane, "BlueLake")
+            .expect_err("double release must report no binding");
+        assert_eq!(second.kind(), std::io::ErrorKind::NotFound);
+        write_identity(&project, pane, "NewHarbor").expect("claim after release");
+        assert_eq!(
+            resolve_identity(&project, pane).as_deref(),
+            Some("NewHarbor")
+        );
+        drop(config);
+    }
+
+    #[test]
+    fn legacy_live_binding_is_never_generation_verified() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("legacy-live-state");
+        let tmux = LiveTmuxPanesGuard::new(vec!["%42".into()]);
+        let path = write_identity(&project, "%42", "BlueLake").expect("write legacy binding");
+
+        assert_eq!(
+            identity_binding_state("%42", &path).expect("classify binding"),
+            "live-unverified"
+        );
+        drop(tmux);
+        drop(config);
+    }
+
+    #[test]
+    fn binding_generation_parser_requires_the_complete_v1_marker() {
+        let complete = serde_json::json!({
+            "schema_version": "am.pane-binding.v1",
+            "name": "BlueLake",
+            "pane_id": "main:0:1",
+            "socket_path": "/tmp/tmux-1000/default",
+            "socket_device": 7,
+            "socket_inode": 11,
+            "server_pid": 13,
+            "tmux_pane_id": "%17",
+        });
+        let parsed = parse_binding_generation(&complete.to_string()).expect("parse generation");
+        assert_eq!(parsed.pane_id, "main:0:1");
+        assert_eq!(parsed.socket_device, 7);
+        assert_eq!(parsed.socket_inode, 11);
+        assert_eq!(parsed.server_pid, 13);
+        assert_eq!(parsed.tmux_pane_id, "%17");
+
+        let mut incomplete = complete;
+        incomplete
+            .as_object_mut()
+            .expect("binding object")
+            .remove("socket_inode");
+        assert!(parse_binding_generation(&incomplete.to_string()).is_none());
+    }
+
+    #[test]
+    fn generation_match_ignores_renamed_composite_but_not_stable_tmux_fields() {
+        let original = BindingGeneration {
+            pane_id: "former:1:2".into(),
+            socket_path: "/tmp/tmux-1000/default".into(),
+            socket_device: 7,
+            socket_inode: 11,
+            server_pid: 13,
+            tmux_pane_id: "%42".into(),
+        };
+        let mut renamed = original.clone();
+        renamed.pane_id = "current:1:2".into();
+        assert!(binding_generations_are_same(&original, &renamed));
+
+        renamed.server_pid = 14;
+        assert!(!binding_generations_are_same(&original, &renamed));
+    }
+
+    #[test]
+    fn dead_composite_v1_binding_resolves_and_releases_by_bare_pane() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("dead-composite-v1-project");
+        let path = write_v1_fixture(&project, "former:1:2", "%42", "BlueLake");
+
+        assert_eq!(
+            resolve_identity(&project, "%42").as_deref(),
+            Some("BlueLake")
+        );
+        let (_, released) =
+            release_identity(&project, "%42", "BlueLake").expect("release dead v1 row");
+
+        assert!(!path.exists());
+        assert!(released.exists());
+        assert_eq!(
+            resolve_released_identity(&project, "%42")
+                .as_ref()
+                .map(|(name, path)| (name.as_str(), path)),
+            Some(("BlueLake", &released))
+        );
+        drop(config);
+    }
+
+    #[test]
+    fn ambiguous_dead_v1_generations_for_bare_pane_fail_closed() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("ambiguous-v1-project");
+        write_v1_fixture(&project, "former-a:1:2", "%42", "BlueLake");
+        write_v1_fixture(&project, "former-b:1:2", "%42", "RedStone");
+
+        assert!(resolve_identity(&project, "%42").is_none());
+        let error = release_identity(&project, "%42", "BlueLake")
+            .expect_err("ambiguous generations must not be guessed");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+        drop(config);
+    }
+
+    #[test]
+    fn composite_v1_inventory_uses_stored_pane_and_cleanup_releases_it() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("composite-v1-inventory-project");
+        let composite = "former:1:2";
+        let path = write_v1_fixture(&project, composite, "%42", "BlueLake");
+
+        let listed = list_identities_with_paths(&project);
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].0, composite);
+        assert_eq!(listed[0].1, "BlueLake");
+        assert_eq!(listed[0].2, path);
+
+        let released = cleanup_stale_identities(&project);
+        assert_eq!(released.len(), 1);
+        assert!(!path.exists());
+        assert!(released[0].exists());
+        drop(config);
+    }
+
+    #[test]
+    fn exact_composite_match_beats_lossy_sanitized_alias() {
+        assert!(!tmux_pane_id_is_exact_match(
+            "foo@bar:1:1",
+            "foo bar:1:1",
+            "%0"
+        ));
+        assert!(tmux_pane_ids_match("foo@bar:1:1", "foo bar:1:1"));
+        assert!(tmux_pane_id_is_exact_match(
+            "foo@bar:1:1",
+            "foo@bar:1:1",
+            "%1"
+        ));
+    }
+
+    #[test]
+    fn successful_release_removes_older_pending_sibling() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-pending-sibling-project");
+        let pane = "%42";
+        let canonical = write_identity(&project, pane, "NewAgent").expect("write identity");
+        let pending = canonical.with_file_name(".42.release-old-fixture");
+        std::fs::write(&pending, "OldAgent\n").expect("write old pending identity");
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+
+        release_identity(&project, pane, "NewAgent").expect("release dead pane state");
+
+        assert!(resolve_identity(&project, pane).is_none());
+        assert!(!canonical.exists());
+        assert!(!pending.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn tmux_no_server_errors_mean_no_live_panes() {
+        assert!(tmux_output_means_no_server(
+            "no server running on /tmp/tmux-1/default"
+        ));
+        assert!(tmux_output_means_no_server(
+            "error connecting to /tmp/tmux-1/test (No such file or directory)"
+        ));
+        assert!(!tmux_output_means_no_server("permission denied"));
+        assert!(!tmux_output_means_no_server(
+            "failed to connect to server: Permission denied"
+        ));
+    }
+
+    #[test]
+    fn release_identity_refuses_live_pane_and_preserves_binding() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-live-project");
+        let pane = "%42";
+        let path = write_identity(&project, pane, "BlueLake").expect("write identity");
+        let _tmux = LiveTmuxPanesGuard::new(vec![pane.to_string()]);
+
+        let error = release_identity(&project, pane, "BlueLake")
+            .expect_err("live pane release must refuse");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(path.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn release_identity_refuses_live_unprefixed_numeric_pane() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-live-unprefixed-project");
+        let path = write_identity(&project, "42", "BlueLake").expect("write identity");
+        let _tmux = LiveTmuxPanesGuard::new(vec!["%42".to_string()]);
+
+        let error = release_identity(&project, "42", "BlueLake")
+            .expect_err("unprefixed alias of live pane must refuse");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(path.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn release_identity_preserves_binding_when_tmux_query_fails() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-query-failure-project");
+        let path = write_identity(&project, "%42", "BlueLake").expect("write identity");
+        let _tmux = LiveTmuxPanesGuard::new(vec!["__QUERY_ERROR__".to_string()]);
+
+        let error = release_identity(&project, "%42", "BlueLake")
+            .expect_err("tmux query failure must fail closed");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(path.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn pending_release_remains_resolvable_after_crash_window() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-crash-project");
+        let pane = "%42";
+        let path = write_identity(&project, pane, "BlueLake").expect("write identity");
+        let pending = path.with_file_name(".42.release-crash-fixture");
+        std::fs::rename(&path, &pending).expect("simulate crash after quarantine rename");
+
+        let (agent, resolved_path) =
+            resolve_identity_with_path(&project, pane).expect("pending identity must resolve");
+
+        assert_eq!(agent, "BlueLake");
+        assert_eq!(resolved_path, pending);
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+        release_identity(&project, pane, "BlueLake").expect("retry pending release");
+        assert!(resolve_identity(&project, pane).is_none());
+        drop(config);
+    }
+
+    #[test]
+    fn pending_release_survives_late_tmux_query_failure() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-pending-query-failure-project");
+        let pane = "%42";
+        let path = write_identity(&project, pane, "BlueLake").expect("write identity");
+        let pending = path.with_file_name(".42.release-crash-fixture");
+        std::fs::rename(&path, &pending).expect("simulate pending release");
+        let _tmux = LiveTmuxPanesGuard::new(vec!["__QUERY_ERROR_AFTER_1__".to_string()]);
+
+        let error = release_identity(&project, pane, "BlueLake")
+            .expect_err("late tmux query failure must fail closed");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            resolve_identity(&project, pane).as_deref(),
+            Some("BlueLake")
+        );
+        assert!(pending.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn recycled_pane_becoming_live_after_quarantine_is_restored() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-late-live-project");
+        let pane = "%42";
+        let path = write_identity(&project, pane, "BlueLake").expect("write identity");
+        let _tmux = LiveTmuxPanesGuard::new(vec!["__LIVE_AFTER_1__:%42".to_string()]);
+
+        let error = release_identity(&project, pane, "BlueLake")
+            .expect_err("pane recycled after quarantine must refuse");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            resolve_identity(&project, pane).as_deref(),
+            Some("BlueLake")
+        );
+        assert!(path.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn anchored_restore_never_overwrites_concurrent_canonical_binding() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-no-overwrite-project");
+        let pane = "%42";
+        let path = write_identity(&project, pane, "NewAgent").expect("write canonical");
+        let pending = path.with_file_name(".42.release-race-fixture");
+        std::fs::write(&pending, "OldAgent\n").expect("write pending identity");
+        let anchored = AnchoredIdentity::open(&path).expect("open identity parent");
+
+        let error = anchored
+            .rename_no_replace(
+                pending.file_name().expect("pending name"),
+                path.file_name().expect("canonical name"),
+            )
+            .expect_err("restore must not replace a concurrent canonical binding");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(read_identity_file(&path).as_deref(), Some("NewAgent"));
+        assert_eq!(read_identity_file(&pending).as_deref(), Some("OldAgent"));
+        drop(config);
+    }
+
+    #[test]
+    fn release_identity_refuses_live_composite_pane_and_preserves_binding() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-live-composite-project");
+        let pane = "session-a:1:2";
+        let path = write_identity(&project, pane, "BlueLake").expect("write identity");
+        let _tmux = LiveTmuxPanesGuard::new(vec![pane.to_string()]);
+
+        let error = release_identity(&project, pane, "BlueLake")
+            .expect_err("live composite pane release must refuse");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(path.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn release_identity_refuses_wrong_agent_and_preserves_binding() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("release-wrong-agent-project");
+        let pane = "%42";
+        let path = write_identity(&project, pane, "BlueLake").expect("write identity");
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+
+        let error = release_identity(&project, pane, "RedStone")
+            .expect_err("wrong-agent release must refuse");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(path.exists());
         drop(config);
     }
 
@@ -2032,6 +3348,7 @@ mod tests {
     #[test]
     fn composite_resolution_honors_virtual_bare_tmux_pane_fallback() {
         let config = IsolatedConfigBaseDir::new();
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
         let unique_key = config.project_key("bare-fallback-project");
         let bare_pane = "%23";
         let written_path =
@@ -2050,15 +3367,102 @@ mod tests {
     #[test]
     fn list_identities_returns_entries() {
         let config = IsolatedConfigBaseDir::new();
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
         let unique_key = config.project_key("list-project");
         let pane = "%99";
         write_identity(&unique_key, pane, "RedFox").expect("write identity");
 
         let entries = list_identities(&unique_key);
         assert!(
-            entries.iter().any(|(p, n)| p == "99" && n == "RedFox"),
+            entries.iter().any(|(p, n)| p == "%99" && n == "RedFox"),
             "expected RedFox entry: {entries:?}"
         );
+        drop(config);
+    }
+
+    #[test]
+    fn cleanup_and_listing_preserve_live_pending_release_identity() {
+        let config = IsolatedConfigBaseDir::new();
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
+        let scoped_project = config.project_key("pending-scoped-cleanup-project");
+        let global_project = config.project_key("pending-global-cleanup-project");
+        let scoped =
+            write_identity(&scoped_project, "%42", "BlueLake").expect("write scoped identity");
+        let global =
+            write_identity(&global_project, "%42", "RedStone").expect("write global identity");
+        let scoped_pending = scoped.with_file_name(".42.release-scoped-fixture");
+        let global_pending = global.with_file_name(".42.release-global-fixture");
+        std::fs::rename(&scoped, &scoped_pending).expect("quarantine scoped identity");
+        std::fs::rename(&global, &global_pending).expect("quarantine global identity");
+        set_test_live_tmux_panes(Some(vec!["42".to_string()]));
+
+        assert!(cleanup_stale_identities(&scoped_project).is_empty());
+        assert!(scoped_pending.exists());
+        assert_eq!(
+            list_identities(&scoped_project),
+            vec![("%42".to_string(), "BlueLake".to_string())]
+        );
+
+        assert!(cleanup_all_stale_identities().is_empty());
+        assert!(scoped_pending.exists());
+        assert!(global_pending.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn cleanup_releases_dead_binding_but_preserves_live_binding() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("safe-cleanup-project");
+        let dead = write_identity(&project, "%41", "OldHarbor").expect("write dead binding");
+        let live = write_identity(&project, "%42", "BlueLake").expect("write live binding");
+        let _tmux = LiveTmuxPanesGuard::new(vec!["%42".to_string()]);
+
+        let released = cleanup_stale_identities(&project);
+
+        assert_eq!(released.len(), 1);
+        assert!(released[0].exists());
+        assert!(!dead.exists());
+        assert!(live.exists());
+        assert_eq!(
+            resolve_identity(&project, "%42").as_deref(),
+            Some("BlueLake")
+        );
+        write_identity(&project, "%41", "NewHarbor").expect("claim released pane");
+        assert_eq!(
+            resolve_identity(&project, "%41").as_deref(),
+            Some("NewHarbor")
+        );
+        drop(config);
+    }
+
+    #[test]
+    fn cleanup_fails_closed_when_tmux_query_fails() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("cleanup-query-failure-project");
+        let binding = write_identity(&project, "%42", "BlueLake").expect("write identity binding");
+        let _tmux = LiveTmuxPanesGuard::new(vec!["__QUERY_ERROR__".to_string()]);
+
+        assert!(cleanup_stale_identities(&project).is_empty());
+        assert!(binding.exists());
+        drop(config);
+    }
+
+    #[test]
+    fn cleanup_preserves_live_composite_binding_from_sanitized_filename() {
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("cleanup-live-composite-project");
+        let pane = "session-a:1:2";
+        let binding = write_identity(&project, pane, "BlueLake").expect("write binding");
+        assert!(
+            binding
+                .file_name()
+                .and_then(OsStr::to_str)
+                .is_some_and(|name| name == "session-a-1-2")
+        );
+        let _tmux = LiveTmuxPanesGuard::new(vec![pane.to_string()]);
+
+        assert!(cleanup_stale_identities(&project).is_empty());
+        assert!(binding.exists());
         drop(config);
     }
 
@@ -2326,6 +3730,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let config = IsolatedConfigBaseDir::new();
+        let _tmux = LiveTmuxPanesGuard::new(Vec::new());
         let project = config.project_key("backend");
 
         // The caller's pane %97 has composite key main:14:1, which owns the

--- a/crates/mcp-agent-mail-tools/src/identity.rs
+++ b/crates/mcp-agent-mail-tools/src/identity.rs
@@ -3034,33 +3034,37 @@ pub async fn resolve_pane_identity(
         &effective_pane,
     );
 
-    resolve_identity_from_project_keys(&project_keys, &effective_pane).map_or_else(
-        || {
-            Err(legacy_tool_error(
-                "IDENTITY_NOT_FOUND",
-                format!(
-                    "No identity file found for pane '{effective_pane}' in project '{project_key}'. \
-                     Register an agent first with register_agent or macro_start_session."
-                ),
-                false,
-                json!({
-                    "pane_id": effective_pane,
-                    "project_key": project_key,
-                    "checked_path": checked_path.to_string_lossy(),
-                }),
-            ))
-        },
-        |(agent_name, resolved_path, binding)| {
-            let response = json!({
-                "agent_name": agent_name,
+    let resolved = resolve_identity_from_project_keys(&project_keys, &effective_pane)
+        .map(|(name, path, binding)| (name, path, binding.as_str().to_string()))
+        .or_else(|| {
+            project_keys.iter().find_map(|key| {
+                mcp_agent_mail_core::resolve_released_identity(key, &effective_pane)
+                    .map(|(name, path)| (name, path, "released".to_string()))
+            })
+        });
+    let Some((agent_name, resolved_path, binding)) = resolved else {
+        return Err(legacy_tool_error(
+            "IDENTITY_NOT_FOUND",
+            format!(
+                "No identity file found for pane '{effective_pane}' in project '{project_key}'. \
+                 Register an agent first with register_agent or macro_start_session."
+            ),
+            false,
+            json!({
                 "pane_id": effective_pane,
-                "identity_path": resolved_path.to_string_lossy(),
-                "binding": binding.as_str(),
-            });
-            serde_json::to_string(&response)
-                .map_err(|e| McpError::internal_error(format!("JSON error: {e}")))
-        },
-    )
+                "project_key": project_key,
+                "checked_path": checked_path.to_string_lossy(),
+            }),
+        ));
+    };
+    let response = json!({
+        "agent_name": agent_name,
+        "pane_id": effective_pane,
+        "identity_path": resolved_path.to_string_lossy(),
+        "binding": binding,
+    });
+    serde_json::to_string(&response)
+        .map_err(|e| McpError::internal_error(format!("JSON error: {e}")))
 }
 
 /// Clean up stale per-pane identity files for dead tmux panes.
@@ -3074,7 +3078,7 @@ pub async fn resolve_pane_identity(
 /// # Conformance
 /// Rust-native.
 #[tool(
-    description = "Remove stale per-pane identity files for tmux panes that no longer exist.\n\nQueries tmux for live panes and removes identity files that reference dead panes.\nSafety: does nothing if tmux is not running (to avoid accidentally removing everything).\n\nParameters\n----------\nproject_key : Optional[str]\n    If provided, only clean up identity files for this project.\n    If omitted, clean up across all projects.\n\nReturns\n-------\ndict\n    { removed_count, removed_paths }"
+    description = "Release stale per-pane identity bindings for tmux panes that no longer exist.\n\nEvery row is compare-and-released through repeated direct tmux probes. A live pane or failed liveness query is refused; an absent tmux server means there are no live panes.\n\nParameters\n----------\nproject_key : Optional[str]\n    If provided, only clean up identity files for this project.\n    If omitted, clean up across all projects.\n\nReturns\n-------\ndict\n    { schema_version, released_count, released_paths }"
 )]
 pub fn cleanup_pane_identities(
     _ctx: &McpContext,
@@ -3091,8 +3095,9 @@ pub fn cleanup_pane_identities(
         .collect();
 
     let response = json!({
-        "removed_count": removed.len(),
-        "removed_paths": paths,
+        "schema_version": "am.agents.sweep.v1",
+        "released_count": removed.len(),
+        "released_paths": paths,
     });
 
     serde_json::to_string(&response)


### PR DESCRIPTION
## Summary

- port the five local agent-factory-7x5 pane-identity commits onto current main and reconcile them with the GH#252 binding model
- make cleanup and explicit release durable through pending/released tombstones, with generation-aware tmux evidence and crash-safe restore
- refuse destructive release when a binding is live, recycled, query-unverifiable, or lacks sufficient generation/liveness evidence
- preserve legacy identity resolution conservatively and heal unevidenced rows on re-registration

This combines agent-factory-7x5 with its required agent-factory-3tf reconciliation. The intermediate 7x5-only landing commit is intentionally not proposed alone because later falsification proved its unevidenced fallback could release a live binding.

## Verification

At head `c4e1f61adb7b4b361f639b75788ad97923c7b99b`:

- `cargo fmt --check`: passed
- `git diff --check origin/main..HEAD`: passed
- pane-identity unit suite: 93 passed, 0 failed (exact-commit test binary, `TMPDIR=/dev/shm`)
- three affected crates (`mcp-agent-mail-core`, `mcp-agent-mail-tools`, `mcp-agent-mail-cli`): cold build reached the branch crates, then the shared Cargo target filled `/` and rustc failed with `ENOSPC` while compiling `beads_rust` / a tools integration target; no Rust diagnostic from this branch
- upstream CI: not yet scheduled for this fork PR; maintainer workflow approval may be required

The production Agent Mail service remains pinned to the previously verified `am 0.3.30` binary until this PR is merged; this PR source follows current upstream `0.3.31`.

## Tracking

- agent-factory-7x5
- agent-factory-3tf
- agent-factory-38u7