### PR TITLE
fix(identity): preserve caller tmux socket during registration

### DIFF
--- a/crates/mcp-agent-mail-cli/src/doctor/selftest.rs
+++ b/crates/mcp-agent-mail-cli/src/doctor/selftest.rs
@@ -565,6 +565,7 @@ fn run_selftest_sequence_in_process(project_key: &str) -> WriteSelftestReport {
             None,
             None,
             None,
+            None,
         )
         .await
         {
@@ -583,6 +584,7 @@ fn run_selftest_sequence_in_process(project_key: &str) -> WriteSelftestReport {
             "selftest".to_string(),
             Some(RECIPIENT.to_string()),
             Some("doctor write-selftest recipient".to_string()),
+            None,
             None,
             None,
             None,

--- a/crates/mcp-agent-mail-cli/src/lib.rs
+++ b/crates/mcp-agent-mail-cli/src/lib.rs
@@ -39770,6 +39770,7 @@ async fn handle_macros_async(action: MacroCommand) -> CliResult<()> {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .map_err(mcp_error_to_cli_error)?;
@@ -41244,6 +41245,37 @@ mod mail_server_cli_bridge_tests {
         assert_eq!(trusted_tmux_pane_header_value(None), None);
         let too_long = format!("%{}", "9".repeat(80));
         assert_eq!(trusted_tmux_pane_header_value(Some(&too_long)), None);
+    }
+
+    #[test]
+    fn caller_tmux_socket_header_uses_only_valid_tmux_socket_field() {
+        use crate::caller_tmux_socket_header;
+
+        mcp_agent_mail_core::config::with_process_env_overrides_for_test(
+            &[("TMUX", "/tmp/tmux-1001/gpqeprobe,12345,0")],
+            || {
+                assert_eq!(
+                    caller_tmux_socket_header()
+                        .expect("valid tmux socket context")
+                        .as_deref(),
+                    Some("/tmp/tmux-1001/gpqeprobe")
+                );
+            },
+        );
+        for hostile in ["relative/socket,12345,0", "/tmp/good\r\nX-Bad: yes,12345,0"] {
+            mcp_agent_mail_core::config::with_process_env_overrides_for_test(
+                &[("TMUX", hostile)],
+                || {
+                    assert!(
+                        caller_tmux_socket_header().is_err(),
+                        "hostile TMUX socket context was silently downgraded: {hostile:?}"
+                    );
+                },
+            );
+        }
+        mcp_agent_mail_core::config::with_process_env_overrides_for_test(&[("TMUX", "")], || {
+            assert!(caller_tmux_socket_header().is_err())
+        });
     }
 
     #[test]
@@ -85048,7 +85080,24 @@ fn trusted_tmux_pane_header_value(raw: Option<&str>) -> Option<String> {
 /// daemon injects this into identity-tool args so pane-identity reuse works for
 /// CLI-routed identity calls.
 fn caller_tmux_pane_header() -> Option<String> {
-    trusted_tmux_pane_header_value(std::env::var("TMUX_PANE").ok().as_deref())
+    trusted_tmux_pane_header_value(
+        mcp_agent_mail_core::config::process_env_value("TMUX_PANE").as_deref(),
+    )
+}
+
+/// The caller's tmux server socket as a trusted `X-Tmux-Socket` header.
+///
+/// `$TMUX` is `<socket_path>,<server_pid>,<session_index>`. The CLI extracts
+/// only the first field and applies the shared absolute/bounded/newline-free
+/// validator before the value can cross the HTTP boundary.
+fn caller_tmux_socket_header() -> CliResult<Option<String>> {
+    let Some(tmux) = mcp_agent_mail_core::config::process_env_value("TMUX") else {
+        return Ok(None);
+    };
+    let socket_path = tmux.split(',').next().unwrap_or_default();
+    mcp_agent_mail_core::validate_tmux_socket_path(Some(socket_path)).map_err(|message| {
+        CliError::InvalidArgument(format!("invalid TMUX socket context: {message}"))
+    })
 }
 
 fn post_jsonrpc_request_blocking_http(
@@ -85084,13 +85133,17 @@ fn post_jsonrpc_request_blocking_http(
     let x_tmux_pane = caller_tmux_pane_header()
         .map(|pane| format!("X-Tmux-Pane: {pane}\r\n"))
         .unwrap_or_default();
+    let x_tmux_socket = caller_tmux_socket_header()?
+        .map(|socket_path| format!("X-Tmux-Socket: {socket_path}\r\n"))
+        .unwrap_or_default();
     let head = format!(
-        "POST {} HTTP/1.1\r\nHost: {}\r\nUser-Agent: mcp-agent-mail-cli\r\nAccept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n{}{}\r\n",
+        "POST {} HTTP/1.1\r\nHost: {}\r\nUser-Agent: mcp-agent-mail-cli\r\nAccept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n{}{}{}\r\n",
         target.request_target,
         target.host_header,
         body.len(),
         authorization,
-        x_tmux_pane
+        x_tmux_pane,
+        x_tmux_socket
     );
     // GH#220: writes must retry transient EAGAIN/EINTR just like reads.
     let deadline = std::time::Instant::now() + timeout;
@@ -85383,6 +85436,9 @@ async fn post_jsonrpc_request(
     // Carry the caller's tmux pane to the daemon (GH#177 Defect 3).
     if let Some(pane) = caller_tmux_pane_header() {
         headers.push(("X-Tmux-Pane".to_string(), pane));
+    }
+    if let Some(socket_path) = caller_tmux_socket_header()? {
+        headers.push(("X-Tmux-Socket".to_string(), socket_path));
     }
 
     // Production request-scoped Cx, not the test-only `Cx::for_testing()`

--- a/crates/mcp-agent-mail-core/src/lib.rs
+++ b/crates/mcp-agent-mail-core/src/lib.rs
@@ -199,8 +199,11 @@ pub use pane_identity::{
     cleanup_stale_identities, get_composite_tmux_pane_id, identity_source_category,
     is_agent_pane_command, list_identities, list_identities_with_paths, read_identity_record,
     resolve_identity, resolve_identity_current_pane, resolve_identity_with_binding,
-    resolve_identity_with_optional_pane, resolve_identity_with_path, write_identity,
-    write_identity_current_pane, write_identity_with_optional_pane,
+    resolve_identity_with_binding_on_socket, resolve_identity_with_optional_pane,
+    resolve_identity_with_optional_pane_on_socket, resolve_identity_with_path,
+    validate_tmux_socket_path, write_identity, write_identity_current_pane,
+    write_identity_on_socket, write_identity_with_optional_pane,
+    write_identity_with_optional_pane_on_socket,
 };
 pub use search_types::{
     DateRange, DocChange, DocId, DocKind, Document, ExplainComposerConfig, ExplainReasonCode,

--- a/crates/mcp-agent-mail-core/src/pane_identity.rs
+++ b/crates/mcp-agent-mail-core/src/pane_identity.rs
@@ -40,6 +40,13 @@ const IDENTITY_DIR_NAME: &str = "agent-mail/identity";
 /// How many hex chars of the project hash to use in the directory name.
 const PROJECT_HASH_LEN: usize = 12;
 
+/// Maximum accepted byte length for a caller-supplied tmux socket path.
+///
+/// Linux paths are bounded by `PATH_MAX`; keeping the transport value within
+/// that same ceiling prevents unbounded header/argv growth while leaving room
+/// for tmux sockets rooted below long per-user runtime directories.
+const MAX_TMUX_SOCKET_PATH_LEN: usize = 4096;
+
 /// tmux format used to probe a recorded binding's liveness on its own server.
 const LIVENESS_PROBE_FORMAT: &str = "#{session_name}\t#{pane_pid}\t#{pane_current_command}";
 
@@ -334,6 +341,35 @@ pub fn canonical_identity_path(project_key: &str, pane_id: &str) -> PathBuf {
     base.join(IDENTITY_DIR_NAME).join(hash).join(sanitized_pane)
 }
 
+/// Validate and normalize a tmux socket path received from a caller.
+///
+/// The value may cross an HTTP-header boundary before it becomes the argument
+/// to `tmux -S`, so it must be bounded, newline-free, NUL-free, and absolute.
+/// `None` means no socket context was supplied and preserves the legacy
+/// ambient-socket behavior.
+pub fn validate_tmux_socket_path(raw: Option<&str>) -> Result<Option<String>, &'static str> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    if raw.len() > MAX_TMUX_SOCKET_PATH_LEN {
+        return Err("tmux socket path exceeds the maximum length");
+    }
+    if raw
+        .bytes()
+        .any(|byte| matches!(byte, b'\r' | b'\n' | b'\0'))
+    {
+        return Err("tmux socket path must not contain CR, LF, or NUL");
+    }
+    let socket_path = raw.trim();
+    if socket_path.is_empty() {
+        return Err("tmux socket path must not be empty");
+    }
+    if !Path::new(socket_path).is_absolute() {
+        return Err("tmux socket path must be absolute");
+    }
+    Ok(Some(socket_path.to_string()))
+}
+
 /// Write an agent name to the canonical identity file for a pane.
 ///
 /// Creates parent directories as needed. Returns the path written to on
@@ -365,6 +401,21 @@ pub fn write_identity(
     pane_id: &str,
     agent_name: &str,
 ) -> std::io::Result<PathBuf> {
+    write_identity_on_socket(project_key, pane_id, None, agent_name)
+}
+
+/// Write an identity using an explicitly supplied tmux socket when present.
+///
+/// The socket path is validated before it can enter the `tmux` argv. Omitting
+/// it preserves the ambient-socket behavior used by local/stdio callers.
+pub fn write_identity_on_socket(
+    project_key: &str,
+    pane_id: &str,
+    socket_path: Option<&str>,
+    agent_name: &str,
+) -> std::io::Result<PathBuf> {
+    let socket_path = validate_tmux_socket_path(socket_path)
+        .map_err(|message| std::io::Error::new(std::io::ErrorKind::InvalidInput, message))?;
     let path = canonical_identity_path(project_key, pane_id);
     if let Some(parent) = path.parent() {
         ensure_real_directory(parent)?;
@@ -379,7 +430,7 @@ pub fn write_identity(
         ));
     }
 
-    let facts = query_target_pane_facts(pane_id);
+    let facts = query_target_pane_facts(pane_id, socket_path.as_deref());
 
     // GH#252: never overwrite a verifiably live binding held by another pane.
     if let Some(existing) = read_identity_record(&path)
@@ -470,7 +521,24 @@ pub fn resolve_identity_with_binding(
     project_key: &str,
     pane_id: &str,
 ) -> Option<(String, PathBuf, PaneBindingStatus)> {
-    let mut resolver = PaneBindingResolver::new(pane_id);
+    resolve_identity_with_binding_on_socket(project_key, pane_id, None)
+}
+
+/// Resolve identity and binding status on an explicitly supplied tmux socket.
+///
+/// Callers crossing a transport boundary must validate `socket_path` with
+/// [`validate_tmux_socket_path`] first. The value is used only as an argv
+/// element following `tmux -S`; it is never interpreted by a shell.
+#[must_use]
+pub fn resolve_identity_with_binding_on_socket(
+    project_key: &str,
+    pane_id: &str,
+    socket_path: Option<&str>,
+) -> Option<(String, PathBuf, PaneBindingStatus)> {
+    let Ok(socket_path) = validate_tmux_socket_path(socket_path) else {
+        return None;
+    };
+    let mut resolver = PaneBindingResolver::new(pane_id, socket_path.as_deref());
 
     // 1. Canonical path (composite or bare)
     let canonical = canonical_identity_path(project_key, pane_id);
@@ -491,7 +559,7 @@ pub fn resolve_identity_with_binding(
     // ask about their own pane on a host where tmux is not reachable.
     let bare_candidates: Vec<String> = if pane_id.contains(':') {
         let mut candidates = Vec::new();
-        if let Some(bare) = bare_for_composite_pane(pane_id)
+        if let Some(bare) = bare_for_composite_pane(pane_id, socket_path.as_deref())
             && bare != pane_id
         {
             candidates.push(bare);
@@ -524,7 +592,7 @@ pub fn resolve_identity_with_binding(
     //     call, or a trusted `X-Tmux-Pane` header — would otherwise miss its own
     //     composite-keyed identity (GH#177 Defect 2).
     if !pane_id.contains(':')
-        && let Some(composite) = composite_for_bare_pane(pane_id)
+        && let Some(composite) = composite_for_bare_pane(pane_id, socket_path.as_deref())
         && composite != pane_id
     {
         let composite_canonical = canonical_identity_path(project_key, &composite);
@@ -641,9 +709,20 @@ pub fn resolve_identity_with_optional_pane(
     project_key: &str,
     pane_id: Option<&str>,
 ) -> Option<String> {
+    resolve_identity_with_optional_pane_on_socket(project_key, pane_id, None)
+}
+
+/// Resolve an optional pane using an explicitly supplied tmux socket.
+#[must_use]
+pub fn resolve_identity_with_optional_pane_on_socket(
+    project_key: &str,
+    pane_id: Option<&str>,
+    socket_path: Option<&str>,
+) -> Option<String> {
     let trimmed = pane_id.map(str::trim).filter(|pane| !pane.is_empty());
     if let Some(pane) = trimmed {
-        return resolve_identity_for_pane(project_key, Some(pane));
+        return resolve_identity_with_binding_on_socket(project_key, pane, socket_path)
+            .map(|(name, _, _)| name);
     }
     resolve_identity_current_pane(project_key)
 }
@@ -670,9 +749,25 @@ pub fn write_identity_with_optional_pane(
     pane_id: Option<&str>,
     agent_name: &str,
 ) -> Option<std::io::Result<PathBuf>> {
+    write_identity_with_optional_pane_on_socket(project_key, pane_id, None, agent_name)
+}
+
+/// Write an optional pane identity using an explicitly supplied tmux socket.
+#[must_use]
+pub fn write_identity_with_optional_pane_on_socket(
+    project_key: &str,
+    pane_id: Option<&str>,
+    socket_path: Option<&str>,
+    agent_name: &str,
+) -> Option<std::io::Result<PathBuf>> {
     let trimmed = pane_id.map(str::trim).filter(|pane| !pane.is_empty());
     if let Some(pane) = trimmed {
-        return write_identity_for_pane(project_key, Some(pane), agent_name);
+        return Some(write_identity_on_socket(
+            project_key,
+            pane,
+            socket_path,
+            agent_name,
+        ));
     }
     write_identity_current_pane(project_key, agent_name)
 }
@@ -1037,9 +1132,13 @@ fn pane_target_for(pane_id: &str) -> Option<String> {
 /// Query tmux (in the caller's environment) for the binding facts of the pane
 /// named by `pane_id`. Returns `None` when tmux is unavailable or the pane
 /// does not exist — the caller then behaves as it did before GH#252.
-fn query_target_pane_facts(pane_id: &str) -> Option<TargetPaneFacts> {
+fn query_target_pane_facts(pane_id: &str, socket_path: Option<&str>) -> Option<TargetPaneFacts> {
     let target = pane_target_for(pane_id)?;
-    let output = tmux_command()
+    let mut command = tmux_command();
+    if let Some(socket_path) = socket_path {
+        command.args(["-S", socket_path]);
+    }
+    let output = command
         .args(["display-message", "-t", &target, "-p", TARGET_FACTS_FORMAT])
         .output()
         .ok()?;
@@ -1124,14 +1223,16 @@ fn adopt_record_at(path: &Path, name: &str, facts: &TargetPaneFacts) {
 /// the lookup order describes) and classifies each candidate record found.
 struct PaneBindingResolver {
     pane_arg: String,
+    socket_path: Option<String>,
     facts_queried: bool,
     facts: Option<TargetPaneFacts>,
 }
 
 impl PaneBindingResolver {
-    fn new(pane_id: &str) -> Self {
+    fn new(pane_id: &str, socket_path: Option<&str>) -> Self {
         Self {
             pane_arg: pane_id.to_string(),
+            socket_path: socket_path.map(str::to_string),
             facts_queried: false,
             facts: None,
         }
@@ -1139,7 +1240,7 @@ impl PaneBindingResolver {
 
     fn target_facts(&mut self) -> Option<&TargetPaneFacts> {
         if !self.facts_queried {
-            self.facts = query_target_pane_facts(&self.pane_arg);
+            self.facts = query_target_pane_facts(&self.pane_arg, self.socket_path.as_deref());
             self.facts_queried = true;
         }
         self.facts.as_ref()
@@ -1610,12 +1711,16 @@ pub fn get_composite_tmux_pane_id() -> Option<String> {
 /// the daemon for a caller-provided pane (GH#177 Defect 2). Returns `None` when
 /// tmux is unavailable, the pane is unknown, or the answer isn't a composite key.
 #[must_use]
-fn composite_for_bare_pane(pane_id: &str) -> Option<String> {
+fn composite_for_bare_pane(pane_id: &str, socket_path: Option<&str>) -> Option<String> {
     let pane = pane_id.trim();
     if pane.is_empty() {
         return None;
     }
-    let output = tmux_command()
+    let mut command = tmux_command();
+    if let Some(socket_path) = socket_path {
+        command.args(["-S", socket_path]);
+    }
+    let output = command
         .args([
             "display-message",
             "-t",
@@ -1639,9 +1744,13 @@ fn composite_for_bare_pane(pane_id: &str) -> Option<String> {
 /// `session:window:pane` form and tmux's own `session:window.pane` form
 /// resolve. Returns `None` when tmux is unavailable, the pane does not exist,
 /// or the answer is not a bare `%N` pane id.
-fn bare_for_composite_pane(pane_id: &str) -> Option<String> {
+fn bare_for_composite_pane(pane_id: &str, socket_path: Option<&str>) -> Option<String> {
     let target = pane_target_for(pane_id)?;
-    let output = tmux_command()
+    let mut command = tmux_command();
+    if let Some(socket_path) = socket_path {
+        command.args(["-S", socket_path]);
+    }
+    let output = command
         .args(["display-message", "-t", &target, "-p", PANE_ID_FORMAT])
         .output()
         .ok()?;
@@ -2492,6 +2601,59 @@ mod tests {
                 "explicit pane must not fall back to TMUX_PANE when a different pane is supplied"
             );
         });
+        drop(config);
+    }
+
+    #[test]
+    fn tmux_socket_path_validation_rejects_hostile_values() {
+        assert_eq!(validate_tmux_socket_path(None), Ok(None));
+        assert_eq!(
+            validate_tmux_socket_path(Some(" /tmp/tmux-1001/gpqeprobe ")),
+            Ok(Some("/tmp/tmux-1001/gpqeprobe".to_string()))
+        );
+        assert!(validate_tmux_socket_path(Some("relative/socket")).is_err());
+        assert!(validate_tmux_socket_path(Some("/tmp/good\r\nX-Bad: yes")).is_err());
+        assert!(validate_tmux_socket_path(Some("/tmp/good\r\n")).is_err());
+        assert!(validate_tmux_socket_path(Some("/tmp/bad\0socket")).is_err());
+        assert!(validate_tmux_socket_path(Some("")).is_err());
+        let too_long = format!("/{}", "x".repeat(MAX_TMUX_SOCKET_PATH_LEN));
+        assert!(validate_tmux_socket_path(Some(&too_long)).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_socket_selects_target_pane_facts_server() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let config = IsolatedConfigBaseDir::new();
+        let project = config.project_key("socket-aware-write");
+        let temp = tempfile::tempdir().expect("tmux stub tempdir");
+        let tmux_path = temp.path().join("tmux");
+        let expected_socket = "/tmp/tmux-1001/gpqeprobe";
+        let script = "#!/bin/sh\n\
+             if [ \"$1\" != \"-S\" ] || [ \"$2\" != \"/tmp/tmux-1001/gpqeprobe\" ]; then exit 41; fi\n\
+             printf 'probe\\t%%42\\t4242\\tclaude\\t/tmp/tmux-1001/gpqeprobe\\n'\n";
+        std::fs::write(&tmux_path, script).expect("write tmux stub");
+        let mut perms = std::fs::metadata(&tmux_path)
+            .expect("tmux stub metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&tmux_path, perms).expect("chmod tmux stub");
+        let tmux_bin = tmux_path.to_string_lossy().into_owned();
+
+        crate::config::with_process_env_overrides_for_test(
+            &[("AM_TEST_TMUX_BIN", tmux_bin.as_str())],
+            || {
+                let path =
+                    write_identity_on_socket(&project, "%42", Some(expected_socket), "BlueLake")
+                        .expect("socket-aware identity write");
+                let record = read_identity_record(&path).expect("structured identity record");
+                assert_eq!(record.session_name.as_deref(), Some("probe"));
+                assert_eq!(record.pane_id.as_deref(), Some("%42"));
+                assert_eq!(record.pane_pid, Some(4242));
+                assert_eq!(record.socket_path.as_deref(), Some(expected_socket));
+            },
+        );
         drop(config);
     }
 

--- a/crates/mcp-agent-mail-server/src/lib.rs
+++ b/crates/mcp-agent-mail-server/src/lib.rs
@@ -11585,7 +11585,10 @@ impl HttpState {
             return resp;
         }
 
-        let json_rpc = inject_tmux_pane_header(json_rpc, &req);
+        let json_rpc = match inject_tmux_pane_header(json_rpc, &req) {
+            Ok(request) => request,
+            Err(message) => return self.error_response(&req, 400, message),
+        };
         let response = self.dispatch(json_rpc).await.map_or_else(
             || HttpResponse::new(fastmcp_transport::http::HttpStatus::ACCEPTED),
             |resp| HttpResponse::ok().with_json(&resp),
@@ -16759,6 +16762,22 @@ fn tmux_pane_header(req: &Http1Request) -> Option<String> {
         })
 }
 
+fn tmux_socket_header(req: &Http1Request) -> Result<Option<String>, &'static str> {
+    let mut socket_path = None;
+    for (_, value) in req
+        .headers
+        .iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case("x-tmux-socket"))
+    {
+        let validated = mcp_agent_mail_core::validate_tmux_socket_path(Some(value))?;
+        if socket_path.is_some() && socket_path != validated {
+            return Err("conflicting X-Tmux-Socket headers are not allowed");
+        }
+        socket_path = validated;
+    }
+    Ok(socket_path)
+}
+
 fn accepts_pane_id_header(tool_name: &str) -> bool {
     matches!(
         tool_name,
@@ -16772,25 +16791,27 @@ fn accepts_pane_id_header(tool_name: &str) -> bool {
     )
 }
 
-fn inject_tmux_pane_header(mut request: JsonRpcRequest, req: &Http1Request) -> JsonRpcRequest {
+fn inject_tmux_pane_header(
+    mut request: JsonRpcRequest,
+    req: &Http1Request,
+) -> Result<JsonRpcRequest, &'static str> {
     if request.method != "tools/call" {
-        return request;
+        return Ok(request);
     }
-    let Some(pane_id) = tmux_pane_header(req) else {
-        return request;
-    };
+    let pane_id = tmux_pane_header(req);
+    let socket_path = tmux_socket_header(req)?;
     let Some(params) = request
         .params
         .as_mut()
         .and_then(serde_json::Value::as_object_mut)
     else {
-        return request;
+        return Ok(request);
     };
     let Some(tool_name) = params.get("name").and_then(serde_json::Value::as_str) else {
-        return request;
+        return Ok(request);
     };
     if !accepts_pane_id_header(tool_name) {
-        return request;
+        return Ok(request);
     }
 
     let arguments = params
@@ -16800,17 +16821,26 @@ fn inject_tmux_pane_header(mut request: JsonRpcRequest, req: &Http1Request) -> J
         *arguments = serde_json::json!({});
     }
     let Some(args) = arguments.as_object_mut() else {
-        return request;
+        return Ok(request);
     };
 
     let caller_supplied_pane = args
         .get("pane_id")
         .and_then(serde_json::Value::as_str)
         .is_some_and(|value| !value.trim().is_empty());
-    if !caller_supplied_pane {
+    if !caller_supplied_pane && let Some(pane_id) = pane_id {
         args.insert("pane_id".to_string(), serde_json::Value::String(pane_id));
     }
-    request
+    // Socket context is transport-derived for HTTP calls. Never honor a JSON
+    // argument that could disagree with the authenticated request header.
+    args.remove("tmux_socket_path");
+    if let Some(socket_path) = socket_path {
+        args.insert(
+            "tmux_socket_path".to_string(),
+            serde_json::Value::String(socket_path),
+        );
+    }
+    Ok(request)
 }
 
 fn parse_params<T: serde::de::DeserializeOwned>(
@@ -20925,9 +20955,25 @@ first body
             .as_str()
     }
 
+    fn injected_tmux_socket_path(request: &JsonRpcRequest) -> Option<&str> {
+        request
+            .params
+            .as_ref()?
+            .get("arguments")?
+            .get("tmux_socket_path")?
+            .as_str()
+    }
+
     #[test]
     fn x_tmux_pane_header_injects_pane_id_for_identity_tools() {
-        let req = make_request(Http1Method::Post, "/mcp/", &[("X-Tmux-Pane", "%23")]);
+        let req = make_request(
+            Http1Method::Post,
+            "/mcp/",
+            &[
+                ("X-Tmux-Pane", "%23"),
+                ("X-Tmux-Socket", "/tmp/tmux-1001/gpqeprobe"),
+            ],
+        );
         let json_rpc = JsonRpcRequest::new(
             "tools/call",
             Some(serde_json::json!({
@@ -20941,8 +20987,58 @@ first body
             1,
         );
 
-        let injected = inject_tmux_pane_header(json_rpc, &req);
+        let injected = inject_tmux_pane_header(json_rpc, &req).expect("trusted pane header");
         assert_eq!(injected_pane_id(&injected), Some("%23"));
+        assert_eq!(
+            injected_tmux_socket_path(&injected),
+            Some("/tmp/tmux-1001/gpqeprobe")
+        );
+    }
+
+    #[test]
+    fn x_tmux_socket_header_refuses_hostile_values_before_dispatch() {
+        for value in ["relative/socket", "/tmp/good\r\nX-Bad: yes"] {
+            let req = make_request(Http1Method::Post, "/mcp/", &[("X-Tmux-Socket", value)]);
+            let json_rpc = JsonRpcRequest::new(
+                "tools/call",
+                Some(serde_json::json!({
+                    "name": "register_agent",
+                    "arguments": {
+                        "project_key": "/tmp/project",
+                        "program": "claude-code",
+                        "model": "opus",
+                        "pane_id": "%23"
+                    }
+                })),
+                1,
+            );
+
+            assert!(
+                inject_tmux_pane_header(json_rpc, &req).is_err(),
+                "hostile X-Tmux-Socket was accepted: {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn x_tmux_socket_json_argument_is_not_trusted_without_header() {
+        let req = make_request(Http1Method::Post, "/mcp/", &[("X-Tmux-Pane", "%23")]);
+        let json_rpc = JsonRpcRequest::new(
+            "tools/call",
+            Some(serde_json::json!({
+                "name": "register_agent",
+                "arguments": {
+                    "project_key": "/tmp/project",
+                    "program": "claude-code",
+                    "model": "opus",
+                    "tmux_socket_path": "/tmp/untrusted"
+                }
+            })),
+            1,
+        );
+
+        let injected = inject_tmux_pane_header(json_rpc, &req).expect("trusted pane header");
+        assert_eq!(injected_tmux_socket_path(&injected), None);
     }
 
     #[test]
@@ -20962,7 +21058,7 @@ first body
             1,
         );
 
-        let injected = inject_tmux_pane_header(json_rpc, &req);
+        let injected = inject_tmux_pane_header(json_rpc, &req).expect("trusted pane header");
         assert_eq!(injected_pane_id(&injected), Some("%99"));
     }
 
@@ -20978,7 +21074,7 @@ first body
             1,
         );
 
-        let injected = inject_tmux_pane_header(json_rpc, &req);
+        let injected = inject_tmux_pane_header(json_rpc, &req).expect("unrelated tool");
         assert_eq!(injected_pane_id(&injected), None);
     }
 
@@ -20996,7 +21092,7 @@ first body
             1,
         );
 
-        let injected = inject_tmux_pane_header(json_rpc, &req);
+        let injected = inject_tmux_pane_header(json_rpc, &req).expect("trusted pane header");
         assert_eq!(injected_pane_id(&injected), Some("%23"));
     }
 
@@ -21020,7 +21116,7 @@ first body
             1,
         );
 
-        let injected = inject_tmux_pane_header(json_rpc, &req);
+        let injected = inject_tmux_pane_header(json_rpc, &req).expect("trusted duplicate");
         assert_eq!(injected_pane_id(&injected), Some("%23"));
     }
 
@@ -21041,7 +21137,7 @@ first body
                 1,
             );
 
-            let injected = inject_tmux_pane_header(json_rpc, &req);
+            let injected = inject_tmux_pane_header(json_rpc, &req).expect("pane header ignored");
             assert_eq!(
                 injected_pane_id(&injected),
                 None,

--- a/crates/mcp-agent-mail-tools/src/identity.rs
+++ b/crates/mcp-agent-mail-tools/src/identity.rs
@@ -1644,6 +1644,7 @@ fn authenticate_lifecycle_agent(
     agent: &mcp_agent_mail_db::AgentRow,
     registration_token: Option<&str>,
     pane_id: Option<&str>,
+    tmux_socket_path: Option<&str>,
     action: &str,
 ) -> McpResult<()> {
     let provided_token = registration_token.filter(|token| !token.is_empty());
@@ -1655,8 +1656,12 @@ fn authenticate_lifecycle_agent(
     // An explicitly supplied but invalid token must not silently fall back to
     // ambient pane identity. That keeps stale or stolen credentials loud.
     let pane_matches = provided_token.is_none()
-        && mcp_agent_mail_core::resolve_identity_with_optional_pane(&project.human_key, pane_id)
-            .is_some_and(|resolved| resolved.eq_ignore_ascii_case(&agent.name));
+        && mcp_agent_mail_core::resolve_identity_with_optional_pane_on_socket(
+            &project.human_key,
+            pane_id,
+            validated_tmux_socket_path(tmux_socket_path)?.as_deref(),
+        )
+        .is_some_and(|resolved| resolved.eq_ignore_ascii_case(&agent.name));
     if token_matches || pane_matches {
         return Ok(());
     }
@@ -1674,6 +1679,17 @@ fn authenticate_lifecycle_agent(
             "token_param": "registration_token",
         }),
     ))
+}
+
+pub(crate) fn validated_tmux_socket_path(raw: Option<&str>) -> McpResult<Option<String>> {
+    mcp_agent_mail_core::validate_tmux_socket_path(raw).map_err(|message| {
+        legacy_tool_error(
+            "INVALID_TMUX_SOCKET_PATH",
+            message,
+            true,
+            json!({ "field": "tmux_socket_path" }),
+        )
+    })
 }
 
 async fn reject_deregistered_lifecycle_transition(
@@ -2124,6 +2140,8 @@ Check that all parameters have valid values."
 /// - `reaper_exempt`: Optional bool to exempt agent from the inactivity reaper (default: false)
 /// - `pane_id`: Optional tmux pane identifier. HTTP clients should pass the
 ///   caller pane explicitly; stdio callers may omit it.
+/// - `tmux_socket_path`: Optional absolute tmux socket path. The HTTP server
+///   derives this from the validated `X-Tmux-Socket` transport header.
 ///
 /// # Returns
 /// Agent profile with all fields
@@ -2148,6 +2166,7 @@ pub async fn register_agent(
     attachments_policy: Option<String>,
     reaper_exempt: Option<bool>,
     pane_id: Option<String>,
+    tmux_socket_path: Option<String>,
     registration_proof: Option<String>,
 ) -> McpResult<String> {
     use mcp_agent_mail_core::models::{detect_agent_name_mistake, generate_agent_name};
@@ -2175,6 +2194,7 @@ pub async fn register_agent(
         ));
     }
 
+    let tmux_socket_path = validated_tmux_socket_path(tmux_socket_path.as_deref())?;
     let pool = get_db_pool()?;
 
     let project = resolve_project(ctx, &pool, &project_key).await?;
@@ -2396,9 +2416,10 @@ Check that all parameters have valid values."
     try_write_agent_profile(config, &project.slug, &agent_json);
 
     // Write per-pane identity file (best-effort, only when $TMUX_PANE is set)
-    if let Some(result) = mcp_agent_mail_core::write_identity_with_optional_pane(
+    if let Some(result) = mcp_agent_mail_core::write_identity_with_optional_pane_on_socket(
         &project.human_key,
         pane_id.as_deref(),
+        tmux_socket_path.as_deref(),
         &row.name,
     ) {
         match result {
@@ -2451,6 +2472,8 @@ Check that all parameters have valid values."
 /// - `attachments_policy`: Optional attachment handling policy
 /// - `pane_id`: Optional tmux pane identifier. HTTP clients should pass the
 ///   caller pane explicitly; stdio callers may omit it.
+/// - `tmux_socket_path`: Optional absolute tmux socket path. The HTTP server
+///   derives this from the validated `X-Tmux-Socket` transport header.
 /// - `return_registration_token`: When `true` (default), the response includes
 ///   the freshly-minted `registration_token`. When `false`, the token is
 ///   omitted from the tool result (transcript safety, GH#255 / Python issue
@@ -2478,6 +2501,7 @@ pub async fn create_agent_identity(
     task_description: Option<String>,
     attachments_policy: Option<String>,
     pane_id: Option<String>,
+    tmux_socket_path: Option<String>,
     registration_proof: Option<String>,
     return_registration_token: Option<bool>,
 ) -> McpResult<String> {
@@ -2506,6 +2530,7 @@ pub async fn create_agent_identity(
         ));
     }
 
+    let tmux_socket_path = validated_tmux_socket_path(tmux_socket_path.as_deref())?;
     let pool = get_db_pool()?;
 
     let project = resolve_project(ctx, &pool, &project_key).await?;
@@ -2686,9 +2711,10 @@ Choose a different name (or omit the name to auto-generate one)."
     try_write_agent_profile(config, &project.slug, &agent_json);
 
     // Write per-pane identity file (best-effort, only when $TMUX_PANE is set)
-    if let Some(result) = mcp_agent_mail_core::write_identity_with_optional_pane(
+    if let Some(result) = mcp_agent_mail_core::write_identity_with_optional_pane_on_socket(
         &project.human_key,
         pane_id.as_deref(),
+        tmux_socket_path.as_deref(),
         &row.name,
     ) {
         match result {
@@ -2754,6 +2780,7 @@ pub async fn retire_agent(
     agent_name: String,
     registration_token: Option<String>,
     pane_id: Option<String>,
+    tmux_socket_path: Option<String>,
 ) -> McpResult<String> {
     let pool = get_db_pool()?;
     let project = resolve_existing_project(ctx, &pool, &project_key).await?;
@@ -2771,6 +2798,7 @@ pub async fn retire_agent(
         &agent,
         registration_token.as_deref(),
         pane_id.as_deref(),
+        tmux_socket_path.as_deref(),
         "retire_agent",
     )?;
     reject_deregistered_lifecycle_transition(ctx, &pool, &agent, "retired").await?;
@@ -2813,6 +2841,7 @@ pub async fn unretire_agent(
     agent_name: String,
     registration_token: Option<String>,
     pane_id: Option<String>,
+    tmux_socket_path: Option<String>,
 ) -> McpResult<String> {
     let pool = get_db_pool()?;
     let project = resolve_existing_project(ctx, &pool, &project_key).await?;
@@ -2830,6 +2859,7 @@ pub async fn unretire_agent(
         &agent,
         registration_token.as_deref(),
         pane_id.as_deref(),
+        tmux_socket_path.as_deref(),
         "unretire_agent",
     )?;
     reject_deregistered_lifecycle_transition(ctx, &pool, &agent, "unretired").await?;
@@ -2861,6 +2891,7 @@ pub async fn deregister_agent(
     agent_name: String,
     registration_token: Option<String>,
     pane_id: Option<String>,
+    tmux_socket_path: Option<String>,
 ) -> McpResult<String> {
     let pool = get_db_pool()?;
     let project = resolve_existing_project(ctx, &pool, &project_key).await?;
@@ -2878,6 +2909,7 @@ pub async fn deregister_agent(
         &agent,
         registration_token.as_deref(),
         pane_id.as_deref(),
+        tmux_socket_path.as_deref(),
         "deregister_agent",
     )?;
 
@@ -3049,13 +3081,18 @@ pub async fn whois(
 fn resolve_identity_from_project_keys(
     project_keys: &[String],
     pane_id: &str,
+    tmux_socket_path: Option<&str>,
 ) -> Option<(
     String,
     std::path::PathBuf,
     mcp_agent_mail_core::PaneBindingStatus,
 )> {
     project_keys.iter().find_map(|project_key| {
-        mcp_agent_mail_core::resolve_identity_with_binding(project_key, pane_id)
+        mcp_agent_mail_core::resolve_identity_with_binding_on_socket(
+            project_key,
+            pane_id,
+            tmux_socket_path,
+        )
     })
 }
 
@@ -3077,7 +3114,9 @@ pub async fn resolve_pane_identity(
     ctx: &McpContext,
     project_key: String,
     pane_id: Option<String>,
+    tmux_socket_path: Option<String>,
 ) -> McpResult<String> {
+    let tmux_socket_path = validated_tmux_socket_path(tmux_socket_path.as_deref())?;
     let effective_pane = match pane_id {
         Some(p) if !p.trim().is_empty() => p.trim().to_string(),
         _ => mcp_agent_mail_core::get_composite_tmux_pane_id().unwrap_or_default(),
@@ -3107,7 +3146,12 @@ pub async fn resolve_pane_identity(
         &effective_pane,
     );
 
-    resolve_identity_from_project_keys(&project_keys, &effective_pane).map_or_else(
+    resolve_identity_from_project_keys(
+        &project_keys,
+        &effective_pane,
+        tmux_socket_path.as_deref(),
+    )
+    .map_or_else(
         || {
             Err(legacy_tool_error(
                 "IDENTITY_NOT_FOUND",
@@ -4897,7 +4941,7 @@ body
                 );
 
                 let resolved =
-                    resolve_identity_from_project_keys(&[raw_project_key, human_key], pane)
+                    resolve_identity_from_project_keys(&[raw_project_key, human_key], pane, None)
                         .expect("resolve identity across project keys");
                 assert_eq!(resolved.0, "BlueLake");
                 assert_eq!(resolved.1, written_path);

--- a/crates/mcp-agent-mail-tools/src/macros.rs
+++ b/crates/mcp-agent-mail-tools/src/macros.rs
@@ -135,6 +135,7 @@ pub async fn macro_start_session(
     inbox_limit: Option<i32>,
     reaper_exempt: Option<bool>,
     pane_id: Option<String>,
+    tmux_socket_path: Option<String>,
     registration_proof: Option<String>,
 ) -> McpResult<String> {
     let agent_name =
@@ -169,10 +170,13 @@ pub async fn macro_start_session(
     // live in a DIFFERENT pane is never reused (the lookup returns None and a
     // fresh name is minted below), while a dead binding is adopted and its
     // record rewritten with this caller's pane facts.
+    let tmux_socket_path =
+        crate::identity::validated_tmux_socket_path(tmux_socket_path.as_deref())?;
     let resolved_name = agent_name.or_else(|| {
-        mcp_agent_mail_core::pane_identity::resolve_identity_with_optional_pane(
+        mcp_agent_mail_core::pane_identity::resolve_identity_with_optional_pane_on_socket(
             &project.human_key,
             pane_id.as_deref(),
+            tmux_socket_path.as_deref(),
         )
         .and_then(|name| normalize_resolved_pane_agent_name(&name))
     });
@@ -187,6 +191,7 @@ pub async fn macro_start_session(
         None,
         reaper_exempt,
         pane_id,
+        tmux_socket_path,
         registration_proof,
     )
     .await?;
@@ -353,6 +358,7 @@ pub async fn macro_prepare_thread(
             model,
             agent_name,
             task_description,
+            None,
             None,
             None,
             None,

--- a/crates/mcp-agent-mail-tools/src/messaging.rs
+++ b/crates/mcp-agent-mail-tools/src/messaging.rs
@@ -4961,6 +4961,7 @@ mod tests {
                         None,
                         None,
                         None,
+                        None,
                     )
                     .await
                     .expect("register sender");
@@ -4972,6 +4973,7 @@ mod tests {
                         Some("GreenStone".to_string()),
                         Some("recipient".to_string()),
                         Some("auto".to_string()),
+                        None,
                         None,
                         None,
                         None,
@@ -5100,6 +5102,7 @@ mod tests {
                         None,
                         None,
                         None,
+                        None,
                     )
                     .await
                     .expect("register sender");
@@ -5111,6 +5114,7 @@ mod tests {
                         Some("GreenStone".to_string()),
                         Some("stable recipient".to_string()),
                         Some("auto".to_string()),
+                        None,
                         None,
                         None,
                         None,
@@ -5128,6 +5132,7 @@ mod tests {
                         None,
                         None,
                         None,
+                        None,
                     )
                     .await
                     .expect("register replaceable recipient");
@@ -5142,6 +5147,7 @@ mod tests {
                         Some("AzureCanyon".to_string()),
                         Some("recipient activity refresh".to_string()),
                         Some("auto".to_string()),
+                        None,
                         None,
                         None,
                         None,
@@ -5173,6 +5179,7 @@ mod tests {
                         Some("AzureCanyon".to_string()),
                         Some("replacement recipient".to_string()),
                         Some("auto".to_string()),
+                        None,
                         None,
                         None,
                         None,

--- a/crates/mcp-agent-mail-tools/src/resources.rs
+++ b/crates/mcp-agent-mail-tools/src/resources.rs
@@ -6153,6 +6153,7 @@ mod resource_shape_tests {
                         None,
                         None,
                         None,
+                        None,
                     )
                     .await
                     .expect("register_agent"),
@@ -6167,6 +6168,7 @@ mod resource_shape_tests {
                         "gpt-5".to_string(),
                         Some("GreenCastle".to_string()),
                         Some("resource visibility regression".to_string()),
+                        None,
                         None,
                         None,
                         None,
@@ -6235,6 +6237,7 @@ mod resource_shape_tests {
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await
                 .expect("register sender");
@@ -6245,6 +6248,7 @@ mod resource_shape_tests {
                     "gpt-5".to_string(),
                     Some("RedPeak".to_string()),
                     Some("resource visibility regression".to_string()),
+                    None,
                     None,
                     None,
                     None,
@@ -7732,6 +7736,7 @@ mod resource_shape_tests {
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await
                 .expect("register_agent GreenLake");
@@ -7743,6 +7748,7 @@ mod resource_shape_tests {
                     "sonnet-4.5".to_string(),
                     Some("BlueDog".to_string()),
                     Some("frontend work".to_string()),
+                    None,
                     None,
                     None,
                     None,

--- a/crates/mcp-agent-mail-tools/tests/agent_name_parity.rs
+++ b/crates/mcp-agent-mail-tools/tests/agent_name_parity.rs
@@ -178,6 +178,7 @@ fn test_invalid_format_detection() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect_err("invalid format should fail");

--- a/crates/mcp-agent-mail-tools/tests/auto_name_collision.rs
+++ b/crates/mcp-agent-mail-tools/tests/auto_name_collision.rs
@@ -88,6 +88,7 @@ async fn register_explicit(
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("explicit register_agent should succeed");
@@ -295,6 +296,7 @@ fn register_agent_without_name_never_reuses_existing_row() {
                 "opus-4.5".to_string(),
                 None,
                 Some("phase1 R2-25".to_string()),
+                None,
                 None,
                 None,
                 None,

--- a/crates/mcp-agent-mail-tools/tests/auto_register_profile.rs
+++ b/crates/mcp-agent-mail-tools/tests/auto_register_profile.rs
@@ -105,6 +105,7 @@ fn auto_registered_recipient_gets_an_archived_profile() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("register sender");

--- a/crates/mcp-agent-mail-tools/tests/contact_policy_parity.rs
+++ b/crates/mcp-agent-mail-tools/tests/contact_policy_parity.rs
@@ -110,6 +110,7 @@ async fn setup_project_and_agents(ctx: &McpContext, project_key: &str, agents: &
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("register_agent");

--- a/crates/mcp-agent-mail-tools/tests/idempotency_tool_acceptance.rs
+++ b/crates/mcp-agent-mail-tools/tests/idempotency_tool_acceptance.rs
@@ -84,6 +84,7 @@ async fn setup_project_and_agent(ctx: &McpContext, project_key: &str, agent: &st
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("register_agent");

--- a/crates/mcp-agent-mail-tools/tests/messaging_error_parity.rs
+++ b/crates/mcp-agent-mail-tools/tests/messaging_error_parity.rs
@@ -90,6 +90,7 @@ async fn setup_project_and_agent(ctx: &McpContext, project_key: &str, agent: &st
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("register_agent");
@@ -700,6 +701,7 @@ async fn register_agent_with_token(ctx: &McpContext, project_key: &str, agent: &
         "gpt-5".to_string(),
         Some(agent.to_string()),
         Some("fail-closed reply test".to_string()),
+        None,
         None,
         None,
         None,

--- a/crates/mcp-agent-mail-tools/tests/registration_proof_gate.rs
+++ b/crates/mcp-agent-mail-tools/tests/registration_proof_gate.rs
@@ -202,6 +202,7 @@ fn disabled_gate_registers_without_proof() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("register_agent should succeed with gate disabled");
@@ -218,6 +219,7 @@ fn disabled_gate_registers_without_proof() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("create_agent_identity should succeed with gate disabled");
@@ -230,6 +232,7 @@ fn disabled_gate_registers_without_proof() {
             "opus-4.1".to_string(),
             Some("RedStone".to_string()),
             Some("proof gate disabled".to_string()),
+            None,
             None,
             None,
             None,
@@ -271,6 +274,7 @@ fn enabled_gate_blocks_every_entry_point_without_proof() {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect_err("register_agent must fail closed without proof");
@@ -288,6 +292,7 @@ fn enabled_gate_blocks_every_entry_point_without_proof() {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect_err("create_agent_identity must fail closed without proof");
@@ -301,6 +306,7 @@ fn enabled_gate_blocks_every_entry_point_without_proof() {
                 "opus-4.1".to_string(),
                 Some("RedStone".to_string()),
                 Some("no proof".to_string()),
+                None,
                 None,
                 None,
                 None,
@@ -377,6 +383,7 @@ fn enabled_gate_allows_valid_proof_through_tool_and_macro() {
                 None,
                 None,
                 None,
+                None,
                 Some(proof),
             )
             .await
@@ -401,6 +408,7 @@ fn enabled_gate_allows_valid_proof_through_tool_and_macro() {
                 "opus-4.1".to_string(),
                 Some("GreenCastle".to_string()),
                 Some("valid proof".to_string()),
+                None,
                 None,
                 None,
                 None,
@@ -456,6 +464,7 @@ fn enabled_gate_rejects_replayed_nonce_durably() {
                 None,
                 None,
                 None,
+                None,
                 Some(proof1),
             )
             .await
@@ -486,6 +495,7 @@ fn enabled_gate_rejects_replayed_nonce_durably() {
                 "opus-4.1".to_string(),
                 Some("GreenCastle".to_string()),
                 Some("replay".to_string()),
+                None,
                 None,
                 None,
                 None,
@@ -538,6 +548,7 @@ async fn register_with_proof(
         "opus-4.1".to_string(),
         Some(name.to_string()),
         Some("valid proof".to_string()),
+        None,
         None,
         None,
         None,
@@ -691,6 +702,7 @@ fn disabled_gate_auto_registers_via_send_message_and_request_contact() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("register sender");
@@ -735,6 +747,7 @@ fn disabled_gate_auto_registers_via_send_message_and_request_contact() {
             "opus-4.1".to_string(),
             Some("RedStone".to_string()),
             Some("gate off".to_string()),
+            None,
             None,
             None,
             None,

--- a/crates/mcp-agent-mail-tools/tests/reservation_error_parity.rs
+++ b/crates/mcp-agent-mail-tools/tests/reservation_error_parity.rs
@@ -78,6 +78,7 @@ async fn setup_project_and_agents(ctx: &McpContext, project_key: &str, agents: &
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("register_agent");

--- a/crates/mcp-agent-mail-tools/tests/system_error_parity.rs
+++ b/crates/mcp-agent-mail-tools/tests/system_error_parity.rs
@@ -194,6 +194,7 @@ fn register_agent_under_sqlite_lock_maps_to_resource_busy() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect_err("locked sqlite write should fail");

--- a/crates/mcp-agent-mail-tools/tests/transcript_safe_identity.rs
+++ b/crates/mcp-agent-mail-tools/tests/transcript_safe_identity.rs
@@ -95,6 +95,7 @@ fn token_echoed_by_default() {
                 None,
                 None,
                 None,
+                None,
                 None, // return_registration_token omitted => default true
             )
             .await
@@ -131,6 +132,7 @@ fn token_omitted_on_opt_out_but_persisted() {
                 "gpt-5".to_string(),
                 None,
                 Some("transcript-safety opt-out".to_string()),
+                None,
                 None,
                 None,
                 None,
@@ -234,6 +236,7 @@ fn send_message_null_auto_contact_contract() {
                 "claude-code".to_string(),
                 "opus-4.5".to_string(),
                 Some(name.to_string()),
+                None,
                 None,
                 None,
                 None,

--- a/crates/mcp-agent-mail-tools/tests/validation_error_parity.rs
+++ b/crates/mcp-agent-mail-tools/tests/validation_error_parity.rs
@@ -83,6 +83,7 @@ async fn setup_project_and_agent(ctx: &McpContext, project_key: &str, agent: &st
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("register_agent");
@@ -327,6 +328,7 @@ fn test_empty_program_message() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect_err("empty program should fail");
@@ -369,6 +371,7 @@ fn test_empty_model_message() {
             "codex-cli".to_string(),
             "  ".to_string(), // whitespace-only
             Some("BlueLake".to_string()),
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
## Summary

- carry the caller tmux socket from the CLI in a validated `X-Tmux-Socket` header
- thread that socket through pane identity registration, resolution, lifecycle authentication, and `macro_start_session`
- query the target pane with `tmux -S <caller-socket>` so bare pane IDs cannot resolve against the daemon's ambient socket
- reject relative, overlong, CR/LF-bearing, and NUL-bearing socket paths before they can reach argv; HTTP JSON cannot override the transport-derived socket

## Bug

Tmux pane IDs are only unique within a server. The CLI previously sent only `X-Tmux-Pane: %N`, while the HTTP daemon queried `%N` on its own ambient socket. If the same `%N` existed there, registration silently wrote a verified binding for the wrong pane; only a missing collision degraded to `legacy-unverified`.

## Verification

- `cargo test -p mcp-agent-mail-cli caller_tmux_socket_header_uses_only_valid_tmux_socket_field --lib`
- `cargo test -p mcp-agent-mail-server x_tmux_socket --lib`
- `cargo test -p mcp-agent-mail-server x_tmux_pane_header_injects_pane_id_for_identity_tools --lib`
- `cargo test -p mcp-agent-mail-core pane_identity --lib` (67 passed)
- `cargo check -p mcp-agent-mail-tools --all-targets`
- `cargo check -p mcp-agent-mail-cli --all-targets`
- `cargo check -p mcp-agent-mail-server --all-targets`
- `cargo check -p mcp-agent-mail-core --all-targets`
- `cargo clippy -p mcp-agent-mail-core -p mcp-agent-mail-tools -p mcp-agent-mail-server -p mcp-agent-mail-cli --all-targets -- -D warnings`

The legacy no-`$TMUX` path is preserved by the existing ambient-socket wrappers.